### PR TITLE
Harden actuator health and production logging

### DIFF
--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -1,9 +1,9 @@
 # ---------------- Logging ----------------
 server.port=8084
 logging.level.root=INFO
-logging.level.org.springframework.web=DEBUG
+logging.level.org.springframework.web=INFO
 logging.level.org.hibernate=ERROR
-logging.level.org.springframework.web.servlet.mvc.method.annotation=DEBUG
+logging.level.org.springframework.web.servlet.mvc.method.annotation=INFO
 
 # ---------------- Keycloak ----------------
 # Use Kubernetes DNS names, e.g., http://keycloak.caritas.svc.cluster.local:8080
@@ -36,8 +36,8 @@ spring.datasource.hikari.minimum-idle=8
 spring.datasource.hikari.idle-timeout=500000
 spring.datasource.hikari.maxLifetime=500000
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MariaDB103Dialect
-spring.jpa.show-sql=true
-spring.jpa.properties.hibernate.format_sql=true
+spring.jpa.show-sql=false
+spring.jpa.properties.hibernate.format_sql=false
 spring.jpa.hibernate.ddl-auto=validate
 
 # ---------------- Liquibase ----------------

--- a/src/main/resources/application-staging.properties
+++ b/src/main/resources/application-staging.properties
@@ -1,9 +1,9 @@
 # ---------------- Logging ----------------
 server.port=8084
 logging.level.root=INFO
-logging.level.org.springframework.web=DEBUG
+logging.level.org.springframework.web=INFO
 logging.level.org.hibernate=ERROR
-logging.level.org.springframework.web.servlet.mvc.method.annotation=DEBUG
+logging.level.org.springframework.web.servlet.mvc.method.annotation=INFO
 
 # ---------------- Keycloak ----------------
 # Use Kubernetes DNS names, e.g., http://keycloak.caritas.svc.cluster.local:8080
@@ -36,8 +36,8 @@ spring.datasource.hikari.minimum-idle=8
 spring.datasource.hikari.idle-timeout=500000
 spring.datasource.hikari.maxLifetime=500000
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MariaDB103Dialect
-spring.jpa.show-sql=true
-spring.jpa.properties.hibernate.format_sql=true
+spring.jpa.show-sql=false
+spring.jpa.properties.hibernate.format_sql=false
 spring.jpa.hibernate.ddl-auto=validate
 
 # ---------------- Liquibase ----------------

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -130,8 +130,8 @@ spring.datasource.hikari.minimum-idle=8
 spring.datasource.hikari.idle-timeout=500000
 spring.datasource.hikari.maxLifetime=500000
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MariaDB103Dialect
-spring.jpa.show-sql=true
-spring.jpa.properties.hibernate.format_sql=true
+spring.jpa.show-sql=false
+spring.jpa.properties.hibernate.format_sql=false
 spring.jpa.hibernate.ddl-auto=validate
 
 # ---------------- Liquibase ----------------
@@ -151,7 +151,7 @@ multitenancy.enabled=${MULTITENANCY_ENABLED:false}
 
 # ---------------- Actuator ----------------
 management.endpoint.health.enabled=true
-management.endpoint.health.show-details=always
+management.endpoint.health.show-details=when_authorized
 management.endpoints.web.exposure.include=health,loggers
 management.endpoint.health.probes.enabled=true
 management.endpoint.loggers.enabled=true


### PR DESCRIPTION
## Summary

- Changed actuator health details from `always` to `when_authorized` so unauthenticated `/actuator/health` calls no longer expose component details.
- Disabled default SQL logging in base configuration.
- Reduced Spring Web/MVC logging from `DEBUG` to `INFO` in `prod` and `staging`.
- Disabled SQL statement formatting/logging explicitly in `prod` and `staging`.

## Notes

- `/actuator/health/**` remains whitelisted so Kubernetes liveness/readiness probes continue to work.
- `dev` and `testing` profiles keep DEBUG web logging and SQL logging for local development diagnostics.

## Verification

- `mvn -DskipTests -Dspotless.check.skip=true compile` passes.
- Config audit confirms:
  - no `management.endpoint.health.show-details=always` remains in base/prod/staging scope
  - no `logging.level.org.springframework.web=DEBUG` remains in prod/staging
  - no `spring.jpa.show-sql=true` remains in base/prod/staging