### PR TITLE
Add local AgencyService run configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 /target/
 !.mvn/wrapper/maven-wrapper.jar
 /node_modules
+config.env
+.env
 
 # Local Spring profile — contains secrets and machine-specific config
 src/main/resources/application-local.properties

--- a/config.env.example
+++ b/config.env.example
@@ -12,8 +12,8 @@ SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK_SET_URI=https://auth.oriso-dev.sit
 
 # Optional if the remote dev API, Matrix, or Keycloak certificates are not trusted by your local JVM.
 # Uncomment after creating a local truststore that contains the required dev CA certificate.
-# LOCAL_JAVA_TRUSTSTORE=$HOME/.oriso/dev-truststore.jks
-# LOCAL_JAVA_TRUSTSTORE_PASSWORD=changeit
+LOCAL_JAVA_TRUSTSTORE=$HOME/.oriso/dev-truststore.jks
+LOCAL_JAVA_TRUSTSTORE_PASSWORD=changeit
 
 SPRING_DATASOURCE_URL=jdbc:mariadb://46.224.170.69:CHANGE_ME/agencyservice
 SPRING_DATASOURCE_USERNAME=agencyservice
@@ -23,8 +23,8 @@ SERVER_SERVLET_CONTEXT_PATH=/service
 AGENCY_DELETEWORKFLOW_CRON="0 0 2 * * *"
 
 MULTITENANCY_ENABLED=true
-# Localhost has no ingress-provided subdomain. Use the frontend tenantId header instead.
-FEATURE_MULTITENANCY_WITH_SINGLE_DOMAIN_ENABLED=false
+# Match the dev ingress behavior for localhost testing.
+FEATURE_MULTITENANCY_WITH_SINGLE_DOMAIN_ENABLED=true
 
 # Prefer local services when they are running; otherwise use the public dev API.
 TENANT_SERVICE_API_URL=http://localhost:8081/service

--- a/config.env.example
+++ b/config.env.example
@@ -1,0 +1,48 @@
+# Copy to config.env and fill the CHANGE_ME values.
+# config.env is ignored by git and must not be committed.
+
+KEYCLOAK_AUTH_SERVER_URL=https://auth.oriso-dev.site
+KEYCLOAK_REALM=online-beratung
+KEYCLOAK_CONFIG_ADMIN_USERNAME=technical
+KEYCLOAK_CONFIG_ADMIN_PASSWORD=CHANGE_ME
+KEYCLOAK_CONFIG_ADMIN_CLIENT_ID=admin-cli
+KEYCLOAK_CONFIG_APP_CLIENT_ID=app
+SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_ISSUER_URI=https://auth.oriso-dev.site/realms/online-beratung
+SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK_SET_URI=https://auth.oriso-dev.site/realms/online-beratung/protocol/openid-connect/certs
+
+# Optional if the remote dev API, Matrix, or Keycloak certificates are not trusted by your local JVM.
+# Uncomment after creating a local truststore that contains the required dev CA certificate.
+# LOCAL_JAVA_TRUSTSTORE=$HOME/.oriso/dev-truststore.jks
+# LOCAL_JAVA_TRUSTSTORE_PASSWORD=changeit
+
+SPRING_DATASOURCE_URL=jdbc:mariadb://46.224.170.69:CHANGE_ME/agencyservice
+SPRING_DATASOURCE_USERNAME=agencyservice
+SPRING_DATASOURCE_PASSWORD=CHANGE_ME
+SPRING_LIQUIBASE_ENABLED=false
+SERVER_SERVLET_CONTEXT_PATH=/service
+AGENCY_DELETEWORKFLOW_CRON="0 0 2 * * *"
+
+MULTITENANCY_ENABLED=true
+# Localhost has no ingress-provided subdomain. Use the frontend tenantId header instead.
+FEATURE_MULTITENANCY_WITH_SINGLE_DOMAIN_ENABLED=false
+
+# Prefer local services when they are running; otherwise use the public dev API.
+TENANT_SERVICE_API_URL=http://localhost:8081/service
+USER_ADMIN_SERVICE_API_URL=http://localhost:8082/service
+CONSULTING_TYPE_SERVICE_API_URL=https://api.oriso-dev.site/service
+APPOINTMENT_SERVICE_API_URL=https://api.oriso-dev.site/service
+
+MATRIX_API_URL=https://matrix.oriso-dev.site
+MATRIX_SERVER_NAME=oriso-dev.site
+MATRIX_REGISTRATION_SHARED_SECRET=CHANGE_ME
+MATRIX_ADMIN_USERNAME=caritas_admin
+MATRIX_ADMIN_PASSWORD=CHANGE_ME
+
+ROCKET_CHAT_BASE_URL=
+ROCKET_CHAT_MONGO_URL=
+ROCKET_TECHNICAL_USERNAME=
+ROCKET_TECHNICAL_PASSWORD=
+
+AGENCY_CORS_ENABLED=true
+AGENCY_CORS_ALLOWED_ORIGINS=http://localhost:9001,http://127.0.0.1:9001
+AGENCY_CORS_ALLOWED_PATHS=/**

--- a/run-local-remote-db.sh
+++ b/run-local-remote-db.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+cd "$(dirname "$0")"
+
+if [ -z "${JAVA_HOME:-}" ]; then
+  export JAVA_HOME="$(/usr/libexec/java_home -v 17 2>/dev/null || /usr/libexec/java_home)"
+fi
+export PATH="$JAVA_HOME/bin:$PATH"
+
+if [ -f config.env ]; then
+  set -a
+  # shellcheck disable=SC1091
+  . ./config.env
+  set +a
+fi
+
+# Keep Maven on the default JVM truststore. The dev truststore is passed only
+# to the Spring Boot app JVM below, otherwise Maven Central downloads can fail.
+unset JAVA_TOOL_OPTIONS
+
+JVM_ARGUMENTS=""
+if [ -n "${LOCAL_JAVA_TRUSTSTORE:-}" ]; then
+  JVM_ARGUMENTS="-Djavax.net.ssl.trustStore=${LOCAL_JAVA_TRUSTSTORE} -Djavax.net.ssl.trustStorePassword=${LOCAL_JAVA_TRUSTSTORE_PASSWORD:-changeit}"
+fi
+
+echo "Datasource: ${SPRING_DATASOURCE_URL}"
+./mvnw spring-boot:run \
+  -Dspring-boot.run.profiles=local \
+  -Dspring-boot.run.jvmArguments="${JVM_ARGUMENTS}" \
+  -Dspotless.check.skip=true

--- a/src/main/java/de/caritas/cob/agencyservice/config/CorsConfig.java
+++ b/src/main/java/de/caritas/cob/agencyservice/config/CorsConfig.java
@@ -1,0 +1,40 @@
+package de.caritas.cob.agencyservice.config;
+
+import java.util.List;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.web.filter.CorsFilter;
+
+@Configuration
+@ConditionalOnProperty(name = "agency.cors.enabled", havingValue = "true")
+public class CorsConfig {
+
+  @Value("${agency.cors.allowed.origins}")
+  private String[] allowedOrigins;
+
+  @Value("${agency.cors.allowed.paths}")
+  private List<String> allowedPaths;
+
+  @Bean
+  public FilterRegistrationBean<CorsFilter> corsFilterRegistrationBean() {
+    var configuration = new CorsConfiguration();
+    configuration.setAllowCredentials(true);
+    configuration.setAllowedOrigins(List.of(allowedOrigins));
+    configuration.setAllowedMethods(List.of("OPTIONS", "GET", "POST", "PUT", "PATCH", "DELETE"));
+    configuration.setAllowedHeaders(List.of("*"));
+    configuration.setExposedHeaders(List.of("X-Reason"));
+
+    var source = new UrlBasedCorsConfigurationSource();
+    allowedPaths.forEach(path -> source.registerCorsConfiguration(path, configuration));
+
+    var registrationBean = new FilterRegistrationBean<>(new CorsFilter(source));
+    registrationBean.setOrder(Ordered.HIGHEST_PRECEDENCE);
+    return registrationBean;
+  }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -34,6 +34,9 @@ matrix.admin-password=${MATRIX_ADMIN_PASSWORD:}
 # ---------------- CORS ----------------
 registration.cors.allowed.origins=
 registration.cors.allowed.paths=
+agency.cors.enabled=${AGENCY_CORS_ENABLED:false}
+agency.cors.allowed.origins=${AGENCY_CORS_ALLOWED_ORIGINS:}
+agency.cors.allowed.paths=${AGENCY_CORS_ALLOWED_PATHS:/**}
 
 spring.web.locale=de_DE
 spring.jackson.time-zone=Europe/Berlin
@@ -84,6 +87,10 @@ cache.appsettings.configuration.maxEntriesLocalHeap=100
 cache.appsettings.configuration.eternal=false
 cache.appsettings.configuration.timeToIdleSeconds=0
 cache.appsettings.configuration.timeToLiveSeconds=60
+cache.applicationsettings.configuration.maxEntriesLocalHeap=100
+cache.applicationsettings.configuration.eternal=false
+cache.applicationsettings.configuration.timeToIdleSeconds=0
+cache.applicationsettings.configuration.timeToLiveSeconds=60
 
 # ---------------- Keycloak ----------------
 # Use Kubernetes DNS names, e.g., http://keycloak.caritas.svc.cluster.local:8080
@@ -124,6 +131,7 @@ spring.liquibase.enabled=false
 appointments.delete-job-cron=0 0 0 * * ?
 appointments.delete-job-enabled=false
 appointments.lifespan-in-hours=24
+agency.deleteworkflow.cron=${AGENCY_DELETEWORKFLOW_CRON:0 0 3 * * ?}
 feature.topics.enabled=true
 feature.demographics.enabled=false
 feature.appointment.enabled=false


### PR DESCRIPTION
## Summary
- add an ignored local config pattern and sample `config.env.example` for running AgencyService against the dev environment
- add `run-local-remote-db.sh` to load local config and avoid applying the custom truststore to Maven dependency downloads
- add optional AgencyService CORS support for localhost frontend testing
- add missing local defaults for the application settings cache and delete-workflow cron

## Safety
- CORS is disabled by default with `AGENCY_CORS_ENABLED=false` unless explicitly enabled in local config
- real `config.env` and `.env` files are ignored and not committed
- existing cluster/prod behavior is unchanged unless the new local-only env vars are set

## Validation
- `JAVA_HOME=$(/usr/libexec/java_home -v 17) JAVA_TOOL_OPTIONS= MAVEN_OPTS= ./mvnw -q -DskipTests -Dmaven.compiler.enablePreview=false compile`
- started AgencyService locally on `http://localhost:8084/service`
- verified `/service/actuator/health` returns `UP`
- verified CORS preflight from `http://localhost:9001` allows `tenantId`, `content-type`, and `authorization` headers
