### PR TITLE
AS-M13 parameterize deploy script paths and namespace

### DIFF
--- a/deploy-development.sh
+++ b/deploy-development.sh
@@ -1,8 +1,13 @@
 #!/bin/bash
 set -e
-cd /root/online-beratung/ORISO-Complete/caritas-workspace/ORISO-AgencyService
-export JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
+
+NAMESPACE=${NAMESPACE:-caritas}
+DEPLOYMENT=${DEPLOYMENT:-oriso-platform-agencyservice}
+export JAVA_HOME=${JAVA_HOME:-/usr/lib/jvm/java-17-openjdk-amd64}
 export PATH="$JAVA_HOME/bin:$PATH"
+
+cd "$(dirname "$(realpath "$0")")"
+
 mvn clean package -DskipTests -Dmaven.test.skip=true -Dspotless.check.skip=true -Dcheckstyle.skip=true
 cp -f target/AgencyService.jar AgencyService.jar
 TS=$(date +%s)
@@ -11,5 +16,5 @@ docker build -t ${IMAGE_TAG} .
 docker tag ${IMAGE_TAG} oriso-agencyservice:latest
 docker save ${IMAGE_TAG} | sudo k3s ctr images import - > /dev/null 2>&1
 docker save oriso-agencyservice:latest | sudo k3s ctr images import - > /dev/null 2>&1
-kubectl rollout restart deployment/oriso-platform-agencyservice -n caritas
-kubectl rollout status deployment/oriso-platform-agencyservice -n caritas --timeout=240s
+kubectl rollout restart deployment/${DEPLOYMENT} -n ${NAMESPACE}
+kubectl rollout status deployment/${DEPLOYMENT} -n ${NAMESPACE} --timeout=240s


### PR DESCRIPTION
﻿## What
- Replaced hardcoded absolute cd path with script-relative cd using dirname/realpath
- Parameterized namespace: NAMESPACE defaults to caritas
- Parameterized deployment name: DEPLOYMENT defaults to oriso-platform-agencyservice
- Made JAVA_HOME overrideable with a sensible default

## Why
Fixes audit finding AS-M13 -- hardcoded developer machine paths and locked namespace made the deploy script non-portable and tied to one specific server layout.
Closes #38

## Test
- [ ] Run deploy-development.sh from repo root on the dev server -- confirm build and rollout succeed
- [ ] Run NAMESPACE=test deploy-development.sh -- confirm it deploys to the test namespace

## Reviewer checklist
- [ ] No functional logic changed -- only path/var parameterization
- [ ] Default values match current production values (namespace=caritas)
