### PR TITLE
AS-M15 lock actuator health behind auth and remove debug web logging from prod

### DIFF
--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -1,9 +1,7 @@
 # ---------------- Logging ----------------
 server.port=8084
 logging.level.root=INFO
-logging.level.org.springframework.web=DEBUG
 logging.level.org.hibernate=ERROR
-logging.level.org.springframework.web.servlet.mvc.method.annotation=DEBUG
 
 # ---------------- Keycloak ----------------
 # Use Kubernetes DNS names, e.g., http://keycloak.caritas.svc.cluster.local:8080

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -151,7 +151,7 @@ multitenancy.enabled=${MULTITENANCY_ENABLED:false}
 
 # ---------------- Actuator ----------------
 management.endpoint.health.enabled=true
-management.endpoint.health.show-details=always
+management.endpoint.health.show-details=when-authorized
 management.endpoints.web.exposure.include=health,loggers
 management.endpoint.health.probes.enabled=true
 management.endpoint.loggers.enabled=true


### PR DESCRIPTION
## What
- Changed \`management.endpoint.health.show-details=always\` → \`when-authorized\` in \`application.properties\`
- Removed \`logging.level.org.springframework.web=DEBUG\` and \`logging.level.org.springframework.web.servlet.mvc.method.annotation=DEBUG\` from \`application-prod.properties\`

## Why
Closes #34 — unauthenticated callers could query \`/actuator/health\` and receive full internal component details (DB state, disk space). DEBUG web logging in prod also leaks request/response details to logs.

## Test
- [ ] \`GET /actuator/health\` without auth → \`{"status":"UP"}\` only, no component details
- [ ] \`GET /actuator/health\` with valid JWT → full details visible
- [ ] K8s liveness/readiness probes still pass after deploy
- [ ] Pod logs no longer contain \`o.s.web.servlet.DispatcherServlet\` DEBUG lines