### PR TITLE
AS-M01 remove unused MongoDB startup requirement

### DIFF
--- a/src/main/java/de/caritas/cob/agencyservice/config/ConfigurationValidator.java
+++ b/src/main/java/de/caritas/cob/agencyservice/config/ConfigurationValidator.java
@@ -34,9 +34,6 @@ public class ConfigurationValidator {
   @Value("${spring.security.oauth2.resourceserver.jwt.jwk-set-uri:}")
   private String jwtJwkSetUri;
 
-  @Value("${spring.data.mongodb.uri:}")
-  private String mongodbUri;
-
   @Value("${matrix.api-url:}")
   private String matrixApiUrl;
 
@@ -85,9 +82,6 @@ public class ConfigurationValidator {
     }
     if (isEmpty(jwtJwkSetUri)) {
       missingConfigs.add("spring.security.oauth2.resourceserver.jwt.jwk-set-uri (SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK_SET_URI)");
-    }
-    if (isEmpty(mongodbUri)) {
-      missingConfigs.add("spring.data.mongodb.uri (SPRING_DATA_MONGODB_URI)");
     }
     if (isEmpty(matrixApiUrl)) {
       missingConfigs.add("matrix.api-url (MATRIX_API_URL)");

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -138,11 +138,6 @@ spring.jpa.hibernate.ddl-auto=validate
 spring.liquibase.enabled=false
 # Database schemas are managed separately in ORISO-Database repository
 
-# ---------------- Spring Boot MongoDB connection ----------------
-# Use Kubernetes DNS names, e.g., mongodb://mongodb.caritas.svc.cluster.local:27017/agencyservice
-# NOT hardcoded IPs like mongodb://203.0.113.40:27017/agencyservice
-spring.data.mongodb.uri=${SPRING_DATA_MONGODB_URI:}
-
 # ---------------- Appointments & Features ----------------
 appointments.delete-job-cron=0 0 0 * * ?
 appointments.delete-job-enabled=false

--- a/src/test/java/de/caritas/cob/agencyservice/config/ConfigurationValidatorTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/config/ConfigurationValidatorTest.java
@@ -1,0 +1,39 @@
+package de.caritas.cob.agencyservice.config;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class ConfigurationValidatorTest {
+
+  @Test
+  void validateConfiguration_Should_NotRequireMongoDbUri() {
+    var validator = new ConfigurationValidator();
+    setRequiredConfiguration(validator);
+
+    assertDoesNotThrow(validator::validateConfiguration);
+  }
+
+  private void setRequiredConfiguration(ConfigurationValidator validator) {
+    setField(validator, "datasourceUrl");
+    setField(validator, "datasourceUsername");
+    setField(validator, "datasourcePassword");
+    setField(validator, "keycloakAuthServerUrl");
+    setField(validator, "keycloakRealm");
+    setField(validator, "jwtIssuerUri");
+    setField(validator, "jwtJwkSetUri");
+    setField(validator, "matrixApiUrl");
+    setField(validator, "matrixRegistrationSharedSecret");
+    setField(validator, "matrixServerName");
+    setField(validator, "matrixAdminUsername");
+    setField(validator, "matrixAdminPassword");
+    setField(validator, "consultingTypeServiceApiUrl");
+    setField(validator, "tenantServiceApiUrl");
+    setField(validator, "userAdminServiceApiUrl");
+  }
+
+  private void setField(ConfigurationValidator validator, String fieldName) {
+    ReflectionTestUtils.setField(validator, fieldName, "configured");
+  }
+}


### PR DESCRIPTION
## Summary

Fixes AS-M01: AgencyService required `SPRING_DATA_MONGODB_URI` during startup even though the service does not use MongoDB.

## Changes

- Removed unused MongoDB URI validation from `ConfigurationValidator`.
- Removed dead `spring.data.mongodb.uri` property from `application.properties`.
- Added regression coverage confirming AgencyService configuration validation no longer requires MongoDB URI when real required settings are present.

No API changes, no database changes, and no runtime behavior changes are intended except removing the unnecessary startup requirement.

## Verification

- Confirmed old behavior failed startup without `SPRING_DATA_MONGODB_URI`.
- Confirmed fixed branch starts without `SPRING_DATA_MONGODB_URI`.
- Manual smoke test: `GET /actuator/health` returns `200`.
- `mvn -DskipTests -Dspotless.check.skip=true compile` -> BUILD SUCCESS.

Note: `spotless:check` is not available in this repo as a Maven plugin prefix.