### PR TITLE
Fix CSRF matching for agency admin endpoints

### DIFF
--- a/src/main/java/de/caritas/cob/agencyservice/filter/StatelessCsrfFilter.java
+++ b/src/main/java/de/caritas/cob/agencyservice/filter/StatelessCsrfFilter.java
@@ -3,9 +3,8 @@ package de.caritas.cob.agencyservice.filter;
 import static de.caritas.cob.agencyservice.config.SecurityConfig.WHITE_LIST;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
+import java.util.Locale;
 import java.util.regex.Pattern;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -16,6 +15,7 @@ import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.security.web.access.AccessDeniedHandlerImpl;
 import org.springframework.security.web.util.matcher.RequestMatcher;
+import org.springframework.util.AntPathMatcher;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 /**
@@ -62,19 +62,30 @@ public class StatelessCsrfFilter extends OncePerRequestFilter {
 
   public static final class DefaultRequiresCsrfMatcher implements RequestMatcher {
     private final Pattern allowedMethods = Pattern.compile("^(HEAD|TRACE|OPTIONS|GET)$");
+    private final AntPathMatcher pathMatcher = new AntPathMatcher();
 
     @Override
     public boolean matches(HttpServletRequest request) {
 
       // Allow specific whitelist items to disable CSRF protection for Swagger UI documentation
-      List<String> csrfWhitelist = new ArrayList<>(Arrays.asList(WHITE_LIST));
-      csrfWhitelist.add("/agencyadmin");
-      if (csrfWhitelist.parallelStream()
-          .anyMatch(request.getRequestURI().toLowerCase()::contains)) {
+      String requestPath = getPathWithinApplication(request).toLowerCase(Locale.ROOT);
+      if (Arrays.stream(WHITE_LIST)
+          .map(whitelistPattern -> whitelistPattern.toLowerCase(Locale.ROOT))
+          .anyMatch(whitelistPattern -> pathMatcher.match(whitelistPattern, requestPath))) {
         return false;
       }
 
       return !allowedMethods.matcher(request.getMethod()).matches();
+    }
+
+    private String getPathWithinApplication(HttpServletRequest request) {
+      String requestUri = request.getRequestURI();
+      String contextPath = request.getContextPath();
+      if (contextPath == null || contextPath.isBlank() || !requestUri.startsWith(contextPath)) {
+        return requestUri;
+      }
+      String path = requestUri.substring(contextPath.length());
+      return path.isBlank() ? "/" : path;
     }
   }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -171,8 +171,8 @@ thread.executor.threadNamePrefix=AgencyService-
 user.admin.service.api.url=${USER_ADMIN_SERVICE_API_URL:}
 
 # ---------------- CSRF ----------------
-csrf.header.property=
-csrf.cookie.property=
+csrf.header.property=X-CSRF-Token
+csrf.cookie.property=CSRF-TOKEN
 csrf.whitelist.adminUris=
 csrf.whitelist.configUris=
 csrf.whitelist.header.property=

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/controller/AgencyAdminControllerAuthorizationIT.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/controller/AgencyAdminControllerAuthorizationIT.java
@@ -51,7 +51,11 @@ import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 
 @RunWith(SpringRunner.class)
-@TestPropertySource(properties = "spring.profiles.active=testing")
+@TestPropertySource(properties = {
+    "spring.profiles.active=testing",
+    "csrf.header.property=csrfHeader",
+    "csrf.cookie.property=csrfCookie"
+})
 @SpringBootTest
 @AutoConfigureMockMvc
 @AutoConfigureTestDatabase(replace = Replace.ANY)
@@ -137,6 +141,20 @@ public class AgencyAdminControllerAuthorizationIT {
         .cookie(CSRF_COOKIE)
         .header(CSRF_HEADER, CSRF_VALUE))
         .andExpect(status().isUnauthorized());
+
+    verifyNoMoreInteractions(this.agencyAdminService);
+    verifyNoMoreInteractions(this.agencyValidator);
+  }
+
+  @Test
+  @WithMockUser(authorities = {"AUTHORIZATION_AGENCY_ADMIN"})
+  public void createAgency_Should_ReturnForbiddenAndCallNoMethods_When_csrfTokenIsMissing()
+      throws Exception {
+
+    mvc.perform(post(CREATE_AGENCY_PATH)
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(VALID_AGENCY_DTO))
+        .andExpect(status().isForbidden());
 
     verifyNoMoreInteractions(this.agencyAdminService);
     verifyNoMoreInteractions(this.agencyValidator);

--- a/src/test/java/de/caritas/cob/agencyservice/filter/StatelessCsrfFilterTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/filter/StatelessCsrfFilterTest.java
@@ -1,0 +1,93 @@
+package de.caritas.cob.agencyservice.filter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import de.caritas.cob.agencyservice.filter.StatelessCsrfFilter.DefaultRequiresCsrfMatcher;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+class StatelessCsrfFilterTest {
+
+  private static final String CSRF_COOKIE = "csrfCookie";
+  private static final String CSRF_HEADER = "csrfHeader";
+  private static final String CSRF_TOKEN = "token";
+
+  private final DefaultRequiresCsrfMatcher matcher = new DefaultRequiresCsrfMatcher();
+
+  @Test
+  void matches_ShouldRequireCsrf_WhenAgencyAdminMutationIsRequested() {
+    MockHttpServletRequest request = request("POST", "/agencyadmin/agencies");
+
+    assertThat(matcher.matches(request)).isTrue();
+  }
+
+  @Test
+  void matches_ShouldNotRequireCsrf_WhenAgencyAdminSafeMethodIsRequested() {
+    MockHttpServletRequest request = request("GET", "/agencyadmin/agencies");
+
+    assertThat(matcher.matches(request)).isFalse();
+  }
+
+  @Test
+  void matches_ShouldNotBypassCsrf_WhenWhitelistPatternIsOnlyContainedInPath() {
+    MockHttpServletRequest request = request("POST", "/foo/internal/agencies/bar");
+
+    assertThat(matcher.matches(request)).isTrue();
+  }
+
+  @Test
+  void matches_ShouldNotRequireCsrf_WhenWhitelistedPathIsRequested() {
+    MockHttpServletRequest request = request("POST", "/swagger-ui/index.html");
+
+    assertThat(matcher.matches(request)).isFalse();
+  }
+
+  @Test
+  void matches_ShouldMatchWhitelistAgainstPathWithinContext() {
+    MockHttpServletRequest request = request("POST", "/agency-service/swagger-ui/index.html");
+    request.setContextPath("/agency-service");
+
+    assertThat(matcher.matches(request)).isFalse();
+  }
+
+  @Test
+  void doFilter_ShouldRejectAgencyAdminMutation_WhenCsrfTokenIsMissing()
+      throws ServletException, IOException {
+    StatelessCsrfFilter filter = new StatelessCsrfFilter(CSRF_COOKIE, CSRF_HEADER);
+    MockHttpServletRequest request = request("POST", "/agencyadmin/agencies");
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    MockFilterChain filterChain = new MockFilterChain();
+
+    filter.doFilter(request, response, filterChain);
+
+    assertThat(response.getStatus()).isEqualTo(403);
+    assertThat(filterChain.getRequest()).isNull();
+  }
+
+  @Test
+  void doFilter_ShouldAllowAgencyAdminMutation_WhenCsrfCookieAndHeaderMatch()
+      throws ServletException, IOException {
+    StatelessCsrfFilter filter = new StatelessCsrfFilter(CSRF_COOKIE, CSRF_HEADER);
+    MockHttpServletRequest request = request("POST", "/agencyadmin/agencies");
+    request.addHeader(CSRF_HEADER, CSRF_TOKEN);
+    request.setCookies(new Cookie(CSRF_COOKIE, CSRF_TOKEN));
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    MockFilterChain filterChain = new MockFilterChain();
+
+    filter.doFilter(request, response, filterChain);
+
+    assertThat(response.getStatus()).isEqualTo(200);
+    assertThat(filterChain.getRequest()).isSameAs(request);
+  }
+
+  private MockHttpServletRequest request(String method, String requestUri) {
+    MockHttpServletRequest request = new MockHttpServletRequest(method, requestUri);
+    request.setRequestURI(requestUri);
+    return request;
+  }
+}


### PR DESCRIPTION
## Summary

- Replaced unsafe substring-based CSRF whitelist checks with path-aware `AntPathMatcher` matching.
- Removed the blanket `/agencyadmin` CSRF exemption so mutating agency admin requests require the double-submit CSRF cookie/header pair.
- Added CSRF header/cookie defaults used by ORISO Admin: `X-CSRF-Token` and `CSRF-TOKEN`.
- Added focused tests for the CSRF matcher/filter and missing-CSRF agency admin mutation.

## Verification

- `mvn -DskipTests -Dspotless.check.skip=true compile` passes.
Manual E2E smoke:
- Verified that `POST /agencyadmin/agencies` without a valid CSRF header/cookie pair is rejected with `403`.
- Verified that the same request with matching `X-Csrf-Token` and `CSRF-TOKEN` passes CSRF/auth and reaches `AgencyAdminController#createAgency`.
- The follow-up `500` occurred only in the local smoke setup because the dependent ConsultingTypeService URL was intentionally not configured for this isolated AgencyService run; it is unrelated to the CSRF/security change.
  
<img width="975" height="548" alt="image" src="https://github.com/user-attachments/assets/d8f6c404-6604-4cc1-b121-b328409a473e" />
