### PR TITLE
AS-L01 enable liquibase in dev profile

### DIFF
--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -41,8 +41,9 @@ spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.hibernate.ddl-auto=validate
 
 # ---------------- Liquibase ----------------
-spring.liquibase.enabled=false
-# Database already exists, skip Liquibase migration
+# Enabled in dev so new environments bootstrap automatically from changesets.
+# Prod stays false — schemas managed via ORISO-Database repo (platform-wide decision).
+spring.liquibase.enabled=true
 
 # ---------------- Local App Settings ----------------
 app.base.url=http://localhost:8084


### PR DESCRIPTION
## What
- Set `spring.liquibase.enabled=true` in `application-dev.properties`

## Why
Fixes audit finding AS-L01 — Liquibase was disabled in the dev profile, masking schema drift between code and database during development.
Closes #37

## Test
- [ ] Service starts on dev profile without Liquibase errors
- [ ] No unexpected changeset re-runs on a clean dev DB

## Reviewer checklist
- [ ] Only `application-dev.properties` changed — prod/staging untouched
- [ ] No new changesets introduced