### PR TITLE
remove hardcoded Matrix registration secret default from MatrixConfig

### DIFF
--- a/src/main/java/de/caritas/cob/agencyservice/api/service/matrix/MatrixConfig.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/service/matrix/MatrixConfig.java
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Component;
 public class MatrixConfig {
 
   private String apiUrl = "http://matrix-synapse:8008";
-  private String registrationSharedSecret = "caritas-registration-secret-2025";
+  private String registrationSharedSecret;
   private String serverName = "caritas.local";
   private String adminUsername;
   private String adminPassword;


### PR DESCRIPTION
## What
- Removed hardcoded default `caritas-registration-secret-2025` from `MatrixConfig.java` field declaration

## Why
Fixes audit finding AS-M10 — the baked-in default allowed arbitrary Matrix user creation on any code path where the env var was accidentally missing (tests, property removal). The secret also persists in Git history. ConfigurationValidator already enforces this field as mandatory at startup, so removing the default causes a clear startup failure instead of silent use of the committed secret.
Closes #44

## Test
- [ ] Service starts when `MATRIX_REGISTRATION_SHARED_SECRET` env var is set
- [ ] Startup fails with clear ConfigurationValidator error when env var is missing
- [ ] No string literal for registrationSharedSecret in MatrixConfig.java

## Reviewer checklist
- [ ] `MatrixConfig.java` has no string literal default for `registrationSharedSecret`
- [ ] `ConfigurationValidator` still validates it as required (unchanged)