### PR TITLE
Sanitary Integration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,7 @@
     <maven.compiler.target>17</maven.compiler.target>
     <hibernate.search.version>6.1.1.Final</hibernate.search.version>
     <springfox.boot.starter.version>3.0.0</springfox.boot.starter.version>
+    <sentry.version>8.43.2</sentry.version>
   </properties>
 
   <dependencies>
@@ -89,6 +90,16 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-freemarker</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.sentry</groupId>
+      <artifactId>sentry-spring-boot-starter-jakarta</artifactId>
+      <version>${sentry.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.sentry</groupId>
+      <artifactId>sentry-logback</artifactId>
+      <version>${sentry.version}</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,6 +8,15 @@ spring.data.jpa.repositories.bootstrap-mode=default
 spring.main.banner-mode=off
 spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.mongo.MongoAutoConfiguration,org.springframework.boot.autoconfigure.data.mongo.MongoDataAutoConfiguration
 
+# ---------------- Sentry ----------------
+sentry.dsn=${SENTRY_DSN:}
+sentry.environment=${SENTRY_ENVIRONMENT:dev}
+sentry.release=${SENTRY_RELEASE:oriso-agencyservice@local}
+sentry.traces-sample-rate=${SENTRY_TRACES_SAMPLE_RATE:0.0}
+sentry.send-default-pii=${SENTRY_SEND_DEFAULT_PII:false}
+sentry.logging.minimum-event-level=${SENTRY_LOGGING_MINIMUM_EVENT_LEVEL:warn}
+sentry.logging.minimum-breadcrumb-level=${SENTRY_LOGGING_MINIMUM_BREADCRUMB_LEVEL:info}
+
 # ---------------- Server ----------------
 server.port=8084
 server.host=http://localhost


### PR DESCRIPTION
## Summary
- Add Sentry Spring Boot 3 Jakarta starter to capture AgencyService application exceptions.
- Add Sentry Logback integration so warning/error logs can be sent to Sentry.
- Configure Sentry through environment-backed properties for DSN, environment, release, PII, tracing, and log thresholds.

## Validation
- `./mvnw -DskipTests dependency:tree -Dincludes=io.sentry`
- `./mvnw -q -DskipTests compile` currently fails on the existing compiler configuration: `invalid source release 17 with --enable-preview`.

## Deployment Notes
- Create a Sentry project for `oriso-agencyservice` and set its DSN as `SENTRY_DSN` in the AgencyService deployment.
- Set `SENTRY_RELEASE` to the deployed image tag or git SHA.
- Optional: adjust `SENTRY_LOGGING_MINIMUM_EVENT_LEVEL` and `SENTRY_LOGGING_MINIMUM_BREADCRUMB_LEVEL` if warnings are too noisy.
