### PR TITLE
fix: remove hardcoded matrix credentials from MatrixConfig (AS-M10)

### DIFF
--- a/src/main/java/de/caritas/cob/agencyservice/api/service/matrix/MatrixConfig.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/service/matrix/MatrixConfig.java
@@ -11,9 +11,9 @@ import org.springframework.stereotype.Component;
 @ConfigurationProperties(prefix = "matrix")
 public class MatrixConfig {
 
-  private String apiUrl = "http://matrix-synapse:8008";
-  private String registrationSharedSecret = "caritas-registration-secret-2025";
-  private String serverName = "caritas.local";
+  private String apiUrl;
+  private String registrationSharedSecret;
+  private String serverName;
   private String adminUsername;
   private String adminPassword;
 


### PR DESCRIPTION
#### [Issue #46](https://github.com/OpenResilienceInitiative/ORISO-AgencyService/issues/46)

## Summary

Fixes AS-M10: three sensitive values were hardcoded as Java field defaults in `MatrixConfig.java` and committed to version-controlled source.

## Changes Made

**MatrixConfig.java**
- Removed `registrationSharedSecret = "caritas-registration-secret-2025"` → `null`
- Removed `serverName = "caritas.local"` → `null`
- Removed `apiUrl = "http://matrix-synapse:8008"` → `null`

No other changes — `ConfigurationValidator` already enforces all Matrix properties as mandatory at startup via env vars. App fails to start if any are missing, so these Java defaults were dead code in practice but exposed a plausible secret in version-controlled source.

## What was NOT changed

- `ConfigurationValidator.java` — already enforces `MATRIX_REGISTRATION_SHARED_SECRET`, `MATRIX_SERVER_NAME`, `MATRIX_API_URL` as mandatory. No changes needed.
- `application*.properties` — already use env var placeholders only. No literal secret was ever in properties files.
- `adminUsername` / `adminPassword` — these never had hardcoded defaults. Unchanged.

## Follow-up required (not in this PR)

- **Git history cleanup** — `caritas-registration-secret-2025` still exists in old commits. BFG Repo-Cleaner or `git filter-repo` needed to fully purge from public history.
- **Secret rotation** — the exposed secret should be rotated in staging and prod after history cleanup.

## Testing

- `grep -rn "caritas-registration-secret-2025\|matrix-synapse:8008\|caritas.local" src/main/java/` → zero results
- Change is syntactically trivial — three field initializers removed. No logic change.
- `ConfigurationValidator` test coverage confirms startup fails without env vars set.