### PR TITLE
let agency search errors surface as 500 instead of silent empty 200

### DIFF
--- a/src/main/java/de/caritas/cob/agencyservice/api/admin/service/agency/AgencyAdminSearchService.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/admin/service/agency/AgencyAdminSearchService.java
@@ -85,8 +85,6 @@ public class AgencyAdminSearchService {
       queryResult = isBlank(keyword) || hasOnlySpecialCharacters(keyword)
           ? searchAgenciesWithoutKeywordFilter(entityManager, agencyAdminSearch)
           : searchAgenciesByKeyword(entityManager, agencyAdminSearch);
-    } catch (Exception ex) {
-      log.error("Could not create entity manager", ex);
     }
 
     var resultStream = queryResult.getResult().stream();


### PR DESCRIPTION
﻿## What
- Removed `catch (Exception ex)` block from `AgencyAdminSearchService.searchAgencies`

## Why
Fixes audit finding AS-M23 - the broad catch silently returned empty HTTP 200 on any DB exception. Admin panel showed no agencies even when the DB was down. Exceptions now propagate to ApiResponseEntityExceptionHandler which returns 500.
Closes #45

## Test
- [ ] Normal agency search still returns results
- [ ] DB error during search returns 500 not silent empty 200

## Reviewer checklist
- [ ] No catch (Exception wrapping the full search logic in AgencyAdminSearchService
