### PR TITLE
Resolve tenant in single pass

### DIFF
--- a/src/main/java/de/caritas/cob/agencyservice/api/tenant/AccessTokenTenantResolver.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/tenant/AccessTokenTenantResolver.java
@@ -86,11 +86,4 @@ public class AccessTokenTenantResolver implements TenantResolver {
       return Map.of();
     }
   }
-
-  @Override
-  public boolean canResolve(HttpServletRequest request) {
-    return resolve(request).isPresent();
-  }
-
-
 }

--- a/src/main/java/de/caritas/cob/agencyservice/api/tenant/CustomHeaderTenantResolver.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/tenant/CustomHeaderTenantResolver.java
@@ -16,9 +16,4 @@ public class CustomHeaderTenantResolver implements TenantResolver {
   public Optional<Long> resolve(HttpServletRequest request) {
     return tenantHeaderSupplier.getTenantFromHeader();
   }
-
-  @Override
-  public boolean canResolve(HttpServletRequest request) {
-    return resolve(request).isPresent();
-  }
 }

--- a/src/main/java/de/caritas/cob/agencyservice/api/tenant/MultitenancyWithSingleDomainTenantResolver.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/tenant/MultitenancyWithSingleDomainTenantResolver.java
@@ -107,9 +107,4 @@ public class MultitenancyWithSingleDomainTenantResolver implements TenantResolve
     String subdomain = mainTenantSubdomainForSingleDomainMultitenancy.getValue();
     return Optional.ofNullable(subdomain);
   }
-
-  @Override
-  public boolean canResolve(HttpServletRequest request) {
-    return resolve(request).isPresent();
-  }
 }

--- a/src/main/java/de/caritas/cob/agencyservice/api/tenant/SubdomainTenantResolver.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/tenant/SubdomainTenantResolver.java
@@ -37,9 +37,4 @@ public class SubdomainTenantResolver implements TenantResolver {
   private Long getTenantIdBySubdomain(String currentSubdomain) {
     return tenantService.getRestrictedTenantDataBySubdomain(currentSubdomain).getId();
   }
-
-  @Override
-  public boolean canResolve(HttpServletRequest request) {
-    return resolve(request).isPresent();
-  }
 }

--- a/src/main/java/de/caritas/cob/agencyservice/api/tenant/TechnicalUserTenantResolver.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/tenant/TechnicalUserTenantResolver.java
@@ -42,10 +42,4 @@ public class TechnicalUserTenantResolver implements TenantResolver {
     }
     return Lists.newArrayList();
   }
-
-
-  @Override
-  public boolean canResolve(HttpServletRequest request) {
-    return resolve(request).isPresent();
-  }
 }

--- a/src/main/java/de/caritas/cob/agencyservice/api/tenant/TenantResolver.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/tenant/TenantResolver.java
@@ -6,6 +6,4 @@ import jakarta.servlet.http.HttpServletRequest;
 public interface TenantResolver {
 
   Optional<Long> resolve(HttpServletRequest request);
-
-  boolean canResolve(HttpServletRequest request);
 }

--- a/src/main/java/de/caritas/cob/agencyservice/api/tenant/TenantResolverService.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/tenant/TenantResolverService.java
@@ -105,8 +105,9 @@ public class TenantResolverService {
   private Optional<Long> getFirstResolvedTenant(HttpServletRequest request,
       List<TenantResolver> tenantResolvers) {
     for (TenantResolver tenantResolver : tenantResolvers) {
-      if (tenantResolver.canResolve(request)) {
-        return tenantResolver.resolve(request);
+      Optional<Long> tenantId = tenantResolver.resolve(request);
+      if (tenantId.isPresent()) {
+        return tenantId;
       }
     }
     return Optional.empty();

--- a/src/main/java/de/caritas/cob/agencyservice/filter/HttpTenantFilter.java
+++ b/src/main/java/de/caritas/cob/agencyservice/filter/HttpTenantFilter.java
@@ -62,7 +62,7 @@ public class HttpTenantFilter extends OncePerRequestFilter {
     }
 
     private boolean belongsToWhitelist(HttpServletRequest request, List<String> tenantWhitelist) {
-      return tenantWhitelist.parallelStream()
+      return tenantWhitelist.stream()
           .anyMatch(request.getRequestURI().toLowerCase()::contains);
     }
   }

--- a/src/test/java/de/caritas/cob/agencyservice/api/tenant/TenantResolverServiceTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/tenant/TenantResolverServiceTest.java
@@ -1,9 +1,13 @@
 package de.caritas.cob.agencyservice.api.tenant;
 
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import java.util.Optional;
-
 import jakarta.servlet.http.HttpServletRequest;
-
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -16,10 +20,6 @@ import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
-
-import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class TenantResolverServiceTest {
@@ -68,9 +68,9 @@ class TenantResolverServiceTest {
   void resolve_Should_ResolveFromAccessTokenForAuthenticatedUser_And_PassValidation() {
     // given
     givenUserIsAuthenticated();
-    when(accessTokenTenantResolver.canResolve(authenticatedRequest)).thenReturn(true);
+    when(technicalUserTenantResolver.resolve(authenticatedRequest)).thenReturn(Optional.empty());
     when(accessTokenTenantResolver.resolve(authenticatedRequest)).thenReturn(Optional.of(1L));
-    when(subdomainTenantResolver.canResolve(authenticatedRequest)).thenReturn(true);
+    when(customHeaderTenantResolver.resolve(authenticatedRequest)).thenReturn(Optional.empty());
     when(subdomainTenantResolver.resolve(authenticatedRequest)).thenReturn(Optional.of(1L));
 
     // when
@@ -78,6 +78,8 @@ class TenantResolverServiceTest {
 
     // then
     assertThat(resolvedTenantId).isEqualTo(1L);
+    verify(accessTokenTenantResolver).resolve(authenticatedRequest);
+    verify(subdomainTenantResolver).resolve(authenticatedRequest);
   }
 
   private void givenUserIsAuthenticated() {
@@ -91,9 +93,9 @@ class TenantResolverServiceTest {
     // given
 
     givenUserIsAuthenticated();
-    when(accessTokenTenantResolver.canResolve(authenticatedRequest)).thenReturn(true);
+    when(technicalUserTenantResolver.resolve(authenticatedRequest)).thenReturn(Optional.empty());
     when(accessTokenTenantResolver.resolve(authenticatedRequest)).thenReturn(Optional.of(1L));
-    when(subdomainTenantResolver.canResolve(authenticatedRequest)).thenReturn(true);
+    when(customHeaderTenantResolver.resolve(authenticatedRequest)).thenReturn(Optional.empty());
     when(subdomainTenantResolver.resolve(authenticatedRequest)).thenReturn(Optional.of(2L));
 
     // when, then
@@ -105,7 +107,10 @@ class TenantResolverServiceTest {
   void resolve_Should_ThrowAccessDeniedExceptionForAuthenticatedUser_IfAccessTokenResolverCannotResolveTenant() {
     // given
     givenUserIsAuthenticated();
-    when(accessTokenTenantResolver.canResolve(authenticatedRequest)).thenReturn(false);
+    when(technicalUserTenantResolver.resolve(authenticatedRequest)).thenReturn(Optional.empty());
+    when(accessTokenTenantResolver.resolve(authenticatedRequest)).thenReturn(Optional.empty());
+    when(customHeaderTenantResolver.resolve(authenticatedRequest)).thenReturn(Optional.empty());
+    when(subdomainTenantResolver.resolve(authenticatedRequest)).thenReturn(Optional.empty());
 
     // when, then
     assertThrows(AccessDeniedException.class,
@@ -115,7 +120,11 @@ class TenantResolverServiceTest {
   @Test
   void resolve_Should_ThrowAccessDeniedExceptionForNotAuthenticatedUser_IfSubdomainCouldNotBeDetermined() {
     // given
-    when(subdomainTenantResolver.canResolve(nonAuthenticatedRequest)).thenReturn(false);
+    when(multitenancyWithSingleDomainTenantResolver.resolve(nonAuthenticatedRequest))
+        .thenReturn(Optional.empty());
+    when(customHeaderTenantResolver.resolve(nonAuthenticatedRequest)).thenReturn(Optional.empty());
+    when(subdomainTenantResolver.resolve(nonAuthenticatedRequest)).thenReturn(Optional.empty());
+
     // when, then
     assertThrows(AccessDeniedException.class,
         () -> tenantResolverService.resolve(nonAuthenticatedRequest));
@@ -124,31 +133,38 @@ class TenantResolverServiceTest {
   @Test
   void resolve_Should_ResolveTenantId_IfSubdomainCouldBeDetermined() {
     // given
-    when(subdomainTenantResolver.canResolve(nonAuthenticatedRequest)).thenReturn(true);
+    when(multitenancyWithSingleDomainTenantResolver.resolve(nonAuthenticatedRequest))
+        .thenReturn(Optional.empty());
+    when(customHeaderTenantResolver.resolve(nonAuthenticatedRequest)).thenReturn(Optional.empty());
     when(subdomainTenantResolver.resolve(nonAuthenticatedRequest)).thenReturn(Optional.of(1L));
+
     // when
     Long resolved = tenantResolverService.resolve(nonAuthenticatedRequest);
+
     // then
     assertThat(resolved).isEqualTo(1L);
+    verify(subdomainTenantResolver).resolve(nonAuthenticatedRequest);
   }
 
   @Test
   void resolve_Should_ResolveTenantId_ForTechnicalUserRole() {
     // given
     givenUserIsAuthenticated();
-    when(technicalUserTenantResolver.canResolve(authenticatedRequest)).thenReturn(true);
     when(technicalUserTenantResolver.resolve(authenticatedRequest)).thenReturn(
         Optional.of(TECHNICAL_CONTEXT));
 
     Long resolved = tenantResolverService.resolve(authenticatedRequest);
+
     // then
     assertThat(resolved).isEqualTo(TECHNICAL_CONTEXT);
+    verify(accessTokenTenantResolver, never()).resolve(authenticatedRequest);
   }
 
   @Test
   void resolve_Should_ResolveTenantId_FromHeader() {
     // given
-    when(customHeaderTenantResolver.canResolve(authenticatedRequest)).thenReturn(true);
+    when(multitenancyWithSingleDomainTenantResolver.resolve(authenticatedRequest))
+        .thenReturn(Optional.empty());
     when(customHeaderTenantResolver.resolve(authenticatedRequest)).thenReturn(Optional.of(2L));
 
     // when
@@ -156,6 +172,22 @@ class TenantResolverServiceTest {
 
     // then
     assertThat(resolved).isEqualTo(2L);
+    verify(subdomainTenantResolver, never()).resolve(authenticatedRequest);
   }
 
+  @Test
+  void resolve_Should_CallSuccessfulResolverOnlyOnce_ForNonAuthenticatedUser() {
+    // given
+    when(multitenancyWithSingleDomainTenantResolver.resolve(nonAuthenticatedRequest))
+        .thenReturn(Optional.empty());
+    when(customHeaderTenantResolver.resolve(nonAuthenticatedRequest)).thenReturn(Optional.empty());
+    when(subdomainTenantResolver.resolve(nonAuthenticatedRequest)).thenReturn(Optional.of(1L));
+
+    // when
+    Long resolved = tenantResolverService.resolve(nonAuthenticatedRequest);
+
+    // then
+    assertThat(resolved).isEqualTo(1L);
+    verify(subdomainTenantResolver).resolve(nonAuthenticatedRequest);
+  }
 }


### PR DESCRIPTION
## Summary

Fixes AS-L07: tenant resolution no longer runs the same resolver twice per request.

## Changes

- Removed `canResolve()` from the `TenantResolver` interface and all resolver implementations.
- Updated `TenantResolverService` to resolve tenants in a single pass:
  - call `resolve(request)` once per resolver
  - return the first present tenant id
- Preserved existing resolver order and behavior.
- Replaced `parallelStream()` with `stream()` in `HttpTenantFilter` whitelist matching.
- Updated `TenantResolverServiceTest` coverage for the new single-pass behavior.

## Verification

- Confirmed no `canResolve` references remain in main/test sources.
- Confirmed `tenantWhitelist.parallelStream()` is removed.
- `mvn -DskipTests -Dspotless.check.skip=true compile` -> `BUILD SUCCESS`

## Notes

No API changes, no database changes, and no behavior changes are intended.

Targeted test run for `TenantResolverServiceTest,HttpTenantFilterTest` is currently blocked by unrelated existing `testCompile` errors in:
- `AgencyAdminServiceTest`
- `AuthenticatedUserTest`