### PR TITLE
Make development deploy script configurable

### DIFF
--- a/deploy-development.sh
+++ b/deploy-development.sh
@@ -1,15 +1,20 @@
 #!/bin/bash
 set -e
-cd /root/online-beratung/ORISO-Complete/caritas-workspace/ORISO-AgencyService
-export JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
-export PATH="$JAVA_HOME/bin:$PATH"
-mvn clean package -DskipTests -Dmaven.test.skip=true -Dspotless.check.skip=true -Dcheckstyle.skip=true
-cp -f target/AgencyService.jar AgencyService.jar
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+K8S_NAMESPACE="${K8S_NAMESPACE:-caritas}"
+DEPLOYMENT_NAME="${DEPLOYMENT_NAME:-oriso-platform-agencyservice}"
+IMAGE_NAME="${IMAGE_NAME:-oriso-agencyservice}"
+
+./mvnw clean package -DskipTests -Dmaven.test.skip=true -Dspotless.check.skip=true -Dcheckstyle.skip=true
 TS=$(date +%s)
-IMAGE_TAG="oriso-agencyservice:dev-${TS}"
-docker build -t ${IMAGE_TAG} .
-docker tag ${IMAGE_TAG} oriso-agencyservice:latest
-docker save ${IMAGE_TAG} | sudo k3s ctr images import - > /dev/null 2>&1
-docker save oriso-agencyservice:latest | sudo k3s ctr images import - > /dev/null 2>&1
-kubectl rollout restart deployment/oriso-platform-agencyservice -n caritas
-kubectl rollout status deployment/oriso-platform-agencyservice -n caritas --timeout=240s
+IMAGE_TAG="${IMAGE_NAME}:dev-${TS}"
+
+docker build -t "${IMAGE_TAG}" .
+docker tag "${IMAGE_TAG}" "${IMAGE_NAME}:latest"
+docker save "${IMAGE_TAG}" | sudo k3s ctr images import - > /dev/null 2>&1
+docker save "${IMAGE_NAME}:latest" | sudo k3s ctr images import - > /dev/null 2>&1
+kubectl rollout restart "deployment/${DEPLOYMENT_NAME}" -n "${K8S_NAMESPACE}"
+kubectl rollout status "deployment/${DEPLOYMENT_NAME}" -n "${K8S_NAMESPACE}" --timeout=240s


### PR DESCRIPTION
## Summary
- Make `deploy-development.sh` resolve the repository path relative to the script location instead of using the hardcoded `/root/.../caritas-workspace/...` path.
- Parameterize the Kubernetes namespace, deployment name, and image name via environment variables while keeping the current dev defaults.
- Remove hardcoded `JAVA_HOME` and use the project Maven wrapper.

## Verification
- Confirmed `deploy-development.sh` no longer contains the old absolute path or `caritas-workspace` reference.
- Confirmed `K8S_NAMESPACE`, `DEPLOYMENT_NAME`, and `IMAGE_NAME` can be overridden via environment variables.
- Ran `git diff --check`.