### PR TITLE
AS-M09 remove unused copied config

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -38,23 +38,6 @@ registration.cors.allowed.paths=
 spring.web.locale=de_DE
 spring.jackson.time-zone=Europe/Berlin
 
-service.encryption.appkey=
-
-# ---------------- Identity Management ----------------
-identity.email-dummy-suffix=@beratungcaritas.de
-identity.technical-user.username=ali
-identity.technical-user.password=ali
-identity.error-message-duplicated-email=User exists with same email
-identity.error-message-duplicated-username=User exists with same username
-identity.openid-connect-url=${app.base.url}/auth/realms/online-beratung/protocol/openid-connect
-identity.otp-url=${app.base.url}/auth/realms/online-beratung/otp-config
-identity.otp-allowed-for-users=false
-identity.otp-allowed-for-consultants=false
-identity.otp-allowed-for-single-tenant-admins=false
-identity.otp-allowed-for-restricted-agency-admins=false
-identity.otp-allowed-for-tenant-super-admins=false
-identity.display-name-allowed-for-consultants=false
-
 # ---------------- API Docs ----------------
 springfox.docuTitle=Caritas Online Beratung: AgencyService
 springfox.docuDescription=Provides a REST API service to provide user information and actions.
@@ -73,7 +56,6 @@ agency.service.api.get.agencies=${agency.service.api.url}/
 agency.admin.service.api.url=${app.base.url}
 # Use Kubernetes DNS names, e.g., http://consultingtypeservice.caritas.svc.cluster.local:8083
 consulting.type.service.api.url=${CONSULTING_TYPE_SERVICE_API_URL:}
-live.service.api.url=${LIVE_SERVICE_API_URL:${app.base.url}/service/liveevent}
 appointment.service.api.url=${APPOINTMENT_SERVICE_API_URL:}
 tenant.service.api.url=${TENANT_SERVICE_API_URL:}
 
@@ -112,8 +94,8 @@ keycloak.bearer-only=true
 keycloak.resource=agency-service
 keycloak.principal-attribute=preferred_username
 keycloak.cors=false
-keycloak.config.admin-username=technical
-keycloak.config.admin-password=technical
+keycloak.config.admin-username=${KEYCLOAK_CONFIG_ADMIN_USERNAME:}
+keycloak.config.admin-password=${KEYCLOAK_CONFIG_ADMIN_PASSWORD:}
 keycloak.config.admin-client-id=admin-cli
 keycloak.config.app-client-id=app
 


### PR DESCRIPTION
## Summary
- Removed unused UserService-copied configuration from `application.properties` (`identity.*`, `service.encryption.appkey`, `live.service.api.url`).
- Replaced hardcoded Keycloak admin defaults (`technical` / `technical`) with environment-backed values.
- Kept the PR scoped to AS-M09 only.

## Why
These properties are not read by AgencyService and were copy-pasted from UserService. Keeping them in the base config creates confusion, misconfiguration risk, and weak default credentials in the repository.

## Verification
- Removed-key grep returns no matches.
- `mvn -DskipTests -Dspotless.check.skip=true compile` passes.
- Local startup was smoke-tested before removing temporary local-only test config from the final diff.