### PR TITLE
AS-L02 deduplicate agency search handling

### DIFF
--- a/src/main/java/de/caritas/cob/agencyservice/api/service/AgencyService.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/service/AgencyService.java
@@ -29,6 +29,7 @@ import java.time.ZoneOffset;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Supplier;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -252,18 +253,7 @@ public class AgencyService {
   }
 
   private List<Agency> findAgencies(AgencySearch agencySearch) {
-    try {
-      return getAgencyRepositoryForSearch()
-          .searchWithoutTopic(agencySearch.getPostCode().orElse(null),
-              agencySearch.getPostCode().orElse("").length(), agencySearch.getConsultingTypeId().orElse(null),
-              agencySearch.getAge().orElse(null),
-              agencySearch.getGender().orElse(null),
-              agencySearch.getCounsellingRelation().orElse(null),
-              TenantContext.getCurrentTenant());
-    } catch (DataAccessException ex) {
-      throw new InternalServerErrorException(LogService::logDatabaseError,
-          DB_POSTCODES_ERROR);
-    }
+    return searchWithoutTopic(getAgencyRepositoryForSearch(), agencySearch);
   }
 
   private List<Agency> findAgenciesForCurrentTenant(String postCode, Integer topicId) {
@@ -342,31 +332,39 @@ public class AgencyService {
   }
 
   private List<Agency> findAgenciesWithTopic(AgencySearch agencySearch) {
-    try {
-      return getAgencyRepositoryForSearch()
-          .searchWithTopic(agencySearch.getPostCode().orElse(null), agencySearch.getPostCode().orElse("").length(),
-              agencySearch.getConsultingTypeId().orElse(null),
-              agencySearch.getTopicId().orElseThrow(),
-              agencySearch.getAge().orElse(null), agencySearch.getGender().orElse(null),
-              agencySearch.getCounsellingRelation().orElse(null),
-              TenantContext.getCurrentTenant());
-
-    } catch (DataAccessException ex) {
-      throw new InternalServerErrorException(LogService::logDatabaseError,
-          DB_POSTCODES_ERROR);
-    }
+    return searchWithTopic(getAgencyRepositoryForSearch(), agencySearch);
   }
 
   private List<Agency> findAgenciesWithTopicForCurrentTenant(AgencySearch agencySearch) {
-    try {
-      return agencyRepository
-          .searchWithTopic(agencySearch.getPostCode().orElse(null), agencySearch.getPostCode().orElse("").length(),
-              agencySearch.getConsultingTypeId().orElse(null),
-              agencySearch.getTopicId().orElseThrow(),
-              agencySearch.getAge().orElse(null), agencySearch.getGender().orElse(null),
-              agencySearch.getCounsellingRelation().orElse(null),
-              TenantContext.getCurrentTenant());
+    return searchWithTopic(agencyRepository, agencySearch);
+  }
 
+  private List<Agency> searchWithoutTopic(AgencyRepository repository, AgencySearch agencySearch) {
+    return executeAgencySearch(() -> repository.searchWithoutTopic(
+        agencySearch.getPostCode().orElse(null),
+        agencySearch.getPostCode().orElse("").length(),
+        agencySearch.getConsultingTypeId().orElse(null),
+        agencySearch.getAge().orElse(null),
+        agencySearch.getGender().orElse(null),
+        agencySearch.getCounsellingRelation().orElse(null),
+        TenantContext.getCurrentTenant()));
+  }
+
+  private List<Agency> searchWithTopic(AgencyRepository repository, AgencySearch agencySearch) {
+    return executeAgencySearch(() -> repository.searchWithTopic(
+        agencySearch.getPostCode().orElse(null),
+        agencySearch.getPostCode().orElse("").length(),
+        agencySearch.getConsultingTypeId().orElse(null),
+        agencySearch.getTopicId().orElseThrow(),
+        agencySearch.getAge().orElse(null),
+        agencySearch.getGender().orElse(null),
+        agencySearch.getCounsellingRelation().orElse(null),
+        TenantContext.getCurrentTenant()));
+  }
+
+  private List<Agency> executeAgencySearch(Supplier<List<Agency>> search) {
+    try {
+      return search.get();
     } catch (DataAccessException ex) {
       throw new InternalServerErrorException(LogService::logDatabaseError,
           DB_POSTCODES_ERROR);


### PR DESCRIPTION
## Summary

Refactors AS-L02 by removing duplicated agency search logic in `AgencyService`.

## Changes

- Extracted shared `searchWithTopic(AgencyRepository, AgencySearch)` helper.
- Extracted shared `searchWithoutTopic(AgencyRepository, AgencySearch)` helper.
- Centralized duplicated `DataAccessException` handling in `executeAgencySearch`.
- Kept existing repository behavior unchanged:
  - regular agency search still uses `getAgencyRepositoryForSearch()`
  - current-tenant topic search still uses `agencyRepository`

No API changes, no database changes, and no behavior changes are intended.

## Verification

- `mvn -DskipTests compile` -> BUILD SUCCESS

I also attempted to run:

`mvn -Dtest=AgencyServiceTest,AgencyServiceTenantAwareTest -DskipITs test`

but Maven stops during `testCompile` because of existing unrelated test compilation errors in:

- `AgencyAdminServiceTest`
- `AuthenticatedUserTest`

These failures happen before the selected AS-L02 tests are executed and are not caused by this refactor.