### PR TITLE
fix: remove jdwp debug agent and fix dockerfile configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM eclipse-temurin:21-jre
 VOLUME ["/tmp","/log"]
-EXPOSE 8080
+EXPOSE 8084
 ARG JAR_FILE
 ENV JAVA_UPPER_VERSION=eclipse-temurin:21-jre
 COPY ./target/AgencyService.jar app.jar
-ENTRYPOINT ["java","-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005","-Djava.security.egd=file:/dev/./urandom -Dtomcat.util.http.parser.HttpParser.requestTargetAllow=|{}","-jar","/app.jar"]
+ENTRYPOINT ["java","-Djava.security.egd=file:/dev/./urandom","-Dtomcat.util.http.parser.HttpParser.requestTargetAllow=|{}","-XX:MaxRAMPercentage=75","-jar","/app.jar"]


### PR DESCRIPTION
## What
- Removed `-agentlib:jdwp=...` from Dockerfile ENTRYPOINT — eliminates unauthenticated RCE via port 5005
- Fixed two `-D` JVM flags merged into one string argument (Tomcat flag was never being applied)
- Corrected `EXPOSE 8080` → `EXPOSE 8084` to match `server.port=8084`
- Added `-XX:MaxRAMPercentage=75` for container-aware heap sizing

## Why
Closes #10 — JDWP debug agent was active in every production deployment, giving any actor in the cluster unauthenticated RCE access to the JVM. No NetworkPolicies exist in the cluster, making port 5005 reachable cluster-wide.

## Test
- [ ] After deploy: `kubectl exec -n caritas <pod> -- cat /proc/1/cmdline | tr '\0' '\n' | grep jdwp` → empty
- [ ] `nc -z <pod-ip> 5005` from another pod in ns caritas → connection refused
- [ ] `curl http://<pod-ip>:8084/actuator/health` → HTTP 200