### PR TITLE
test: add unit test for AgencySettingsService

### DIFF
--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/service/agency/AgencySettingsServiceTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/service/agency/AgencySettingsServiceTest.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.RuntimeJsonMappingException;
 import de.caritas.cob.agencyservice.api.model.AgencyAdminControls;
 import de.caritas.cob.agencyservice.api.model.Settings;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -123,13 +124,16 @@ class AgencySettingsServiceTest {
     JsonNode parsed = parseJson(agencySettingsService.toSettingsJson(settings));
 
     assertThat(parsed.get("featureStatisticsEnabled").booleanValue()).isTrue();
+    assertThat(parsed.get("activeLanguages")).isNotNull();
+    assertThat(parsed.get("activeLanguages").get(0).asText()).isEqualTo("de");
+    assertThat(parsed.get("activeLanguages").get(1).asText()).isEqualTo("en");
     assertThat(agencyAdminControlsAbsent(parsed)).isTrue();
-    assertThat(activeLanguagesAbsent(parsed)).isTrue();
   }
 
   private Settings buildSettingsWithControls() {
     return new Settings()
         .featureStatisticsEnabled(true)
+        .activeLanguages(List.of("de", "en"))
         .agencyAdminControls(new AgencyAdminControls().permissionsPageEnabled(true));
   }
 
@@ -140,11 +144,6 @@ class AgencySettingsServiceTest {
   private boolean agencyAdminControlsAbsent(JsonNode parsed) {
     JsonNode controls = parsed.path("agencyAdminControls");
     return controls.isMissingNode() || controls.isNull();
-  }
-
-  private boolean activeLanguagesAbsent(JsonNode parsed) {
-    JsonNode activeLanguages = parsed.path("activeLanguages");
-    return activeLanguages.isMissingNode() || activeLanguages.isNull();
   }
 
   private JsonNode parseJson(String json) {

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/service/agency/AgencySettingsServiceTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/service/agency/AgencySettingsServiceTest.java
@@ -1,0 +1,165 @@
+package de.caritas.cob.agencyservice.api.admin.service.agency;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.RuntimeJsonMappingException;
+import de.caritas.cob.agencyservice.api.model.AgencyAdminControls;
+import de.caritas.cob.agencyservice.api.model.Settings;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class AgencySettingsServiceTest {
+
+  private AgencySettingsService agencySettingsService;
+
+  private final ObjectMapper testObjectMapper = new ObjectMapper();
+
+  @BeforeEach
+  void setUp() {
+    agencySettingsService = new AgencySettingsService();
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"", " ", "\t"})
+  void toSettings_Should_ReturnEmptySettings_When_InputIsBlank(String settingsJson) {
+    Settings result = agencySettingsService.toSettings(settingsJson);
+
+    assertThat(result).isNotNull();
+    assertThat(result.getFeatureStatisticsEnabled()).isNull();
+    assertThat(result.getFeatureTopicsEnabled()).isNull();
+    assertThat(result.getAgencyAdminControls()).isNull();
+  }
+
+  @Test
+  void toSettings_Should_ReturnEmptySettings_When_InputIsNull() {
+    Settings result = agencySettingsService.toSettings(null);
+
+    assertThat(result).isNotNull();
+    assertThat(result.getFeatureStatisticsEnabled()).isNull();
+    assertThat(result.getFeatureTopicsEnabled()).isNull();
+    assertThat(result.getAgencyAdminControls()).isNull();
+  }
+
+  @Test
+  void toSettings_Should_ReturnParsedSettings_When_InputIsValidJson() {
+    String settingsJson =
+        "{\"featureStatisticsEnabled\":true,\"featureTopicsEnabled\":false,"
+            + "\"activeLanguages\":[\"de\",\"en\"]}";
+
+    Settings result = agencySettingsService.toSettings(settingsJson);
+
+    assertThat(result.getFeatureStatisticsEnabled()).isTrue();
+    assertThat(result.getFeatureTopicsEnabled()).isFalse();
+    assertThat(result.getActiveLanguages()).containsExactly("de", "en");
+  }
+
+  @Test
+  void toSettings_Should_ReturnEmptySettings_When_InputIsJsonNullLiteral() {
+    Settings result = agencySettingsService.toSettings("null");
+
+    assertThat(result).isNotNull();
+    assertThat(result.getFeatureStatisticsEnabled()).isNull();
+    assertThat(result.getFeatureTopicsEnabled()).isNull();
+    assertThat(result.getAgencyAdminControls()).isNull();
+  }
+
+  @Test
+  void toSettings_Should_ThrowRuntimeJsonMappingException_When_InputIsInvalidJson() {
+    assertThrows(
+        RuntimeJsonMappingException.class,
+        () -> agencySettingsService.toSettings("{not-valid-json"));
+  }
+
+  @Test
+  void toSettingsJson_Should_ReturnNull_When_SettingsIsNull() {
+    assertThat(agencySettingsService.toSettingsJson(null)).isNull();
+  }
+
+  @Test
+  void toSettingsJson_Should_ReturnJsonWithFeatureFlags_When_SettingsIsValid() throws Exception {
+    Settings settings = buildSettingsWithoutControls();
+
+    String json = agencySettingsService.toSettingsJson(settings);
+    JsonNode parsed = parseJson(json);
+
+    assertThat(json).isNotBlank();
+    assertThat(parsed.get("featureStatisticsEnabled").booleanValue()).isTrue();
+    assertThat(parsed.get("featureTopicsEnabled").booleanValue()).isFalse();
+    assertThat(agencyAdminControlsAbsent(parsed)).isTrue();
+  }
+
+  @Test
+  void toSettingsJson_Should_ThrowRuntimeJsonMappingException_When_SettingsCannotBeSerialized() {
+    ObjectMapper failingMapper = new FailingObjectMapper();
+    ReflectionTestUtils.setField(agencySettingsService, "objectMapper", failingMapper);
+
+    assertThrows(
+        RuntimeJsonMappingException.class,
+        () -> agencySettingsService.toSettingsJson(buildSettingsWithoutControls()));
+  }
+
+  @Test
+  void toSettingsJson_Should_OmitAgencyAdminControls_When_SettingsHasAgencyAdminControls() {
+    Settings settings = buildSettingsWithControls();
+
+    JsonNode parsed = parseJson(agencySettingsService.toSettingsJson(settings));
+
+    assertThat(parsed.get("featureStatisticsEnabled").booleanValue()).isTrue();
+    assertThat(agencyAdminControlsAbsent(parsed)).isTrue();
+  }
+
+  @Test
+  void toSettingsJson_Should_PreserveAllOtherFields_When_StrippingAgencyAdminControls() {
+    Settings settings = buildSettingsWithControls();
+
+    JsonNode parsed = parseJson(agencySettingsService.toSettingsJson(settings));
+
+    assertThat(parsed.get("featureStatisticsEnabled").booleanValue()).isTrue();
+    assertThat(agencyAdminControlsAbsent(parsed)).isTrue();
+    assertThat(activeLanguagesAbsent(parsed)).isTrue();
+  }
+
+  private Settings buildSettingsWithControls() {
+    return new Settings()
+        .featureStatisticsEnabled(true)
+        .agencyAdminControls(new AgencyAdminControls().permissionsPageEnabled(true));
+  }
+
+  private Settings buildSettingsWithoutControls() {
+    return new Settings().featureStatisticsEnabled(true).featureTopicsEnabled(false);
+  }
+
+  private boolean agencyAdminControlsAbsent(JsonNode parsed) {
+    JsonNode controls = parsed.path("agencyAdminControls");
+    return controls.isMissingNode() || controls.isNull();
+  }
+
+  private boolean activeLanguagesAbsent(JsonNode parsed) {
+    JsonNode activeLanguages = parsed.path("activeLanguages");
+    return activeLanguages.isMissingNode() || activeLanguages.isNull();
+  }
+
+  private JsonNode parseJson(String json) {
+    try {
+      return testObjectMapper.readTree(json);
+    } catch (JsonProcessingException exception) {
+      throw new RuntimeException(exception);
+    }
+  }
+
+  private static final class FailingObjectMapper extends ObjectMapper {
+
+    @Override
+    public String writeValueAsString(Object value) throws JsonProcessingException {
+      throw new JsonMappingException(null, "serialization failed");
+    }
+  }
+}

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/service/agencyadmincontrol/AgencyAdminControlsServiceTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/service/agencyadmincontrol/AgencyAdminControlsServiceTest.java
@@ -1,0 +1,264 @@
+package de.caritas.cob.agencyservice.api.admin.service.agencyadmincontrol;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.RuntimeJsonMappingException;
+import de.caritas.cob.agencyservice.api.model.AgencyAdminControls;
+import de.caritas.cob.agencyservice.api.model.Settings;
+import de.caritas.cob.agencyservice.api.repository.agencyadmincontrol.AgencyAdminControlEntity;
+import de.caritas.cob.agencyservice.api.repository.agencyadmincontrol.AgencyAdminControlRepository;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AgencyAdminControlsServiceTest {
+
+  @InjectMocks
+  private AgencyAdminControlsService agencyAdminControlsService;
+
+  @Mock
+  private AgencyAdminControlRepository agencyAdminControlRepository;
+
+  @Mock
+  private AgencyAdminControlsConverter agencyAdminControlsConverter;
+
+  private AgencyAdminControls defaultControls;
+  private AgencyAdminControlsSettings defaultSettings;
+
+  @BeforeEach
+  void setUp() {
+    defaultSettings = AgencyAdminControlsSettings.builder().permissionsPageEnabled(true).build();
+    defaultControls = new AgencyAdminControls().permissionsPageEnabled(true);
+  }
+
+  @Test
+  void getControls_Should_ReturnParsedControls_WhenDbHasValidJson() {
+    when(agencyAdminControlRepository.findTopByOrderByIdAsc())
+        .thenReturn(Optional.of(entityWithControls("{\"permissionsPageEnabled\":false}", 1L)));
+    AgencyAdminControls expected =
+        new AgencyAdminControls().permissionsPageEnabled(false);
+    when(agencyAdminControlsConverter.toAgencyAdminControls(
+            argThat(settings -> Boolean.FALSE.equals(settings.getPermissionsPageEnabled()))))
+        .thenReturn(expected);
+
+    AgencyAdminControls result = agencyAdminControlsService.getControls();
+
+    assertThat(result).isSameAs(expected);
+    verify(agencyAdminControlsConverter, never()).createDefaultControlsSettings();
+  }
+
+  @Test
+  void getControls_Should_ReturnDefaultControls_WhenDbHasNoRecord() {
+    when(agencyAdminControlRepository.findTopByOrderByIdAsc()).thenReturn(Optional.empty());
+    stubConverterDefaults();
+
+    AgencyAdminControls result = agencyAdminControlsService.getControls();
+
+    assertThat(result).isSameAs(defaultControls);
+    verify(agencyAdminControlsConverter).createDefaultControlsSettings();
+  }
+
+  @Test
+  void getControls_Should_ReturnDefaultControls_WhenDbHasEmptyStringJson() {
+    when(agencyAdminControlRepository.findTopByOrderByIdAsc())
+        .thenReturn(Optional.of(entityWithControls("", 1L)));
+    stubConverterDefaults();
+
+    AgencyAdminControls result = agencyAdminControlsService.getControls();
+
+    assertThat(result).isSameAs(defaultControls);
+    verify(agencyAdminControlsConverter).createDefaultControlsSettings();
+  }
+
+  @Test
+  void getControls_Should_ReturnDefaultControls_WhenDbHasSpaceJson() {
+    when(agencyAdminControlRepository.findTopByOrderByIdAsc())
+        .thenReturn(Optional.of(entityWithControls(" ", 1L)));
+    stubConverterDefaults();
+
+    AgencyAdminControls result = agencyAdminControlsService.getControls();
+
+    assertThat(result).isSameAs(defaultControls);
+    verify(agencyAdminControlsConverter).createDefaultControlsSettings();
+  }
+
+  @Test
+  void getControls_Should_ReturnDefaultControls_WhenDbHasTabJson() {
+    when(agencyAdminControlRepository.findTopByOrderByIdAsc())
+        .thenReturn(Optional.of(entityWithControls("\t", 1L)));
+    stubConverterDefaults();
+
+    AgencyAdminControls result = agencyAdminControlsService.getControls();
+
+    assertThat(result).isSameAs(defaultControls);
+    verify(agencyAdminControlsConverter).createDefaultControlsSettings();
+  }
+
+  @Test
+  void getControls_Should_ReturnDefaultControls_WhenDbHasEmptyObjectJson() {
+    when(agencyAdminControlRepository.findTopByOrderByIdAsc())
+        .thenReturn(Optional.of(entityWithControls("{}", 1L)));
+    stubConverterDefaults();
+
+    AgencyAdminControls result = agencyAdminControlsService.getControls();
+
+    assertThat(result).isSameAs(defaultControls);
+    verify(agencyAdminControlsConverter).createDefaultControlsSettings();
+  }
+
+  @Test
+  void getControls_Should_ReturnDefaultControls_WhenDbHasWhitespaceWrappedEmptyObjectJson() {
+    when(agencyAdminControlRepository.findTopByOrderByIdAsc())
+        .thenReturn(Optional.of(entityWithControls(" {} ", 1L)));
+    stubConverterDefaults();
+
+    AgencyAdminControls result = agencyAdminControlsService.getControls();
+
+    assertThat(result).isSameAs(defaultControls);
+    verify(agencyAdminControlsConverter).createDefaultControlsSettings();
+  }
+
+  @Test
+  void getControls_Should_ReturnDefaultControls_WhenDbHasNullLiteralJson() {
+    when(agencyAdminControlRepository.findTopByOrderByIdAsc())
+        .thenReturn(Optional.of(entityWithControls("null", 1L)));
+    stubConverterDefaults();
+
+    AgencyAdminControls result = agencyAdminControlsService.getControls();
+
+    assertThat(result).isSameAs(defaultControls);
+    verify(agencyAdminControlsConverter).createDefaultControlsSettings();
+  }
+
+  @Test
+  void getControls_Should_ThrowRuntimeJsonMappingException_WhenDbHasInvalidJson() {
+    when(agencyAdminControlRepository.findTopByOrderByIdAsc())
+        .thenReturn(Optional.of(entityWithControls("{not-valid-json", 1L)));
+
+    assertThrows(RuntimeJsonMappingException.class, () -> agencyAdminControlsService.getControls());
+  }
+
+  @Test
+  void updateControls_Should_CreateNewEntity_WhenDbHasNoRecord() {
+    AgencyAdminControls input = new AgencyAdminControls().permissionsPageEnabled(false);
+    AgencyAdminControlsSettings settings =
+        AgencyAdminControlsSettings.builder().permissionsPageEnabled(false).build();
+    stubUpdateRoundTrip(input, settings);
+    when(agencyAdminControlRepository.findTopByOrderByIdAsc()).thenReturn(Optional.empty());
+    when(agencyAdminControlRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+    AgencyAdminControls result = agencyAdminControlsService.updateControls(input);
+
+    assertThat(result).isSameAs(input);
+    ArgumentCaptor<AgencyAdminControlEntity> captor =
+        ArgumentCaptor.forClass(AgencyAdminControlEntity.class);
+    verify(agencyAdminControlRepository).save(captor.capture());
+    verify(agencyAdminControlRepository, times(1)).findTopByOrderByIdAsc();
+    assertThat(captor.getValue().getId()).isNull();
+    assertThat(captor.getValue().getControls()).contains("\"permissionsPageEnabled\":false");
+  }
+
+  @Test
+  void updateControls_Should_UpdateExistingEntity_WhenDbHasRecord() {
+    AgencyAdminControls input = new AgencyAdminControls().permissionsPageEnabled(false);
+    AgencyAdminControlsSettings settings =
+        AgencyAdminControlsSettings.builder().permissionsPageEnabled(false).build();
+    stubUpdateRoundTrip(input, settings);
+    AgencyAdminControlEntity existing =
+        entityWithControls("{\"permissionsPageEnabled\":true}", 1L);
+    when(agencyAdminControlRepository.findTopByOrderByIdAsc())
+        .thenReturn(Optional.of(existing));
+    when(agencyAdminControlRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+    AgencyAdminControls result = agencyAdminControlsService.updateControls(input);
+
+    assertThat(result).isSameAs(input);
+    ArgumentCaptor<AgencyAdminControlEntity> captor =
+        ArgumentCaptor.forClass(AgencyAdminControlEntity.class);
+    verify(agencyAdminControlRepository).save(captor.capture());
+    verify(agencyAdminControlRepository, times(1)).findTopByOrderByIdAsc();
+    assertThat(captor.getValue().getId()).isEqualTo(1L);
+    assertThat(captor.getValue().getControls()).contains("\"permissionsPageEnabled\":false");
+  }
+
+  @Test
+  void updateControls_Should_SetUpdateDateOnSave() {
+    AgencyAdminControls input = new AgencyAdminControls().permissionsPageEnabled(false);
+    AgencyAdminControlsSettings settings =
+        AgencyAdminControlsSettings.builder().permissionsPageEnabled(false).build();
+    stubUpdateRoundTrip(input, settings);
+    when(agencyAdminControlRepository.findTopByOrderByIdAsc()).thenReturn(Optional.empty());
+    when(agencyAdminControlRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+    LocalDateTime before = LocalDateTime.now(ZoneOffset.UTC);
+    agencyAdminControlsService.updateControls(input);
+    LocalDateTime after = LocalDateTime.now(ZoneOffset.UTC);
+
+    ArgumentCaptor<AgencyAdminControlEntity> captor =
+        ArgumentCaptor.forClass(AgencyAdminControlEntity.class);
+    verify(agencyAdminControlRepository).save(captor.capture());
+    assertThat(captor.getValue().getUpdateDate())
+        .isAfterOrEqualTo(before)
+        .isBeforeOrEqualTo(after);
+  }
+
+  @Test
+  void enrichSettingsWithAgencyAdminControls_Should_CreateSettingsAndEnrich_WhenSettingsIsNull() {
+    when(agencyAdminControlRepository.findTopByOrderByIdAsc()).thenReturn(Optional.empty());
+    stubConverterDefaults();
+
+    Settings result = agencyAdminControlsService.enrichSettingsWithAgencyAdminControls(null);
+
+    assertThat(result).isNotNull();
+    assertThat(result.getAgencyAdminControls()).isSameAs(defaultControls);
+  }
+
+  @Test
+  void enrichSettingsWithAgencyAdminControls_Should_EnrichExistingSettings_WhenSettingsIsNotNull() {
+    Settings settings = new Settings().featureStatisticsEnabled(true);
+    when(agencyAdminControlRepository.findTopByOrderByIdAsc()).thenReturn(Optional.empty());
+    stubConverterDefaults();
+
+    Settings result = agencyAdminControlsService.enrichSettingsWithAgencyAdminControls(settings);
+
+    assertSame(settings, result);
+    assertThat(result.getFeatureStatisticsEnabled()).isTrue();
+    assertThat(result.getAgencyAdminControls()).isSameAs(defaultControls);
+  }
+
+  private void stubConverterDefaults() {
+    when(agencyAdminControlsConverter.createDefaultControlsSettings()).thenReturn(defaultSettings);
+    when(agencyAdminControlsConverter.toAgencyAdminControls(defaultSettings))
+        .thenReturn(defaultControls);
+  }
+
+  private void stubUpdateRoundTrip(
+      AgencyAdminControls input, AgencyAdminControlsSettings settings) {
+    when(agencyAdminControlsConverter.toAgencyAdminControlsSettings(input)).thenReturn(settings);
+    when(agencyAdminControlsConverter.toAgencyAdminControls(settings)).thenReturn(input);
+  }
+
+  private AgencyAdminControlEntity entityWithControls(String controlsJson, Long id) {
+    return AgencyAdminControlEntity.builder()
+        .id(id)
+        .controls(controlsJson)
+        .updateDate(LocalDateTime.now(ZoneOffset.UTC))
+        .build();
+  }
+}


### PR DESCRIPTION
#### [Issue #58](https://github.com/OpenResilienceInitiative/ORISO-AgencyService/issues/58)

## Summary

Adds 10 unit tests (12 executions) for `AgencySettingsService` — previously had zero dedicated test coverage despite being used by both `AgencyAdminService` and `AgencyService` for all agency settings serialization/deserialization.


## What was tested

**`toSettings(String settingsJson)`:**
- Blank input (`""`, `" "`, `"\t"`) → `new Settings()` returned (parameterized test, 3 executions)
- `null` input → `new Settings()` returned — confirms `StringUtils.isBlank(null)` path
- Valid JSON → parsed `Settings` with correct field values (`featureStatisticsEnabled`, `featureTopicsEnabled`, `activeLanguages`)
- `"null"` JSON literal → Jackson deserializes to Java `null` → `new Settings()` returned via null guard at line 21
- Invalid JSON → `RuntimeJsonMappingException` thrown

**`toSettingsJson(Settings settings)`:**
- `null` input → `null` returned (no exception)
- Valid `Settings` → non-blank JSON string with correct feature flag values; `agencyAdminControls` absent from output
- `agencyAdminControls` stripped when set → `featureStatisticsEnabled` preserved, `agencyAdminControls` absent
- Strip does not affect unset fields → `activeLanguages` absent in output when not set
- Serialization failure → `RuntimeJsonMappingException` thrown (via `ReflectionTestUtils` + `FailingObjectMapper`)

**`stripAgencyAdminControls()` (private):**
Covered transitively via `toSettingsJson()` tests #7, #9, and #10.

## Approach

Pure unit tests with no mocks — real `ObjectMapper` used throughout. `ReflectionTestUtils.setField` used to inject a `FailingObjectMapper` subclass for the serialization failure test only. JSON assertions use parsed `JsonNode` (not string equality) to avoid field-order flakiness.

## Test results
Tests run: 12, Failures: 0, Errors: 0, Skipped: 0 — BUILD SUCCESS

## Files changed

| File | Action |
|---|---|
| `src/test/java/de/caritas/cob/agencyservice/api/admin/service/agency/AgencySettingsServiceTest.java` | Created |

No production code changes.

## Checklist
- [x] All public methods covered
- [x] Private method covered transitively
- [x] All `toSettings` branches covered (blank, null, valid, null literal, invalid)
- [x] All `toSettingsJson` branches covered (null, valid, strip, failure)
- [x] No production code changes
- [x] No mocks — real `ObjectMapper`
- [x] All 12 test executions pass locally