### PR TITLE
test: add unit tests for AgencyAdminControlsService

### DIFF
--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/service/agencyadmincontrol/AgencyAdminControlsServiceTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/service/agencyadmincontrol/AgencyAdminControlsServiceTest.java
@@ -1,0 +1,264 @@
+package de.caritas.cob.agencyservice.api.admin.service.agencyadmincontrol;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.RuntimeJsonMappingException;
+import de.caritas.cob.agencyservice.api.model.AgencyAdminControls;
+import de.caritas.cob.agencyservice.api.model.Settings;
+import de.caritas.cob.agencyservice.api.repository.agencyadmincontrol.AgencyAdminControlEntity;
+import de.caritas.cob.agencyservice.api.repository.agencyadmincontrol.AgencyAdminControlRepository;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AgencyAdminControlsServiceTest {
+
+  @InjectMocks
+  private AgencyAdminControlsService agencyAdminControlsService;
+
+  @Mock
+  private AgencyAdminControlRepository agencyAdminControlRepository;
+
+  @Mock
+  private AgencyAdminControlsConverter agencyAdminControlsConverter;
+
+  private AgencyAdminControls defaultControls;
+  private AgencyAdminControlsSettings defaultSettings;
+
+  @BeforeEach
+  void setUp() {
+    defaultSettings = AgencyAdminControlsSettings.builder().permissionsPageEnabled(true).build();
+    defaultControls = new AgencyAdminControls().permissionsPageEnabled(true);
+  }
+
+  @Test
+  void getControls_Should_ReturnParsedControls_WhenDbHasValidJson() {
+    when(agencyAdminControlRepository.findTopByOrderByIdAsc())
+        .thenReturn(Optional.of(entityWithControls("{\"permissionsPageEnabled\":false}", 1L)));
+    AgencyAdminControls expected =
+        new AgencyAdminControls().permissionsPageEnabled(false);
+    when(agencyAdminControlsConverter.toAgencyAdminControls(
+            argThat(settings -> Boolean.FALSE.equals(settings.getPermissionsPageEnabled()))))
+        .thenReturn(expected);
+
+    AgencyAdminControls result = agencyAdminControlsService.getControls();
+
+    assertThat(result).isSameAs(expected);
+    verify(agencyAdminControlsConverter, never()).createDefaultControlsSettings();
+  }
+
+  @Test
+  void getControls_Should_ReturnDefaultControls_WhenDbHasNoRecord() {
+    when(agencyAdminControlRepository.findTopByOrderByIdAsc()).thenReturn(Optional.empty());
+    stubConverterDefaults();
+
+    AgencyAdminControls result = agencyAdminControlsService.getControls();
+
+    assertThat(result).isSameAs(defaultControls);
+    verify(agencyAdminControlsConverter).createDefaultControlsSettings();
+  }
+
+  @Test
+  void getControls_Should_ReturnDefaultControls_WhenDbHasEmptyStringJson() {
+    when(agencyAdminControlRepository.findTopByOrderByIdAsc())
+        .thenReturn(Optional.of(entityWithControls("", 1L)));
+    stubConverterDefaults();
+
+    AgencyAdminControls result = agencyAdminControlsService.getControls();
+
+    assertThat(result).isSameAs(defaultControls);
+    verify(agencyAdminControlsConverter).createDefaultControlsSettings();
+  }
+
+  @Test
+  void getControls_Should_ReturnDefaultControls_WhenDbHasSpaceJson() {
+    when(agencyAdminControlRepository.findTopByOrderByIdAsc())
+        .thenReturn(Optional.of(entityWithControls(" ", 1L)));
+    stubConverterDefaults();
+
+    AgencyAdminControls result = agencyAdminControlsService.getControls();
+
+    assertThat(result).isSameAs(defaultControls);
+    verify(agencyAdminControlsConverter).createDefaultControlsSettings();
+  }
+
+  @Test
+  void getControls_Should_ReturnDefaultControls_WhenDbHasTabJson() {
+    when(agencyAdminControlRepository.findTopByOrderByIdAsc())
+        .thenReturn(Optional.of(entityWithControls("\t", 1L)));
+    stubConverterDefaults();
+
+    AgencyAdminControls result = agencyAdminControlsService.getControls();
+
+    assertThat(result).isSameAs(defaultControls);
+    verify(agencyAdminControlsConverter).createDefaultControlsSettings();
+  }
+
+  @Test
+  void getControls_Should_ReturnDefaultControls_WhenDbHasEmptyObjectJson() {
+    when(agencyAdminControlRepository.findTopByOrderByIdAsc())
+        .thenReturn(Optional.of(entityWithControls("{}", 1L)));
+    stubConverterDefaults();
+
+    AgencyAdminControls result = agencyAdminControlsService.getControls();
+
+    assertThat(result).isSameAs(defaultControls);
+    verify(agencyAdminControlsConverter).createDefaultControlsSettings();
+  }
+
+  @Test
+  void getControls_Should_ReturnDefaultControls_WhenDbHasWhitespaceWrappedEmptyObjectJson() {
+    when(agencyAdminControlRepository.findTopByOrderByIdAsc())
+        .thenReturn(Optional.of(entityWithControls(" {} ", 1L)));
+    stubConverterDefaults();
+
+    AgencyAdminControls result = agencyAdminControlsService.getControls();
+
+    assertThat(result).isSameAs(defaultControls);
+    verify(agencyAdminControlsConverter).createDefaultControlsSettings();
+  }
+
+  @Test
+  void getControls_Should_ReturnDefaultControls_WhenDbHasNullLiteralJson() {
+    when(agencyAdminControlRepository.findTopByOrderByIdAsc())
+        .thenReturn(Optional.of(entityWithControls("null", 1L)));
+    stubConverterDefaults();
+
+    AgencyAdminControls result = agencyAdminControlsService.getControls();
+
+    assertThat(result).isSameAs(defaultControls);
+    verify(agencyAdminControlsConverter).createDefaultControlsSettings();
+  }
+
+  @Test
+  void getControls_Should_ThrowRuntimeJsonMappingException_WhenDbHasInvalidJson() {
+    when(agencyAdminControlRepository.findTopByOrderByIdAsc())
+        .thenReturn(Optional.of(entityWithControls("{not-valid-json", 1L)));
+
+    assertThrows(RuntimeJsonMappingException.class, () -> agencyAdminControlsService.getControls());
+  }
+
+  @Test
+  void updateControls_Should_CreateNewEntity_WhenDbHasNoRecord() {
+    AgencyAdminControls input = new AgencyAdminControls().permissionsPageEnabled(false);
+    AgencyAdminControlsSettings settings =
+        AgencyAdminControlsSettings.builder().permissionsPageEnabled(false).build();
+    stubUpdateRoundTrip(input, settings);
+    when(agencyAdminControlRepository.findTopByOrderByIdAsc()).thenReturn(Optional.empty());
+    when(agencyAdminControlRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+    AgencyAdminControls result = agencyAdminControlsService.updateControls(input);
+
+    assertThat(result).isSameAs(input);
+    ArgumentCaptor<AgencyAdminControlEntity> captor =
+        ArgumentCaptor.forClass(AgencyAdminControlEntity.class);
+    verify(agencyAdminControlRepository).save(captor.capture());
+    verify(agencyAdminControlRepository, times(1)).findTopByOrderByIdAsc();
+    assertThat(captor.getValue().getId()).isNull();
+    assertThat(captor.getValue().getControls()).contains("\"permissionsPageEnabled\":false");
+  }
+
+  @Test
+  void updateControls_Should_UpdateExistingEntity_WhenDbHasRecord() {
+    AgencyAdminControls input = new AgencyAdminControls().permissionsPageEnabled(false);
+    AgencyAdminControlsSettings settings =
+        AgencyAdminControlsSettings.builder().permissionsPageEnabled(false).build();
+    stubUpdateRoundTrip(input, settings);
+    AgencyAdminControlEntity existing =
+        entityWithControls("{\"permissionsPageEnabled\":true}", 1L);
+    when(agencyAdminControlRepository.findTopByOrderByIdAsc())
+        .thenReturn(Optional.of(existing));
+    when(agencyAdminControlRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+    AgencyAdminControls result = agencyAdminControlsService.updateControls(input);
+
+    assertThat(result).isSameAs(input);
+    ArgumentCaptor<AgencyAdminControlEntity> captor =
+        ArgumentCaptor.forClass(AgencyAdminControlEntity.class);
+    verify(agencyAdminControlRepository).save(captor.capture());
+    verify(agencyAdminControlRepository, times(1)).findTopByOrderByIdAsc();
+    assertThat(captor.getValue().getId()).isEqualTo(1L);
+    assertThat(captor.getValue().getControls()).contains("\"permissionsPageEnabled\":false");
+  }
+
+  @Test
+  void updateControls_Should_SetUpdateDateOnSave() {
+    AgencyAdminControls input = new AgencyAdminControls().permissionsPageEnabled(false);
+    AgencyAdminControlsSettings settings =
+        AgencyAdminControlsSettings.builder().permissionsPageEnabled(false).build();
+    stubUpdateRoundTrip(input, settings);
+    when(agencyAdminControlRepository.findTopByOrderByIdAsc()).thenReturn(Optional.empty());
+    when(agencyAdminControlRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+    LocalDateTime before = LocalDateTime.now(ZoneOffset.UTC);
+    agencyAdminControlsService.updateControls(input);
+    LocalDateTime after = LocalDateTime.now(ZoneOffset.UTC);
+
+    ArgumentCaptor<AgencyAdminControlEntity> captor =
+        ArgumentCaptor.forClass(AgencyAdminControlEntity.class);
+    verify(agencyAdminControlRepository).save(captor.capture());
+    assertThat(captor.getValue().getUpdateDate())
+        .isAfterOrEqualTo(before)
+        .isBeforeOrEqualTo(after);
+  }
+
+  @Test
+  void enrichSettingsWithAgencyAdminControls_Should_CreateSettingsAndEnrich_WhenSettingsIsNull() {
+    when(agencyAdminControlRepository.findTopByOrderByIdAsc()).thenReturn(Optional.empty());
+    stubConverterDefaults();
+
+    Settings result = agencyAdminControlsService.enrichSettingsWithAgencyAdminControls(null);
+
+    assertThat(result).isNotNull();
+    assertThat(result.getAgencyAdminControls()).isSameAs(defaultControls);
+  }
+
+  @Test
+  void enrichSettingsWithAgencyAdminControls_Should_EnrichExistingSettings_WhenSettingsIsNotNull() {
+    Settings settings = new Settings().featureStatisticsEnabled(true);
+    when(agencyAdminControlRepository.findTopByOrderByIdAsc()).thenReturn(Optional.empty());
+    stubConverterDefaults();
+
+    Settings result = agencyAdminControlsService.enrichSettingsWithAgencyAdminControls(settings);
+
+    assertSame(settings, result);
+    assertThat(result.getFeatureStatisticsEnabled()).isTrue();
+    assertThat(result.getAgencyAdminControls()).isSameAs(defaultControls);
+  }
+
+  private void stubConverterDefaults() {
+    when(agencyAdminControlsConverter.createDefaultControlsSettings()).thenReturn(defaultSettings);
+    when(agencyAdminControlsConverter.toAgencyAdminControls(defaultSettings))
+        .thenReturn(defaultControls);
+  }
+
+  private void stubUpdateRoundTrip(
+      AgencyAdminControls input, AgencyAdminControlsSettings settings) {
+    when(agencyAdminControlsConverter.toAgencyAdminControlsSettings(input)).thenReturn(settings);
+    when(agencyAdminControlsConverter.toAgencyAdminControls(settings)).thenReturn(input);
+  }
+
+  private AgencyAdminControlEntity entityWithControls(String controlsJson, Long id) {
+    return AgencyAdminControlEntity.builder()
+        .id(id)
+        .controls(controlsJson)
+        .updateDate(LocalDateTime.now(ZoneOffset.UTC))
+        .build();
+  }
+}


### PR DESCRIPTION
#### [Issue #56](https://github.com/OpenResilienceInitiative/ORISO-AgencyService/issues/56)

## Summary

Adds 14 unit tests for `AgencyAdminControlsService` — previously had zero dedicated test coverage despite managing platform-wide agency admin controls used by `AgencyAdminService`, `AgencyService`, and exposed via `AgencyAdminController`.

## What was tested

**`getControls()`:**
- Valid JSON in DB → parsed controls returned, default path never called
- No DB record → default controls returned
- Blank JSON variants (`""`, `" "`, `"\t"`) → default controls returned (3 separate tests)
- `"{}"` → default controls returned
- `" {} "` (whitespace-wrapped empty object) → default controls returned
- `"null"` literal → Jackson deserializes to Java `null` → default controls returned
- Invalid JSON → `RuntimeJsonMappingException` thrown

**`updateControls()`:**
- No DB record → new entity created and saved (`id == null` verified via `ArgumentCaptor`)
- Existing DB record → existing entity updated and saved (`id == 1L` verified via `ArgumentCaptor`)
- `updateDate` set to current UTC time on save (time-bracket assertion: `isAfterOrEqualTo(before).isBeforeOrEqualTo(after)`)

**`enrichSettingsWithAgencyAdminControls()`:**
- `null` input → new `Settings` created and enriched with controls
- Existing `Settings` → same instance returned (`assertSame`), existing fields preserved, controls set

**Edge cases:**
- `" {} "` with leading/trailing whitespace → correctly falls into default path via `trim().equals("{}")` check
- `"null"` JSON literal → documents Jackson behavior (returns Java `null` for object types) hitting the `settings != null` guard at line 67
- Blank JSON variants tested separately (`""`, `" "`, `"\t"`) to cover all `StringUtils.isBlank()` inputs explicitly

## Approach

Pure unit tests with mocked `AgencyAdminControlRepository` and `AgencyAdminControlsConverter`. Real `ObjectMapper` used for JSON parse/serialize paths — inline `new ObjectMapper()` instantiation in production code is not mockable without refactoring. `ArgumentCaptor` used to verify entity state on save.

## Known gap

`serializeControlsSettings()` `JsonProcessingException` path is not covered — requires injecting `ObjectMapper` as a dependency to mock it. Out of scope for this PR; normal POJO serialization will not throw in practice.

## Test results
Tests run: 14, Failures: 0, Errors: 0, Skipped: 0 — BUILD SUCCESS

## Files changed

| File | Action |
|---|---|
| `src/test/java/de/caritas/cob/agencyservice/api/admin/service/agencyadmincontrol/AgencyAdminControlsServiceTest.java` | Created |

No production code changes.

## Checklist
- [x] All 3 public methods covered
- [x] All 5 private methods covered transitively
- [x] All `parseControlsSettings` branches covered
- [x] Both `saveControlsSettings` branches covered (new vs existing entity)
- [x] Edge cases documented and covered
- [x] No production code changes
- [x] No Spring context (pure unit test)
- [x] All 14 tests pass locally