### PR TITLE
AS-M15 lock actuator health details and remove prod debug logging

### DIFF
--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -1,9 +1,7 @@
 # ---------------- Logging ----------------
 server.port=8084
 logging.level.root=INFO
-logging.level.org.springframework.web=DEBUG
 logging.level.org.hibernate=ERROR
-logging.level.org.springframework.web.servlet.mvc.method.annotation=DEBUG
 
 # ---------------- Keycloak ----------------
 # Use Kubernetes DNS names, e.g., http://keycloak.caritas.svc.cluster.local:8080

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -151,7 +151,7 @@ multitenancy.enabled=${MULTITENANCY_ENABLED:false}
 
 # ---------------- Actuator ----------------
 management.endpoint.health.enabled=true
-management.endpoint.health.show-details=always
+management.endpoint.health.show-details=when-authorized
 management.endpoints.web.exposure.include=health,loggers
 management.endpoint.health.probes.enabled=true
 management.endpoint.loggers.enabled=true


### PR DESCRIPTION
## What
- Changed `management.endpoint.health.show-details=always` → `when-authorized` in `application.properties`
- Removed `logging.level.org.springframework.web=DEBUG` from `application-prod.properties`
- Removed `logging.level.org.springframework.web.servlet.mvc.method.annotation=DEBUG` from `application-prod.properties`

## Why
Unauthenticated callers could query `/actuator/health` and see internal component details. DEBUG web logging in production exposes full HTTP request/response details in logs.

`when-authorized` returns `{status:UP}` only to unauthenticated callers — K8s probes are unaffected.

## Audit
**ID:** AS-M15
**Severity:** Medium
**Batch:** B

## Test
- [ ] `GET /actuator/health` without auth → `{status:UP}` only
- [ ] `GET /actuator/health` with valid JWT → full component details
- [ ] Prod logs show no `DEBUG` web request lines after deploy

Closes #34