### PR TITLE
fix(agencyservice): allow bearer admin mutations

### DIFF
--- a/src/main/java/de/caritas/cob/agencyservice/filter/StatelessCsrfFilter.java
+++ b/src/main/java/de/caritas/cob/agencyservice/filter/StatelessCsrfFilter.java
@@ -38,7 +38,7 @@ public class StatelessCsrfFilter extends OncePerRequestFilter {
   protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
       FilterChain filterChain) throws ServletException, IOException {
 
-    if (requireCsrfProtectionMatcher.matches(request)) {
+    if (requireCsrfProtectionMatcher.matches(request) && !isBearerAuthenticatedRequest(request)) {
       final String csrfTokenValue = request.getHeader(csrfHeaderProperty);
       final Cookie[] cookies = request.getCookies();
 
@@ -58,6 +58,13 @@ public class StatelessCsrfFilter extends OncePerRequestFilter {
       }
     }
     filterChain.doFilter(request, response);
+  }
+
+  private boolean isBearerAuthenticatedRequest(HttpServletRequest request) {
+    String authorizationHeader = request.getHeader("Authorization");
+    return authorizationHeader != null
+        && authorizationHeader.regionMatches(true, 0, "Bearer ", 0, "Bearer ".length())
+        && authorizationHeader.length() > "Bearer ".length();
   }
 
   public static final class DefaultRequiresCsrfMatcher implements RequestMatcher {

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/service/AgencyAdminServiceTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/service/AgencyAdminServiceTest.java
@@ -30,12 +30,14 @@ import de.caritas.cob.agencyservice.api.model.AgencyTypeRequestDTO;
 import de.caritas.cob.agencyservice.api.model.DataProtectionContactDTO;
 import de.caritas.cob.agencyservice.api.model.DataProtectionDTO;
 import de.caritas.cob.agencyservice.api.model.DemographicsDTO;
+import de.caritas.cob.agencyservice.api.model.Settings;
 import de.caritas.cob.agencyservice.api.model.UpdateAgencyDTO;
 import de.caritas.cob.agencyservice.api.model.AgencyDTO;
 import de.caritas.cob.agencyservice.api.repository.agency.Agency;
 import de.caritas.cob.agencyservice.api.repository.agency.AgencyTenantUnawareRepository;
 import de.caritas.cob.agencyservice.api.repository.agency.DataProtectionResponsibleEntity;
 import de.caritas.cob.agencyservice.api.service.AppointmentService;
+import de.caritas.cob.agencyservice.api.service.AgencyService;
 import de.caritas.cob.agencyservice.api.util.AuthenticatedUser;
 import de.caritas.cob.agencyservice.api.util.JsonConverter;
 import java.util.List;
@@ -84,6 +86,9 @@ class AgencyAdminServiceTest {
   AppointmentService appointmentService;
 
   @Mock
+  AgencyService agencyService;
+
+  @Mock
   private Logger logger;
 
   @Mock
@@ -104,9 +109,9 @@ class AgencyAdminServiceTest {
     ReflectionTestUtils.setField(agencyAdminService, "agencyTopicEnrichmentService", agencyTopicEnrichmentService);
     ReflectionTestUtils.setField(agencyAdminService, "demographicsConverter", demographicsConverter);
 
-    when(agencySettingsService.toSettings(any())).thenReturn(new Settings());
-    when(agencySettingsService.toSettingsJson(any())).thenReturn("{}");
-    when(agencyAdminControlsService.enrichSettingsWithAgencyAdminControls(any()))
+    Mockito.lenient().when(agencySettingsService.toSettings(any())).thenReturn(new Settings());
+    Mockito.lenient().when(agencySettingsService.toSettingsJson(any())).thenReturn("{}");
+    Mockito.lenient().when(agencyAdminControlsService.enrichSettingsWithAgencyAdminControls(any()))
         .thenAnswer(invocation -> invocation.getArgument(0) != null
             ? invocation.getArgument(0)
             : new Settings());
@@ -212,7 +217,8 @@ class AgencyAdminServiceTest {
 
     // then
     verify(this.agencyRepository).save(any());
-    verify(this.mergeService).getMergedTopics(Mockito.any(Agency.class), any(List.class));
+    verify(this.mergeService).getMergedTopicsForUpdate(Mockito.any(Agency.class), any(List.class),
+        any(List.class));
     verify(this.agencyTopicEnrichmentService).enrichAgencyWithTopics(agency);
     ReflectionTestUtils.setField(agencyAdminService, "featureTopicsEnabled", false);
   }

--- a/src/test/java/de/caritas/cob/agencyservice/api/util/AuthenticatedUserTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/util/AuthenticatedUserTest.java
@@ -9,7 +9,7 @@ public class AuthenticatedUserTest {
 
   @Test(expected = NullPointerException.class)
   public void AuthenticatedUser_Should_ThrowNullPointerExceptionWhenArgumentsAreNull() {
-    new AuthenticatedUser(null, null, null, null);
+    new AuthenticatedUser(null, null, null, null, null);
   }
 
   @Test(expected = NullPointerException.class)

--- a/src/test/java/de/caritas/cob/agencyservice/filter/StatelessCsrfFilterTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/filter/StatelessCsrfFilterTest.java
@@ -70,6 +70,21 @@ class StatelessCsrfFilterTest {
   }
 
   @Test
+  void doFilter_ShouldAllowAgencyAdminMutation_WhenBearerAuthorizationIsPresentWithoutCsrf()
+      throws ServletException, IOException {
+    StatelessCsrfFilter filter = new StatelessCsrfFilter(CSRF_COOKIE, CSRF_HEADER);
+    MockHttpServletRequest request = request("POST", "/agencyadmin/agencies");
+    request.addHeader("Authorization", "Bearer access-token");
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    MockFilterChain filterChain = new MockFilterChain();
+
+    filter.doFilter(request, response, filterChain);
+
+    assertThat(response.getStatus()).isEqualTo(200);
+    assertThat(filterChain.getRequest()).isSameAs(request);
+  }
+
+  @Test
   void doFilter_ShouldAllowAgencyAdminMutation_WhenCsrfCookieAndHeaderMatch()
       throws ServletException, IOException {
     StatelessCsrfFilter filter = new StatelessCsrfFilter(CSRF_COOKIE, CSRF_HEADER);


### PR DESCRIPTION
## Problem
Creating an agency from the admin panel was rejected by AgencyService CSRF validation even though the request carried a bearer `Authorization` header. The CSRF cookie is scoped to the admin host, while admin API mutations are sent to the API host, so the backend never receives the matching cookie and the frontend falls back to login.

Closes #50

## Solution
- Skip the custom cookie/header CSRF comparison when an explicit bearer token is present.
- Add a regression test for bearer-authenticated admin mutations without a CSRF cookie.
- Refresh stale tests that blocked local Java 17 validation on current `dev`.

## Validation
- `docker run --rm -v "$PWD":/workspace -v "$HOME/.m2":/root/.m2 -w /workspace eclipse-temurin:17-jdk ./mvnw -q -Dtest=StatelessCsrfFilterTest test`
- `docker run --rm -v "$PWD":/workspace -v "$HOME/.m2":/root/.m2 -w /workspace eclipse-temurin:17-jdk ./mvnw -q -Dtest=StatelessCsrfFilterTest,AuthenticatedUserTest,AgencyAdminServiceTest test`
- `docker run --rm -v "$PWD":/workspace -v "$HOME/.m2":/root/.m2 -w /workspace eclipse-temurin:17-jdk ./mvnw -B -Dmaven.test.skip=true package`

## Note
A full `./mvnw -q test` run on current `dev` still has unrelated existing failures in Spring/JPA test setup (`JwtDecoder` test context and missing `agency` table), plus unrelated stale tests. This PR keeps the fix scoped to the reproduced admin create-agency logout.