### PR TITLE
AS-M24 remove debug web and sql logging from all deployed profiles

### DIFF
--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -1,9 +1,7 @@
 # ---------------- Logging ----------------
 server.port=8084
 logging.level.root=INFO
-logging.level.org.springframework.web=DEBUG
 logging.level.org.hibernate=ERROR
-logging.level.org.springframework.web.servlet.mvc.method.annotation=DEBUG
 
 # ---------------- Keycloak ----------------
 # Use Kubernetes DNS names, e.g., http://keycloak.caritas.svc.cluster.local:8080
@@ -36,8 +34,8 @@ spring.datasource.hikari.minimum-idle=8
 spring.datasource.hikari.idle-timeout=500000
 spring.datasource.hikari.maxLifetime=500000
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MariaDB103Dialect
-spring.jpa.show-sql=true
-spring.jpa.properties.hibernate.format_sql=true
+spring.jpa.show-sql=false
+spring.jpa.properties.hibernate.format_sql=false
 spring.jpa.hibernate.ddl-auto=validate
 
 # ---------------- Liquibase ----------------

--- a/src/main/resources/application-staging.properties
+++ b/src/main/resources/application-staging.properties
@@ -1,9 +1,7 @@
 # ---------------- Logging ----------------
 server.port=8084
 logging.level.root=INFO
-logging.level.org.springframework.web=DEBUG
 logging.level.org.hibernate=ERROR
-logging.level.org.springframework.web.servlet.mvc.method.annotation=DEBUG
 
 # ---------------- Keycloak ----------------
 # Use Kubernetes DNS names, e.g., http://keycloak.caritas.svc.cluster.local:8080
@@ -36,8 +34,8 @@ spring.datasource.hikari.minimum-idle=8
 spring.datasource.hikari.idle-timeout=500000
 spring.datasource.hikari.maxLifetime=500000
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MariaDB103Dialect
-spring.jpa.show-sql=true
-spring.jpa.properties.hibernate.format_sql=true
+spring.jpa.show-sql=false
+spring.jpa.properties.hibernate.format_sql=false
 spring.jpa.hibernate.ddl-auto=validate
 
 # ---------------- Liquibase ----------------

--- a/src/main/resources/application-testing.properties
+++ b/src/main/resources/application-testing.properties
@@ -1,9 +1,7 @@
 # ---------------- Logging ----------------
 server.port=8084
 logging.level.root=INFO
-logging.level.org.springframework.web=DEBUG
 logging.level.org.hibernate=ERROR
-logging.level.org.springframework.web.servlet.mvc.method.annotation=DEBUG
 
 # ---------------- Keycloak ----------------
 # Use Kubernetes DNS names, e.g., http://keycloak.caritas.svc.cluster.local:8080
@@ -36,8 +34,8 @@ spring.datasource.hikari.minimum-idle=8
 spring.datasource.hikari.idle-timeout=500000
 spring.datasource.hikari.maxLifetime=500000
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MariaDB103Dialect
-spring.jpa.show-sql=true
-spring.jpa.properties.hibernate.format_sql=true
+spring.jpa.show-sql=false
+spring.jpa.properties.hibernate.format_sql=false
 spring.jpa.hibernate.ddl-auto=validate
 
 # ---------------- Liquibase ----------------


### PR DESCRIPTION
## What
- Removed `logging.level.org.springframework.web=DEBUG` from dev, staging, testing profiles
- Removed `logging.level.org.springframework.web.servlet.mvc.method.annotation=DEBUG` from dev, staging, testing profiles
- `spring.jpa.show-sql=true` → `false` in dev, staging, testing profiles
- `spring.jpa.properties.hibernate.format_sql=true` → `false` in dev, staging, testing profiles

Note: prod profile was already fixed in AS-M15 (separate PR).

## Why
DEBUG web logging exposes full HTTP request/response bodies including auth headers. `show-sql=true` logs every SQL query including any data values bound to parameters — a data exposure risk in shared/staging environments.

## Audit
**ID:** AS-M24
**Severity:** Medium
**Batch:** C

## Test
- [ ] Deploy to dev, tail pod logs — no `DEBUG` web lines, no SQL query output
- [ ] Application behaviour unchanged (property-only change)

Closes #35