### PR TITLE
Test/as test 05 authorisation service

### DIFF
--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/service/agencyadmincontrol/AgencyAdminControlsServiceTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/service/agencyadmincontrol/AgencyAdminControlsServiceTest.java
@@ -1,0 +1,264 @@
+package de.caritas.cob.agencyservice.api.admin.service.agencyadmincontrol;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.RuntimeJsonMappingException;
+import de.caritas.cob.agencyservice.api.model.AgencyAdminControls;
+import de.caritas.cob.agencyservice.api.model.Settings;
+import de.caritas.cob.agencyservice.api.repository.agencyadmincontrol.AgencyAdminControlEntity;
+import de.caritas.cob.agencyservice.api.repository.agencyadmincontrol.AgencyAdminControlRepository;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AgencyAdminControlsServiceTest {
+
+  @InjectMocks
+  private AgencyAdminControlsService agencyAdminControlsService;
+
+  @Mock
+  private AgencyAdminControlRepository agencyAdminControlRepository;
+
+  @Mock
+  private AgencyAdminControlsConverter agencyAdminControlsConverter;
+
+  private AgencyAdminControls defaultControls;
+  private AgencyAdminControlsSettings defaultSettings;
+
+  @BeforeEach
+  void setUp() {
+    defaultSettings = AgencyAdminControlsSettings.builder().permissionsPageEnabled(true).build();
+    defaultControls = new AgencyAdminControls().permissionsPageEnabled(true);
+  }
+
+  @Test
+  void getControls_Should_ReturnParsedControls_WhenDbHasValidJson() {
+    when(agencyAdminControlRepository.findTopByOrderByIdAsc())
+        .thenReturn(Optional.of(entityWithControls("{\"permissionsPageEnabled\":false}", 1L)));
+    AgencyAdminControls expected =
+        new AgencyAdminControls().permissionsPageEnabled(false);
+    when(agencyAdminControlsConverter.toAgencyAdminControls(
+            argThat(settings -> Boolean.FALSE.equals(settings.getPermissionsPageEnabled()))))
+        .thenReturn(expected);
+
+    AgencyAdminControls result = agencyAdminControlsService.getControls();
+
+    assertThat(result).isSameAs(expected);
+    verify(agencyAdminControlsConverter, never()).createDefaultControlsSettings();
+  }
+
+  @Test
+  void getControls_Should_ReturnDefaultControls_WhenDbHasNoRecord() {
+    when(agencyAdminControlRepository.findTopByOrderByIdAsc()).thenReturn(Optional.empty());
+    stubConverterDefaults();
+
+    AgencyAdminControls result = agencyAdminControlsService.getControls();
+
+    assertThat(result).isSameAs(defaultControls);
+    verify(agencyAdminControlsConverter).createDefaultControlsSettings();
+  }
+
+  @Test
+  void getControls_Should_ReturnDefaultControls_WhenDbHasEmptyStringJson() {
+    when(agencyAdminControlRepository.findTopByOrderByIdAsc())
+        .thenReturn(Optional.of(entityWithControls("", 1L)));
+    stubConverterDefaults();
+
+    AgencyAdminControls result = agencyAdminControlsService.getControls();
+
+    assertThat(result).isSameAs(defaultControls);
+    verify(agencyAdminControlsConverter).createDefaultControlsSettings();
+  }
+
+  @Test
+  void getControls_Should_ReturnDefaultControls_WhenDbHasSpaceJson() {
+    when(agencyAdminControlRepository.findTopByOrderByIdAsc())
+        .thenReturn(Optional.of(entityWithControls(" ", 1L)));
+    stubConverterDefaults();
+
+    AgencyAdminControls result = agencyAdminControlsService.getControls();
+
+    assertThat(result).isSameAs(defaultControls);
+    verify(agencyAdminControlsConverter).createDefaultControlsSettings();
+  }
+
+  @Test
+  void getControls_Should_ReturnDefaultControls_WhenDbHasTabJson() {
+    when(agencyAdminControlRepository.findTopByOrderByIdAsc())
+        .thenReturn(Optional.of(entityWithControls("\t", 1L)));
+    stubConverterDefaults();
+
+    AgencyAdminControls result = agencyAdminControlsService.getControls();
+
+    assertThat(result).isSameAs(defaultControls);
+    verify(agencyAdminControlsConverter).createDefaultControlsSettings();
+  }
+
+  @Test
+  void getControls_Should_ReturnDefaultControls_WhenDbHasEmptyObjectJson() {
+    when(agencyAdminControlRepository.findTopByOrderByIdAsc())
+        .thenReturn(Optional.of(entityWithControls("{}", 1L)));
+    stubConverterDefaults();
+
+    AgencyAdminControls result = agencyAdminControlsService.getControls();
+
+    assertThat(result).isSameAs(defaultControls);
+    verify(agencyAdminControlsConverter).createDefaultControlsSettings();
+  }
+
+  @Test
+  void getControls_Should_ReturnDefaultControls_WhenDbHasWhitespaceWrappedEmptyObjectJson() {
+    when(agencyAdminControlRepository.findTopByOrderByIdAsc())
+        .thenReturn(Optional.of(entityWithControls(" {} ", 1L)));
+    stubConverterDefaults();
+
+    AgencyAdminControls result = agencyAdminControlsService.getControls();
+
+    assertThat(result).isSameAs(defaultControls);
+    verify(agencyAdminControlsConverter).createDefaultControlsSettings();
+  }
+
+  @Test
+  void getControls_Should_ReturnDefaultControls_WhenDbHasNullLiteralJson() {
+    when(agencyAdminControlRepository.findTopByOrderByIdAsc())
+        .thenReturn(Optional.of(entityWithControls("null", 1L)));
+    stubConverterDefaults();
+
+    AgencyAdminControls result = agencyAdminControlsService.getControls();
+
+    assertThat(result).isSameAs(defaultControls);
+    verify(agencyAdminControlsConverter).createDefaultControlsSettings();
+  }
+
+  @Test
+  void getControls_Should_ThrowRuntimeJsonMappingException_WhenDbHasInvalidJson() {
+    when(agencyAdminControlRepository.findTopByOrderByIdAsc())
+        .thenReturn(Optional.of(entityWithControls("{not-valid-json", 1L)));
+
+    assertThrows(RuntimeJsonMappingException.class, () -> agencyAdminControlsService.getControls());
+  }
+
+  @Test
+  void updateControls_Should_CreateNewEntity_WhenDbHasNoRecord() {
+    AgencyAdminControls input = new AgencyAdminControls().permissionsPageEnabled(false);
+    AgencyAdminControlsSettings settings =
+        AgencyAdminControlsSettings.builder().permissionsPageEnabled(false).build();
+    stubUpdateRoundTrip(input, settings);
+    when(agencyAdminControlRepository.findTopByOrderByIdAsc()).thenReturn(Optional.empty());
+    when(agencyAdminControlRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+    AgencyAdminControls result = agencyAdminControlsService.updateControls(input);
+
+    assertThat(result).isSameAs(input);
+    ArgumentCaptor<AgencyAdminControlEntity> captor =
+        ArgumentCaptor.forClass(AgencyAdminControlEntity.class);
+    verify(agencyAdminControlRepository).save(captor.capture());
+    verify(agencyAdminControlRepository, times(1)).findTopByOrderByIdAsc();
+    assertThat(captor.getValue().getId()).isNull();
+    assertThat(captor.getValue().getControls()).contains("\"permissionsPageEnabled\":false");
+  }
+
+  @Test
+  void updateControls_Should_UpdateExistingEntity_WhenDbHasRecord() {
+    AgencyAdminControls input = new AgencyAdminControls().permissionsPageEnabled(false);
+    AgencyAdminControlsSettings settings =
+        AgencyAdminControlsSettings.builder().permissionsPageEnabled(false).build();
+    stubUpdateRoundTrip(input, settings);
+    AgencyAdminControlEntity existing =
+        entityWithControls("{\"permissionsPageEnabled\":true}", 1L);
+    when(agencyAdminControlRepository.findTopByOrderByIdAsc())
+        .thenReturn(Optional.of(existing));
+    when(agencyAdminControlRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+    AgencyAdminControls result = agencyAdminControlsService.updateControls(input);
+
+    assertThat(result).isSameAs(input);
+    ArgumentCaptor<AgencyAdminControlEntity> captor =
+        ArgumentCaptor.forClass(AgencyAdminControlEntity.class);
+    verify(agencyAdminControlRepository).save(captor.capture());
+    verify(agencyAdminControlRepository, times(1)).findTopByOrderByIdAsc();
+    assertThat(captor.getValue().getId()).isEqualTo(1L);
+    assertThat(captor.getValue().getControls()).contains("\"permissionsPageEnabled\":false");
+  }
+
+  @Test
+  void updateControls_Should_SetUpdateDateOnSave() {
+    AgencyAdminControls input = new AgencyAdminControls().permissionsPageEnabled(false);
+    AgencyAdminControlsSettings settings =
+        AgencyAdminControlsSettings.builder().permissionsPageEnabled(false).build();
+    stubUpdateRoundTrip(input, settings);
+    when(agencyAdminControlRepository.findTopByOrderByIdAsc()).thenReturn(Optional.empty());
+    when(agencyAdminControlRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+    LocalDateTime before = LocalDateTime.now(ZoneOffset.UTC);
+    agencyAdminControlsService.updateControls(input);
+    LocalDateTime after = LocalDateTime.now(ZoneOffset.UTC);
+
+    ArgumentCaptor<AgencyAdminControlEntity> captor =
+        ArgumentCaptor.forClass(AgencyAdminControlEntity.class);
+    verify(agencyAdminControlRepository).save(captor.capture());
+    assertThat(captor.getValue().getUpdateDate())
+        .isAfterOrEqualTo(before)
+        .isBeforeOrEqualTo(after);
+  }
+
+  @Test
+  void enrichSettingsWithAgencyAdminControls_Should_CreateSettingsAndEnrich_WhenSettingsIsNull() {
+    when(agencyAdminControlRepository.findTopByOrderByIdAsc()).thenReturn(Optional.empty());
+    stubConverterDefaults();
+
+    Settings result = agencyAdminControlsService.enrichSettingsWithAgencyAdminControls(null);
+
+    assertThat(result).isNotNull();
+    assertThat(result.getAgencyAdminControls()).isSameAs(defaultControls);
+  }
+
+  @Test
+  void enrichSettingsWithAgencyAdminControls_Should_EnrichExistingSettings_WhenSettingsIsNotNull() {
+    Settings settings = new Settings().featureStatisticsEnabled(true);
+    when(agencyAdminControlRepository.findTopByOrderByIdAsc()).thenReturn(Optional.empty());
+    stubConverterDefaults();
+
+    Settings result = agencyAdminControlsService.enrichSettingsWithAgencyAdminControls(settings);
+
+    assertSame(settings, result);
+    assertThat(result.getFeatureStatisticsEnabled()).isTrue();
+    assertThat(result.getAgencyAdminControls()).isSameAs(defaultControls);
+  }
+
+  private void stubConverterDefaults() {
+    when(agencyAdminControlsConverter.createDefaultControlsSettings()).thenReturn(defaultSettings);
+    when(agencyAdminControlsConverter.toAgencyAdminControls(defaultSettings))
+        .thenReturn(defaultControls);
+  }
+
+  private void stubUpdateRoundTrip(
+      AgencyAdminControls input, AgencyAdminControlsSettings settings) {
+    when(agencyAdminControlsConverter.toAgencyAdminControlsSettings(input)).thenReturn(settings);
+    when(agencyAdminControlsConverter.toAgencyAdminControls(settings)).thenReturn(input);
+  }
+
+  private AgencyAdminControlEntity entityWithControls(String controlsJson, Long id) {
+    return AgencyAdminControlEntity.builder()
+        .id(id)
+        .controls(controlsJson)
+        .updateDate(LocalDateTime.now(ZoneOffset.UTC))
+        .build();
+  }
+}

--- a/src/test/java/de/caritas/cob/agencyservice/config/security/AuthorisationServiceTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/config/security/AuthorisationServiceTest.java
@@ -1,0 +1,234 @@
+package de.caritas.cob.agencyservice.config.security;
+
+import static de.caritas.cob.agencyservice.api.authorization.Authority.AGENCY_ADMIN;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import java.time.Instant;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+@ExtendWith(MockitoExtension.class)
+class AuthorisationServiceTest {
+
+  private final AuthorisationService authorisationService = new AuthorisationService();
+
+  @Mock
+  private SecurityContext mockSecurityContext;
+
+  @Mock
+  private Authentication mockAuthentication;
+
+  @AfterEach
+  void tearDown() {
+    SecurityContextHolder.clearContext();
+  }
+
+  @Test
+  void extractRealmRoles_Should_returnRolesList_When_realmAccessAndRolesPresent() {
+    List<String> roles = Lists.newArrayList("agency-admin", "other");
+    Jwt jwt = buildJwtWithRealmRoles(roles);
+
+    Collection<String> result = authorisationService.extractRealmRoles(jwt);
+
+    assertThat(result).containsExactlyElementsOf(roles);
+  }
+
+  @Test
+  void extractRealmRoles_Should_returnEmptyList_When_realmAccessPresentButRolesNull() {
+    Jwt jwt = buildJwtWithNullRoles();
+
+    Collection<String> result = authorisationService.extractRealmRoles(jwt);
+
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void extractRealmRoles_Should_returnEmptyList_When_realmAccessIsNull() {
+    Jwt jwt = buildJwtWithoutRealmAccess();
+
+    Collection<String> result = authorisationService.extractRealmRoles(jwt);
+
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void extractRealmRoles_Should_throwClassCastException_When_rolesIsNotAList() {
+    Jwt jwt = buildJwtWithNonListRoles();
+
+    // Documents current (possibly unintended) behavior — unchecked cast at line 43
+    assertThatThrownBy(() -> authorisationService.extractRealmRoles(jwt))
+        .isInstanceOf(ClassCastException.class);
+  }
+
+  @Test
+  void extractRealmAuthorities_Should_returnMappedAuthorities_When_singleValidRole() {
+    Jwt jwt = buildJwtWithRealmRoles(Lists.newArrayList("agency-admin"));
+
+    Collection<GrantedAuthority> result = authorisationService.extractRealmAuthorities(jwt);
+
+    assertThat(result).hasSize(2);
+    List<String> authorities =
+        result.stream().map(GrantedAuthority::getAuthority).toList();
+    assertThat(authorities).containsAll(AGENCY_ADMIN.getAuthorities());
+  }
+
+  @Test
+  void extractRealmAuthorities_Should_returnEmptyCollection_When_rolesIsEmptyList() {
+    Jwt jwt = buildJwtWithRealmRoles(Lists.newArrayList());
+
+    Collection<GrantedAuthority> result = authorisationService.extractRealmAuthorities(jwt);
+
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void extractRealmAuthorities_Should_returnEmptyCollection_When_realmAccessIsNull() {
+    Jwt jwt = buildJwtWithoutRealmAccess();
+
+    Collection<GrantedAuthority> result = authorisationService.extractRealmAuthorities(jwt);
+
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void extractRealmAuthorities_Should_returnEmptyCollection_When_roleIsUnknown() {
+    Jwt jwt = buildJwtWithRealmRoles(Lists.newArrayList("unknown-role"));
+
+    Collection<GrantedAuthority> result = authorisationService.extractRealmAuthorities(jwt);
+
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void extractRealmAuthorities_Should_returnEmptyCollection_When_roleHasDifferentCasing() {
+    Jwt jwt = buildJwtWithRealmRoles(Lists.newArrayList("Agency-Admin"));
+
+    Collection<GrantedAuthority> result = authorisationService.extractRealmAuthorities(jwt);
+
+    // Authority.fromRoleName uses case-sensitive String.equals — "Agency-Admin" does not match
+    // "agency-admin". Unlike the GrantedAuthoritiesMapper overload, extractRealmAuthorities does
+    // not lowercase role names before lookup.
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void extractRealmAuthorities_Should_returnValidAuthorities_When_mixedWithUnknownRoles() {
+    Jwt jwt =
+        buildJwtWithRealmRoles(
+            Lists.newArrayList("unknown-role-1", "agency-admin", "unknown-role-2"));
+
+    Collection<GrantedAuthority> result = authorisationService.extractRealmAuthorities(jwt);
+
+    assertThat(result).hasSize(2);
+    List<String> authorities =
+        result.stream().map(GrantedAuthority::getAuthority).toList();
+    assertThat(authorities).containsAll(AGENCY_ADMIN.getAuthorities());
+    assertThat(authorities).doesNotContain("unknown-role-1", "unknown-role-2");
+  }
+
+  @Test
+  void getUsername_Should_returnUsernameClaim_When_claimPresent() {
+    givenAuthenticatedWithJwt(buildJwtWithUsername("test-user"));
+
+    Object result = authorisationService.getUsername();
+
+    assertThat(result).isEqualTo("test-user");
+  }
+
+  @Test
+  void getUsername_Should_returnNull_When_usernameClaimAbsent() {
+    givenAuthenticatedWithJwt(buildJwtWithoutUsernameClaim());
+
+    Object result = authorisationService.getUsername();
+
+    assertThat(result).isNull();
+  }
+
+  private void givenAuthenticatedWithJwt(Jwt jwt) {
+    SecurityContextHolder.setContext(mockSecurityContext);
+    when(mockSecurityContext.getAuthentication()).thenReturn(mockAuthentication);
+    when(mockAuthentication.getPrincipal()).thenReturn(jwt);
+  }
+
+  private Jwt buildJwtWithRealmRoles(List<String> roles) {
+    Map<String, Object> headers = new HashMap<>();
+    headers.put("alg", "HS256");
+    headers.put("typ", "JWT");
+    HashMap<String, Object> claimMap = Maps.newHashMap();
+    var realmAccess = Maps.newHashMap();
+    realmAccess.put("roles", roles);
+    claimMap.put("realm_access", realmAccess);
+    return new Jwt(
+        "token", Instant.now(), Instant.now().plusSeconds(1), headers, claimMap);
+  }
+
+  private Jwt buildJwtWithNullRoles() {
+    Map<String, Object> headers = new HashMap<>();
+    headers.put("alg", "HS256");
+    headers.put("typ", "JWT");
+    HashMap<String, Object> claimMap = Maps.newHashMap();
+    var realmAccess = Maps.newHashMap();
+    realmAccess.put("roles", null);
+    claimMap.put("realm_access", realmAccess);
+    return new Jwt(
+        "token", Instant.now(), Instant.now().plusSeconds(1), headers, claimMap);
+  }
+
+  private Jwt buildJwtWithoutRealmAccess() {
+    Map<String, Object> headers = new HashMap<>();
+    headers.put("alg", "HS256");
+    headers.put("typ", "JWT");
+    HashMap<String, Object> claimMap = Maps.newHashMap();
+    claimMap.put("sub", "test-subject");
+    return new Jwt(
+        "token", Instant.now(), Instant.now().plusSeconds(1), headers, claimMap);
+  }
+
+  private Jwt buildJwtWithoutUsernameClaim() {
+    Map<String, Object> headers = new HashMap<>();
+    headers.put("alg", "HS256");
+    headers.put("typ", "JWT");
+    HashMap<String, Object> claimMap = Maps.newHashMap();
+    claimMap.put("sub", "test-subject");
+    return new Jwt(
+        "token", Instant.now(), Instant.now().plusSeconds(1), headers, claimMap);
+  }
+
+  private Jwt buildJwtWithNonListRoles() {
+    Map<String, Object> headers = new HashMap<>();
+    headers.put("alg", "HS256");
+    headers.put("typ", "JWT");
+    HashMap<String, Object> claimMap = Maps.newHashMap();
+    var realmAccess = Maps.newHashMap();
+    realmAccess.put("roles", "agency-admin");
+    claimMap.put("realm_access", realmAccess);
+    return new Jwt(
+        "token", Instant.now(), Instant.now().plusSeconds(1), headers, claimMap);
+  }
+
+  private Jwt buildJwtWithUsername(String username) {
+    Map<String, Object> headers = new HashMap<>();
+    headers.put("alg", "HS256");
+    headers.put("typ", "JWT");
+    HashMap<String, Object> claimMap = Maps.newHashMap();
+    claimMap.put("username", username);
+    return new Jwt(
+        "token", Instant.now(), Instant.now().plusSeconds(1), headers, claimMap);
+  }
+}


### PR DESCRIPTION
#### [Issue #62](https://github.com/OpenResilienceInitiative/ORISO-AgencyService/issues/62)

## Summary

Adds 12 unit tests for `AuthorisationService` — previously had zero dedicated test coverage despite being core to the application's security and authorization flow (JWT realm role extraction and `GrantedAuthority` mapping).

## What was tested

**`extractRealmRoles(Jwt jwt)`:**
- `realm_access` present with roles → returns the roles list as-is
- `realm_access` present but `roles` is null → returns empty list
- `realm_access` null/absent → returns empty list
- `realm_access.roles` is not a List type → `ClassCastException` thrown — documents the current unchecked-cast behavior at line 43

**`extractRealmAuthorities(Jwt jwt)`:**
- Single valid role (`"agency-admin"`) → correctly mapped to `AGENCY_ADMIN` authorities (size 2)
- Empty roles list → returns empty authority collection
- `realm_access` null → returns empty authority collection (full pipeline through `extractRealmRoles`)
- Unknown/unmapped role → returns empty collection (`Authority.fromRoleName` returns null, filtered out, no exception)
- Role with different casing (`"Agency-Admin"`) → returns empty collection
- Mixed valid + unknown roles → valid role still maps correctly, unknown roles don't pollute or corrupt the result

**`getUsername()`:**
- Username claim present in JWT → returns claim value
- Username claim absent → returns null

## Notable finding

Test #11 reveals an inconsistency: `extractRealmAuthorities()` uses `Authority.fromRoleName` directly, which is **case-sensitive**. This differs from the `RoleAuthorizationAuthorityMapper.mapAuthorities(Collection<GrantedAuthority>)` overload, which lowercases role names before lookup. A role like `"Agency-Admin"` (capitalized, as some IdPs might send) would silently fail to map via this path. Documented as current behavior — not fixed in this PR, flagging for visibility.

## Approach

Unit tests using real `Jwt` construction (`new Jwt(...)`) — no Mockito mock for `Jwt` itself, following the existing pattern in `TechnicalUserTenantResolverTest`. `SecurityContext`/`Authentication` mocked only for `getUsername()` tests, with `@AfterEach SecurityContextHolder.clearContext()` to prevent state leakage between tests.

## Test results

Tests run: 12, Failures: 0, Errors: 0, Skipped: 0 — BUILD SUCCESS

## Files changed

| File | Action |
|---|---|
| `src/test/java/de/caritas/cob/agencyservice/config/security/AuthorisationServiceTest.java` | Created |

No production code changes.

## Checklist
- [x] Business logic covered (role extraction, authority mapping)
- [x] Happy paths covered
- [x] Error handling covered (null claims, type mismatch)
- [x] Edge cases covered (empty list, unknown role, casing, mixed roles)
- [x] Security and authorization — core focus of this test suite
- [x] No production code changes
- [x] All 12 tests pass locally