### PR TITLE
Fix: agency update wipes topic links when topicIds is omitted

### DIFF
--- a/src/main/java/de/caritas/cob/agencyservice/api/admin/service/AgencyAdminService.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/admin/service/AgencyAdminService.java
@@ -287,8 +287,10 @@ public class AgencyAdminService {
     convertCounsellingRelations(updateAgencyDTO, agencyToUpdate);
 
     if (featureTopicsEnabled) {
-      List<AgencyTopic> agencyTopics = agencyTopicMergeService.getMergedTopics(agencyToUpdate,
-          updateAgencyDTO.getTopicIds());
+      // Use getMergedTopicsForUpdate so that an update which does not carry topicIds (null) keeps
+      // the existing links instead of wiping them; an explicitly empty list still clears them.
+      List<AgencyTopic> agencyTopics = agencyTopicMergeService.getMergedTopicsForUpdate(
+          agencyToUpdate, agency.getAgencyTopics(), updateAgencyDTO.getTopicIds());
       agencyToUpdate.setAgencyTopics(agencyTopics);
     } else {
       // If the Topic feature is not enabled, Hibernate use an empty PersistentBag,

--- a/src/main/java/de/caritas/cob/agencyservice/api/admin/service/AgencyTopicMergeService.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/admin/service/AgencyTopicMergeService.java
@@ -20,6 +20,31 @@ public class AgencyTopicMergeService {
     }
   }
 
+  /**
+   * Resolves the agency topics to persist on an <b>update</b>, distinguishing a topic field that
+   * was omitted from the request from one that was explicitly cleared. This prevents an update that
+   * does not carry topic information (e.g. toggling the agency online, changing the postcode) from
+   * silently wiping all existing agency&#8211;topic links.
+   *
+   * <ul>
+   *   <li>{@code requestTopicIds == null} (field omitted) &rarr; keep the existing links.</li>
+   *   <li>{@code requestTopicIds} empty (field explicitly cleared) &rarr; remove all links.</li>
+   *   <li>{@code requestTopicIds} non-empty &rarr; set exactly to the requested topics.</li>
+   * </ul>
+   *
+   * @param targetAgency    the agency the resulting {@link AgencyTopic}s are attached to
+   * @param existingTopics  the agency's current topics, loaded from the database
+   * @param requestTopicIds the topic ids from the update request ({@code null} if not provided)
+   * @return the list of {@link AgencyTopic}s to persist
+   */
+  public List<AgencyTopic> getMergedTopicsForUpdate(Agency targetAgency,
+      List<AgencyTopic> existingTopics, List<Long> requestTopicIds) {
+    if (requestTopicIds == null) {
+      return createAgencyTopicList(targetAgency, extractTopicIds(existingTopics));
+    }
+    return getMergedTopics(targetAgency, requestTopicIds);
+  }
+
   private List<AgencyTopic> getMergedTopicsForNonEmptyTopicList(Agency agency, List<Long> requestTopicIds) {
     List<AgencyTopic> agencyTopics = agency.getAgencyTopics();
     if (agencyTopics != null) {
@@ -49,6 +74,9 @@ public class AgencyTopicMergeService {
   }
 
   private List<Long> extractTopicIds(List<AgencyTopic> agencyTopics) {
+    if (agencyTopics == null) {
+      return Lists.newArrayList();
+    }
     return agencyTopics.stream().map(AgencyTopic::getTopicId).collect(Collectors.toList());
   }
 

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/service/AgencyTopicMergeServiceTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/service/AgencyTopicMergeServiceTest.java
@@ -120,4 +120,56 @@ class AgencyTopicMergeServiceTest {
     assertThat(mergedTopics).hasSize(2).contains(existingAgencyTopic1);
     assertThat(mergedTopics).extracting(topic -> topic.getTopicId()).containsExactly(1L, 3L);
   }
+
+  @Test
+  void getMergedTopicsForUpdate_Should_PreserveExistingTopicsWhenRequestTopicIdsIsNull() {
+    // given existing links and an update that does not carry topicIds (null)
+    List<AgencyTopic> existingTopics = Lists.newArrayList(
+        AgencyTopic.builder().id(0L).topicId(1L).build(),
+        AgencyTopic.builder().id(1L).topicId(2L).build());
+
+    // when
+    List<AgencyTopic> mergedTopics =
+        agencyTopicMergeService.getMergedTopicsForUpdate(agency, existingTopics, null);
+
+    // then the existing topics are kept (not wiped)
+    assertThat(mergedTopics).extracting(AgencyTopic::getTopicId).containsExactly(1L, 2L);
+  }
+
+  @Test
+  void getMergedTopicsForUpdate_Should_ReturnEmptyWhenRequestTopicIdsIsNullAndNoExistingTopics() {
+    assertThat(agencyTopicMergeService.getMergedTopicsForUpdate(agency, null, null)).isEmpty();
+    assertThat(agencyTopicMergeService.getMergedTopicsForUpdate(agency, Lists.newArrayList(), null))
+        .isEmpty();
+  }
+
+  @Test
+  void getMergedTopicsForUpdate_Should_ClearTopicsWhenRequestTopicIdsIsExplicitlyEmpty() {
+    // given existing links and an explicit empty topic list (user cleared the field)
+    List<AgencyTopic> existingTopics = Lists.newArrayList(
+        AgencyTopic.builder().id(0L).topicId(1L).build());
+
+    // when
+    List<AgencyTopic> mergedTopics =
+        agencyTopicMergeService.getMergedTopicsForUpdate(agency, existingTopics,
+            Lists.newArrayList());
+
+    // then the links are cleared
+    assertThat(mergedTopics).isEmpty();
+  }
+
+  @Test
+  void getMergedTopicsForUpdate_Should_SetTopicsToRequestWhenRequestTopicIdsIsNonEmpty() {
+    // given existing links and a non-empty request
+    List<AgencyTopic> existingTopics = Lists.newArrayList(
+        AgencyTopic.builder().id(0L).topicId(1L).build());
+
+    // when
+    List<AgencyTopic> mergedTopics =
+        agencyTopicMergeService.getMergedTopicsForUpdate(agency, existingTopics,
+            Lists.newArrayList(2L, 3L));
+
+    // then the result reflects exactly the requested topics
+    assertThat(mergedTopics).extracting(AgencyTopic::getTopicId).containsExactly(2L, 3L);
+  }
 }


### PR DESCRIPTION
## Problem

Newly created agencies were disappearing from topic-based registration. One root cause is a destructive merge on agency **update**.

`AgencyAdminService.mergeAgencies` rebuilds the agency entity and called `AgencyTopicMergeService.getMergedTopics(agency, topicIds)`. When `topicIds` is `null` (field not present in the request) or empty, that method returns an empty list. Because `Agency.agencyTopics` is mapped with `orphanRemoval = true`, saving the agency then **deletes all existing `agency_topic` rows**.

Effect: any update that does not carry `topicIds` — toggling the agency online, editing the postcode, etc. — silently wipes the agency's topic links, so it no longer matches the registration query (`INNER JOIN agency_topic ... AND at.topic_id = :topicId`).

This was confirmed on the live cluster: several agencies have `topic_ids = NULL` despite being configured.

## Fix

New method `AgencyTopicMergeService.getMergedTopicsForUpdate(targetAgency, existingTopics, requestTopicIds)` distinguishing intent:

- `requestTopicIds == null` (field omitted) → **keep** existing links
- `requestTopicIds == []` (field explicitly cleared) → remove all links
- `requestTopicIds` non-empty → set exactly to the requested topics

`mergeAgencies` now calls this with the existing agency's topics. `getMergedTopics` (create path) is unchanged, so creating an agency with no topics still results in no links.

## Tests

`AgencyTopicMergeServiceTest`: 4 new cases (preserve-on-null, empty-when-null-and-no-existing, clear-on-empty, set-on-non-empty). Full class: **12 run, 0 failures, 0 errors** (verified locally with JDK 17).

> Note: two pre-existing, unrelated test files do not compile on `dev` (`AuthenticatedUserTest` constructor mismatch, `AgencyAdminServiceTest` missing `Settings` symbol). They are not touched by this PR and were set aside only to run the affected test locally — they should be fixed separately.

## Context

Part of the "newly created agencies invisible in registration" investigation — see OpenResilienceInitiative/ORISO-Frontend#245. Follow-ups: hide topics with no online agency in registration; backfill missing `agency_topic` links; harden the consulting_type/modality model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
