### PR TITLE
AS-L04 replace real config IP examples

### DIFF
--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -26,7 +26,7 @@ spring.security.oauth2.resourceserver.jwt.jwk-set-uri=${SPRING_SECURITY_OAUTH2_R
 
 # ---------------- MariaDB ----------------
 # Use Kubernetes DNS names, e.g., jdbc:mariadb://mariadb.caritas.svc.cluster.local:3306/agencyservice
-# NOT hardcoded IPs like jdbc:mariadb://10.43.123.72:3306/agencyservice
+# NOT hardcoded IPs like jdbc:mariadb://203.0.113.30:3306/agencyservice
 spring.datasource.url=${SPRING_DATASOURCE_URL:}
 spring.datasource.username=${SPRING_DATASOURCE_USERNAME:}
 spring.datasource.password=${SPRING_DATASOURCE_PASSWORD:}
@@ -51,7 +51,7 @@ tenant.service.api.url=${TENANT_SERVICE_API_URL:}
 
 # ---------------- Matrix Synapse ----------------
 # Use Kubernetes DNS names, e.g., http://matrix-synapse.caritas.svc.cluster.local:8008
-# NOT hardcoded IPs like http://91.99.219.182:8008
+# NOT hardcoded IPs like http://203.0.113.10:8008
 matrix.api-url=${MATRIX_API_URL:}
 matrix.registration-shared-secret=${MATRIX_REGISTRATION_SHARED_SECRET:}
 matrix.server-name=${MATRIX_SERVER_NAME:}

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -26,7 +26,7 @@ spring.security.oauth2.resourceserver.jwt.jwk-set-uri=${SPRING_SECURITY_OAUTH2_R
 
 # ---------------- MariaDB ----------------
 # Use Kubernetes DNS names, e.g., jdbc:mariadb://mariadb.caritas.svc.cluster.local:3306/agencyservice
-# NOT hardcoded IPs like jdbc:mariadb://10.43.123.72:3306/agencyservice
+# NOT hardcoded IPs like jdbc:mariadb://203.0.113.30:3306/agencyservice
 spring.datasource.url=${SPRING_DATASOURCE_URL:}
 spring.datasource.username=${SPRING_DATASOURCE_USERNAME:}
 spring.datasource.password=${SPRING_DATASOURCE_PASSWORD:}
@@ -51,7 +51,7 @@ tenant.service.api.url=${TENANT_SERVICE_API_URL:}
 
 # ---------------- Matrix Synapse ----------------
 # Use Kubernetes DNS names, e.g., http://matrix-synapse.caritas.svc.cluster.local:8008
-# NOT hardcoded IPs like http://91.99.219.182:8008
+# NOT hardcoded IPs like http://203.0.113.10:8008
 matrix.api-url=${MATRIX_API_URL:}
 matrix.registration-shared-secret=${MATRIX_REGISTRATION_SHARED_SECRET:}
 matrix.server-name=${MATRIX_SERVER_NAME:}

--- a/src/main/resources/application-staging.properties
+++ b/src/main/resources/application-staging.properties
@@ -26,7 +26,7 @@ spring.security.oauth2.resourceserver.jwt.jwk-set-uri=${SPRING_SECURITY_OAUTH2_R
 
 # ---------------- MariaDB ----------------
 # Use Kubernetes DNS names, e.g., jdbc:mariadb://mariadb.caritas.svc.cluster.local:3306/agencyservice
-# NOT hardcoded IPs like jdbc:mariadb://10.43.123.72:3306/agencyservice
+# NOT hardcoded IPs like jdbc:mariadb://203.0.113.30:3306/agencyservice
 spring.datasource.url=${SPRING_DATASOURCE_URL:}
 spring.datasource.username=${SPRING_DATASOURCE_USERNAME:}
 spring.datasource.password=${SPRING_DATASOURCE_PASSWORD:}
@@ -51,7 +51,7 @@ tenant.service.api.url=${TENANT_SERVICE_API_URL:}
 
 # ---------------- Matrix Synapse ----------------
 # Use Kubernetes DNS names, e.g., http://matrix-synapse.caritas.svc.cluster.local:8008
-# NOT hardcoded IPs like http://91.99.219.182:8008
+# NOT hardcoded IPs like http://203.0.113.10:8008
 matrix.api-url=${MATRIX_API_URL:}
 matrix.registration-shared-secret=${MATRIX_REGISTRATION_SHARED_SECRET:}
 matrix.server-name=${MATRIX_SERVER_NAME:}

--- a/src/main/resources/application-testing.properties
+++ b/src/main/resources/application-testing.properties
@@ -26,7 +26,7 @@ spring.security.oauth2.resourceserver.jwt.jwk-set-uri=${SPRING_SECURITY_OAUTH2_R
 
 # ---------------- MariaDB ----------------
 # Use Kubernetes DNS names, e.g., jdbc:mariadb://mariadb.caritas.svc.cluster.local:3306/agencyservice
-# NOT hardcoded IPs like jdbc:mariadb://10.43.123.72:3306/agencyservice
+# NOT hardcoded IPs like jdbc:mariadb://203.0.113.30:3306/agencyservice
 spring.datasource.url=${SPRING_DATASOURCE_URL:}
 spring.datasource.username=${SPRING_DATASOURCE_USERNAME:}
 spring.datasource.password=${SPRING_DATASOURCE_PASSWORD:}
@@ -51,7 +51,7 @@ tenant.service.api.url=${TENANT_SERVICE_API_URL:}
 
 # ---------------- Matrix Synapse ----------------
 # Use Kubernetes DNS names, e.g., http://matrix-synapse.caritas.svc.cluster.local:8008
-# NOT hardcoded IPs like http://91.99.219.182:8008
+# NOT hardcoded IPs like http://203.0.113.10:8008
 matrix.api-url=${MATRIX_API_URL:}
 matrix.registration-shared-secret=${MATRIX_REGISTRATION_SHARED_SECRET:}
 matrix.server-name=${MATRIX_SERVER_NAME:}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -24,7 +24,7 @@ app.base.url=http://localhost:8084
 
 # ---------------- Matrix Synapse ----------------
 # Use Kubernetes DNS names, e.g., http://matrix-synapse.caritas.svc.cluster.local:8008
-# NOT hardcoded IPs like http://91.99.219.182:8008
+# NOT hardcoded IPs like http://203.0.113.10:8008
 matrix.api-url=${MATRIX_API_URL:}
 matrix.registration-shared-secret=${MATRIX_REGISTRATION_SHARED_SECRET:}
 matrix.server-name=${MATRIX_SERVER_NAME:}
@@ -105,7 +105,7 @@ cache.appsettings.configuration.timeToLiveSeconds=60
 
 # ---------------- Keycloak ----------------
 # Use Kubernetes DNS names, e.g., http://keycloak.caritas.svc.cluster.local:8080
-# NOT hardcoded IPs like http://10.43.63.186:8080
+# NOT hardcoded IPs like http://203.0.113.20:8080
 keycloak.auth-server-url=${KEYCLOAK_AUTH_SERVER_URL:}
 keycloak.realm=${KEYCLOAK_REALM:}
 keycloak.bearer-only=true
@@ -120,7 +120,7 @@ keycloak.config.app-client-id=app
 # ---------------- MariaDB ----------------
 # Configuration must be provided via ConfigMap/Secrets (environment variables)
 # Use Kubernetes DNS names, e.g., jdbc:mariadb://mariadb.caritas.svc.cluster.local:3306/agencyservice
-# NOT hardcoded IPs like jdbc:mariadb://10.43.123.72:3306/agencyservice
+# NOT hardcoded IPs like jdbc:mariadb://203.0.113.30:3306/agencyservice
 spring.datasource.url=${SPRING_DATASOURCE_URL:}
 spring.datasource.username=${SPRING_DATASOURCE_USERNAME:}
 spring.datasource.password=${SPRING_DATASOURCE_PASSWORD:}
@@ -140,7 +140,7 @@ spring.liquibase.enabled=false
 
 # ---------------- Spring Boot MongoDB connection ----------------
 # Use Kubernetes DNS names, e.g., mongodb://mongodb.caritas.svc.cluster.local:27017/agencyservice
-# NOT hardcoded IPs like mongodb://10.43.61.124:27017/agencyservice
+# NOT hardcoded IPs like mongodb://203.0.113.40:27017/agencyservice
 spring.data.mongodb.uri=${SPRING_DATA_MONGODB_URI:}
 
 # ---------------- Appointments & Features ----------------


### PR DESCRIPTION
## Summary

Fixes AS-L04: real public/internal infrastructure IP addresses were exposed in AgencyService config comments.

## Changes

- Replaced real Matrix Synapse public IP example with RFC5737 placeholder.
- Replaced real internal Keycloak, MariaDB and MongoDB IP examples with placeholder IPs.
- Updated affected profiles:
  - `application.properties`
  - `application-dev.properties`
  - `application-prod.properties`
  - `application-staging.properties`
  - `application-testing.properties`

No runtime config values, API behavior, database behavior, or secrets were changed.

## Verification

```powershell
rg -n "91\.99\.219\.182|10\.43\.|178\.105|46\.225" src/main/resources