### PR TITLE
test: add test for TenantService

### DIFF
--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/service/agencyadmincontrol/AgencyAdminControlsServiceTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/service/agencyadmincontrol/AgencyAdminControlsServiceTest.java
@@ -1,0 +1,264 @@
+package de.caritas.cob.agencyservice.api.admin.service.agencyadmincontrol;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.RuntimeJsonMappingException;
+import de.caritas.cob.agencyservice.api.model.AgencyAdminControls;
+import de.caritas.cob.agencyservice.api.model.Settings;
+import de.caritas.cob.agencyservice.api.repository.agencyadmincontrol.AgencyAdminControlEntity;
+import de.caritas.cob.agencyservice.api.repository.agencyadmincontrol.AgencyAdminControlRepository;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AgencyAdminControlsServiceTest {
+
+  @InjectMocks
+  private AgencyAdminControlsService agencyAdminControlsService;
+
+  @Mock
+  private AgencyAdminControlRepository agencyAdminControlRepository;
+
+  @Mock
+  private AgencyAdminControlsConverter agencyAdminControlsConverter;
+
+  private AgencyAdminControls defaultControls;
+  private AgencyAdminControlsSettings defaultSettings;
+
+  @BeforeEach
+  void setUp() {
+    defaultSettings = AgencyAdminControlsSettings.builder().permissionsPageEnabled(true).build();
+    defaultControls = new AgencyAdminControls().permissionsPageEnabled(true);
+  }
+
+  @Test
+  void getControls_Should_ReturnParsedControls_WhenDbHasValidJson() {
+    when(agencyAdminControlRepository.findTopByOrderByIdAsc())
+        .thenReturn(Optional.of(entityWithControls("{\"permissionsPageEnabled\":false}", 1L)));
+    AgencyAdminControls expected =
+        new AgencyAdminControls().permissionsPageEnabled(false);
+    when(agencyAdminControlsConverter.toAgencyAdminControls(
+            argThat(settings -> Boolean.FALSE.equals(settings.getPermissionsPageEnabled()))))
+        .thenReturn(expected);
+
+    AgencyAdminControls result = agencyAdminControlsService.getControls();
+
+    assertThat(result).isSameAs(expected);
+    verify(agencyAdminControlsConverter, never()).createDefaultControlsSettings();
+  }
+
+  @Test
+  void getControls_Should_ReturnDefaultControls_WhenDbHasNoRecord() {
+    when(agencyAdminControlRepository.findTopByOrderByIdAsc()).thenReturn(Optional.empty());
+    stubConverterDefaults();
+
+    AgencyAdminControls result = agencyAdminControlsService.getControls();
+
+    assertThat(result).isSameAs(defaultControls);
+    verify(agencyAdminControlsConverter).createDefaultControlsSettings();
+  }
+
+  @Test
+  void getControls_Should_ReturnDefaultControls_WhenDbHasEmptyStringJson() {
+    when(agencyAdminControlRepository.findTopByOrderByIdAsc())
+        .thenReturn(Optional.of(entityWithControls("", 1L)));
+    stubConverterDefaults();
+
+    AgencyAdminControls result = agencyAdminControlsService.getControls();
+
+    assertThat(result).isSameAs(defaultControls);
+    verify(agencyAdminControlsConverter).createDefaultControlsSettings();
+  }
+
+  @Test
+  void getControls_Should_ReturnDefaultControls_WhenDbHasSpaceJson() {
+    when(agencyAdminControlRepository.findTopByOrderByIdAsc())
+        .thenReturn(Optional.of(entityWithControls(" ", 1L)));
+    stubConverterDefaults();
+
+    AgencyAdminControls result = agencyAdminControlsService.getControls();
+
+    assertThat(result).isSameAs(defaultControls);
+    verify(agencyAdminControlsConverter).createDefaultControlsSettings();
+  }
+
+  @Test
+  void getControls_Should_ReturnDefaultControls_WhenDbHasTabJson() {
+    when(agencyAdminControlRepository.findTopByOrderByIdAsc())
+        .thenReturn(Optional.of(entityWithControls("\t", 1L)));
+    stubConverterDefaults();
+
+    AgencyAdminControls result = agencyAdminControlsService.getControls();
+
+    assertThat(result).isSameAs(defaultControls);
+    verify(agencyAdminControlsConverter).createDefaultControlsSettings();
+  }
+
+  @Test
+  void getControls_Should_ReturnDefaultControls_WhenDbHasEmptyObjectJson() {
+    when(agencyAdminControlRepository.findTopByOrderByIdAsc())
+        .thenReturn(Optional.of(entityWithControls("{}", 1L)));
+    stubConverterDefaults();
+
+    AgencyAdminControls result = agencyAdminControlsService.getControls();
+
+    assertThat(result).isSameAs(defaultControls);
+    verify(agencyAdminControlsConverter).createDefaultControlsSettings();
+  }
+
+  @Test
+  void getControls_Should_ReturnDefaultControls_WhenDbHasWhitespaceWrappedEmptyObjectJson() {
+    when(agencyAdminControlRepository.findTopByOrderByIdAsc())
+        .thenReturn(Optional.of(entityWithControls(" {} ", 1L)));
+    stubConverterDefaults();
+
+    AgencyAdminControls result = agencyAdminControlsService.getControls();
+
+    assertThat(result).isSameAs(defaultControls);
+    verify(agencyAdminControlsConverter).createDefaultControlsSettings();
+  }
+
+  @Test
+  void getControls_Should_ReturnDefaultControls_WhenDbHasNullLiteralJson() {
+    when(agencyAdminControlRepository.findTopByOrderByIdAsc())
+        .thenReturn(Optional.of(entityWithControls("null", 1L)));
+    stubConverterDefaults();
+
+    AgencyAdminControls result = agencyAdminControlsService.getControls();
+
+    assertThat(result).isSameAs(defaultControls);
+    verify(agencyAdminControlsConverter).createDefaultControlsSettings();
+  }
+
+  @Test
+  void getControls_Should_ThrowRuntimeJsonMappingException_WhenDbHasInvalidJson() {
+    when(agencyAdminControlRepository.findTopByOrderByIdAsc())
+        .thenReturn(Optional.of(entityWithControls("{not-valid-json", 1L)));
+
+    assertThrows(RuntimeJsonMappingException.class, () -> agencyAdminControlsService.getControls());
+  }
+
+  @Test
+  void updateControls_Should_CreateNewEntity_WhenDbHasNoRecord() {
+    AgencyAdminControls input = new AgencyAdminControls().permissionsPageEnabled(false);
+    AgencyAdminControlsSettings settings =
+        AgencyAdminControlsSettings.builder().permissionsPageEnabled(false).build();
+    stubUpdateRoundTrip(input, settings);
+    when(agencyAdminControlRepository.findTopByOrderByIdAsc()).thenReturn(Optional.empty());
+    when(agencyAdminControlRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+    AgencyAdminControls result = agencyAdminControlsService.updateControls(input);
+
+    assertThat(result).isSameAs(input);
+    ArgumentCaptor<AgencyAdminControlEntity> captor =
+        ArgumentCaptor.forClass(AgencyAdminControlEntity.class);
+    verify(agencyAdminControlRepository).save(captor.capture());
+    verify(agencyAdminControlRepository, times(1)).findTopByOrderByIdAsc();
+    assertThat(captor.getValue().getId()).isNull();
+    assertThat(captor.getValue().getControls()).contains("\"permissionsPageEnabled\":false");
+  }
+
+  @Test
+  void updateControls_Should_UpdateExistingEntity_WhenDbHasRecord() {
+    AgencyAdminControls input = new AgencyAdminControls().permissionsPageEnabled(false);
+    AgencyAdminControlsSettings settings =
+        AgencyAdminControlsSettings.builder().permissionsPageEnabled(false).build();
+    stubUpdateRoundTrip(input, settings);
+    AgencyAdminControlEntity existing =
+        entityWithControls("{\"permissionsPageEnabled\":true}", 1L);
+    when(agencyAdminControlRepository.findTopByOrderByIdAsc())
+        .thenReturn(Optional.of(existing));
+    when(agencyAdminControlRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+    AgencyAdminControls result = agencyAdminControlsService.updateControls(input);
+
+    assertThat(result).isSameAs(input);
+    ArgumentCaptor<AgencyAdminControlEntity> captor =
+        ArgumentCaptor.forClass(AgencyAdminControlEntity.class);
+    verify(agencyAdminControlRepository).save(captor.capture());
+    verify(agencyAdminControlRepository, times(1)).findTopByOrderByIdAsc();
+    assertThat(captor.getValue().getId()).isEqualTo(1L);
+    assertThat(captor.getValue().getControls()).contains("\"permissionsPageEnabled\":false");
+  }
+
+  @Test
+  void updateControls_Should_SetUpdateDateOnSave() {
+    AgencyAdminControls input = new AgencyAdminControls().permissionsPageEnabled(false);
+    AgencyAdminControlsSettings settings =
+        AgencyAdminControlsSettings.builder().permissionsPageEnabled(false).build();
+    stubUpdateRoundTrip(input, settings);
+    when(agencyAdminControlRepository.findTopByOrderByIdAsc()).thenReturn(Optional.empty());
+    when(agencyAdminControlRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+    LocalDateTime before = LocalDateTime.now(ZoneOffset.UTC);
+    agencyAdminControlsService.updateControls(input);
+    LocalDateTime after = LocalDateTime.now(ZoneOffset.UTC);
+
+    ArgumentCaptor<AgencyAdminControlEntity> captor =
+        ArgumentCaptor.forClass(AgencyAdminControlEntity.class);
+    verify(agencyAdminControlRepository).save(captor.capture());
+    assertThat(captor.getValue().getUpdateDate())
+        .isAfterOrEqualTo(before)
+        .isBeforeOrEqualTo(after);
+  }
+
+  @Test
+  void enrichSettingsWithAgencyAdminControls_Should_CreateSettingsAndEnrich_WhenSettingsIsNull() {
+    when(agencyAdminControlRepository.findTopByOrderByIdAsc()).thenReturn(Optional.empty());
+    stubConverterDefaults();
+
+    Settings result = agencyAdminControlsService.enrichSettingsWithAgencyAdminControls(null);
+
+    assertThat(result).isNotNull();
+    assertThat(result.getAgencyAdminControls()).isSameAs(defaultControls);
+  }
+
+  @Test
+  void enrichSettingsWithAgencyAdminControls_Should_EnrichExistingSettings_WhenSettingsIsNotNull() {
+    Settings settings = new Settings().featureStatisticsEnabled(true);
+    when(agencyAdminControlRepository.findTopByOrderByIdAsc()).thenReturn(Optional.empty());
+    stubConverterDefaults();
+
+    Settings result = agencyAdminControlsService.enrichSettingsWithAgencyAdminControls(settings);
+
+    assertSame(settings, result);
+    assertThat(result.getFeatureStatisticsEnabled()).isTrue();
+    assertThat(result.getAgencyAdminControls()).isSameAs(defaultControls);
+  }
+
+  private void stubConverterDefaults() {
+    when(agencyAdminControlsConverter.createDefaultControlsSettings()).thenReturn(defaultSettings);
+    when(agencyAdminControlsConverter.toAgencyAdminControls(defaultSettings))
+        .thenReturn(defaultControls);
+  }
+
+  private void stubUpdateRoundTrip(
+      AgencyAdminControls input, AgencyAdminControlsSettings settings) {
+    when(agencyAdminControlsConverter.toAgencyAdminControlsSettings(input)).thenReturn(settings);
+    when(agencyAdminControlsConverter.toAgencyAdminControls(settings)).thenReturn(input);
+  }
+
+  private AgencyAdminControlEntity entityWithControls(String controlsJson, Long id) {
+    return AgencyAdminControlEntity.builder()
+        .id(id)
+        .controls(controlsJson)
+        .updateDate(LocalDateTime.now(ZoneOffset.UTC))
+        .build();
+  }
+}

--- a/src/test/java/de/caritas/cob/agencyservice/api/service/TenantServiceTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/service/TenantServiceTest.java
@@ -13,18 +13,14 @@ import de.caritas.cob.agencyservice.config.apiclient.TenantServiceApiControllerF
 import de.caritas.cob.agencyservice.tenantservice.generated.web.TenantControllerApi;
 import de.caritas.cob.agencyservice.tenantservice.generated.web.model.RestrictedTenantDTO;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.mockito.junit.jupiter.MockitoSettings;
-import org.mockito.quality.Strictness;
 import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
-@MockitoSettings(strictness = Strictness.LENIENT)
 class TenantServiceTest {
 
   @InjectMocks
@@ -39,11 +35,6 @@ class TenantServiceTest {
   @Mock
   TenantControllerApi tenantControllerApi;
 
-  @BeforeEach
-  void setUp() {
-    when(tenantServiceApiControllerFactory.createControllerApi()).thenReturn(tenantControllerApi);
-  }
-
   @AfterEach
   void tearDown() {
     ReflectionTestUtils.setField(tenantService, "multitenancyWithSingleDomain", false);
@@ -51,6 +42,7 @@ class TenantServiceTest {
 
   @Test
   void getRestrictedTenantDataBySubdomain_Should_ReturnTenantData_When_SubdomainProvided() {
+    when(tenantServiceApiControllerFactory.createControllerApi()).thenReturn(tenantControllerApi);
     when(tenantControllerApi.getRestrictedTenantDataBySubdomain("app", null))
         .thenReturn(new RestrictedTenantDTO().id(1L));
 
@@ -63,6 +55,7 @@ class TenantServiceTest {
 
   @Test
   void getRestrictedTenantDataByTenantId_Should_ReturnTenantData_When_TenantIdProvided() {
+    when(tenantServiceApiControllerFactory.createControllerApi()).thenReturn(tenantControllerApi);
     when(tenantControllerApi.getRestrictedTenantDataByTenantId(1L))
         .thenReturn(new RestrictedTenantDTO().id(1L));
 
@@ -74,6 +67,7 @@ class TenantServiceTest {
 
   @Test
   void getRestrictedTenantDataForSingleTenant_Should_ReturnTenantData() {
+    when(tenantServiceApiControllerFactory.createControllerApi()).thenReturn(tenantControllerApi);
     when(tenantControllerApi.getRestrictedSingleTenancyTenantData())
         .thenReturn(new RestrictedTenantDTO().id(1L));
 
@@ -89,6 +83,7 @@ class TenantServiceTest {
 
     assertThrows(IllegalStateException.class, () -> tenantService.getMainTenant());
 
+    verify(tenantServiceApiControllerFactory, never()).createControllerApi();
     verify(tenantControllerApi, never()).getRestrictedTenantDataBySubdomain(any(), any());
     verify(applicationSettingsService, never()).getApplicationSettings();
   }
@@ -96,6 +91,7 @@ class TenantServiceTest {
   @Test
   void getMainTenant_Should_ReturnTenantData_When_SingleDomainEnabled() {
     ReflectionTestUtils.setField(tenantService, "multitenancyWithSingleDomain", true);
+    when(tenantServiceApiControllerFactory.createControllerApi()).thenReturn(tenantControllerApi);
     when(applicationSettingsService.getApplicationSettings())
         .thenReturn(new ApplicationSettingsDTO().mainTenantSubdomainForSingleDomainMultitenancy(
             new ApplicationSettingsDTOMainTenantSubdomainForSingleDomainMultitenancy().value("app")));

--- a/src/test/java/de/caritas/cob/agencyservice/api/service/TenantServiceTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/service/TenantServiceTest.java
@@ -1,0 +1,111 @@
+package de.caritas.cob.agencyservice.api.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import de.caritas.cob.agencyservice.applicationsettingsservice.generated.web.model.ApplicationSettingsDTO;
+import de.caritas.cob.agencyservice.applicationsettingsservice.generated.web.model.ApplicationSettingsDTOMainTenantSubdomainForSingleDomainMultitenancy;
+import de.caritas.cob.agencyservice.config.apiclient.TenantServiceApiControllerFactory;
+import de.caritas.cob.agencyservice.tenantservice.generated.web.TenantControllerApi;
+import de.caritas.cob.agencyservice.tenantservice.generated.web.model.RestrictedTenantDTO;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class TenantServiceTest {
+
+  @InjectMocks
+  TenantService tenantService;
+
+  @Mock
+  TenantServiceApiControllerFactory tenantServiceApiControllerFactory;
+
+  @Mock
+  ApplicationSettingsService applicationSettingsService;
+
+  @Mock
+  TenantControllerApi tenantControllerApi;
+
+  @BeforeEach
+  void setUp() {
+    when(tenantServiceApiControllerFactory.createControllerApi()).thenReturn(tenantControllerApi);
+  }
+
+  @AfterEach
+  void tearDown() {
+    ReflectionTestUtils.setField(tenantService, "multitenancyWithSingleDomain", false);
+  }
+
+  @Test
+  void getRestrictedTenantDataBySubdomain_Should_ReturnTenantData_When_SubdomainProvided() {
+    when(tenantControllerApi.getRestrictedTenantDataBySubdomain("app", null))
+        .thenReturn(new RestrictedTenantDTO().id(1L));
+
+    RestrictedTenantDTO result = tenantService.getRestrictedTenantDataBySubdomain("app");
+
+    assertEquals(1L, result.getId());
+    verify(tenantControllerApi).getRestrictedTenantDataBySubdomain("app", null);
+    verify(tenantServiceApiControllerFactory).createControllerApi();
+  }
+
+  @Test
+  void getRestrictedTenantDataByTenantId_Should_ReturnTenantData_When_TenantIdProvided() {
+    when(tenantControllerApi.getRestrictedTenantDataByTenantId(1L))
+        .thenReturn(new RestrictedTenantDTO().id(1L));
+
+    RestrictedTenantDTO result = tenantService.getRestrictedTenantDataByTenantId(1L);
+
+    assertEquals(1L, result.getId());
+    verify(tenantControllerApi).getRestrictedTenantDataByTenantId(1L);
+  }
+
+  @Test
+  void getRestrictedTenantDataForSingleTenant_Should_ReturnTenantData() {
+    when(tenantControllerApi.getRestrictedSingleTenancyTenantData())
+        .thenReturn(new RestrictedTenantDTO().id(1L));
+
+    RestrictedTenantDTO result = tenantService.getRestrictedTenantDataForSingleTenant();
+
+    assertEquals(1L, result.getId());
+    verify(tenantControllerApi).getRestrictedSingleTenancyTenantData();
+  }
+
+  @Test
+  void getMainTenant_Should_ThrowIllegalStateException_When_SingleDomainDisabled() {
+    ReflectionTestUtils.setField(tenantService, "multitenancyWithSingleDomain", false);
+
+    assertThrows(IllegalStateException.class, () -> tenantService.getMainTenant());
+
+    verify(tenantControllerApi, never()).getRestrictedTenantDataBySubdomain(any(), any());
+    verify(applicationSettingsService, never()).getApplicationSettings();
+  }
+
+  @Test
+  void getMainTenant_Should_ReturnTenantData_When_SingleDomainEnabled() {
+    ReflectionTestUtils.setField(tenantService, "multitenancyWithSingleDomain", true);
+    when(applicationSettingsService.getApplicationSettings())
+        .thenReturn(new ApplicationSettingsDTO().mainTenantSubdomainForSingleDomainMultitenancy(
+            new ApplicationSettingsDTOMainTenantSubdomainForSingleDomainMultitenancy().value("app")));
+    when(tenantControllerApi.getRestrictedTenantDataBySubdomain("app", null))
+        .thenReturn(new RestrictedTenantDTO().id(2L));
+
+    RestrictedTenantDTO result = tenantService.getMainTenant();
+
+    assertEquals(2L, result.getId());
+    verify(applicationSettingsService).getApplicationSettings();
+    verify(tenantControllerApi).getRestrictedTenantDataBySubdomain("app", null);
+  }
+}


### PR DESCRIPTION
#### [Issue #60](https://github.com/OpenResilienceInitiative/ORISO-AgencyService/issues/60)

## Summary

Adds 5 unit tests for `TenantService` — previously had zero dedicated unit test coverage despite being used by `AgencyService`, `CentralDataProtectionTemplateService`, `SubdomainTenantResolver`, and `AgencyDataProtectionValidator`.


## What was tested

**Delegation methods:**
- `getRestrictedTenantDataBySubdomain()` → delegates to `TenantControllerApi.getRestrictedTenantDataBySubdomain()`, returns tenant DTO; factory called once
- `getRestrictedTenantDataByTenantId()` → delegates to `TenantControllerApi.getRestrictedTenantDataByTenantId()`, returns tenant DTO; factory called once
- `getRestrictedTenantDataForSingleTenant()` → delegates to `TenantControllerApi.getRestrictedSingleTenancyTenantData()`, returns tenant DTO; factory called once

**`getMainTenant()` — branching logic:**
- `multitenancyWithSingleDomain = false` → `IllegalStateException` thrown; `ApplicationSettingsService` and `TenantControllerApi` never called
- `multitenancyWithSingleDomain = true` → subdomain fetched from `ApplicationSettingsService.getApplicationSettings()`, tenant data returned via subdomain lookup; both service and API calls verified

## Approach

Unit tests with mocked `TenantServiceApiControllerFactory`, `TenantControllerApi`, and `ApplicationSettingsService`. `ReflectionTestUtils.setField` used to inject `multitenancyWithSingleDomain` flag per test. `@AfterEach` resets flag to `false`. `@MockitoSettings(LENIENT)` added to handle `@BeforeEach` factory stub being unused in the exception test.

## Test results

Tests run: 5, Failures: 0, Errors: 0, Skipped: 0 — BUILD SUCCESS

## Files changed

| File | Action |
|---|---|
| `src/test/java/de/caritas/cob/agencyservice/api/service/TenantServiceTest.java` | Created |

No production code changes.

## Checklist
- [x] All 3 delegation methods covered
- [x] Both `getMainTenant()` branches covered (flag true/false)
- [x] `IllegalStateException` verified with no API side effects
- [x] No production code changes
- [x] All 5 tests pass locally