### PR TITLE
AVV / Legal flow — Fachbereich DSE + Beratungszentrum address (review-only, part of TenantService#46)

### DIFF
--- a/src/main/java/de/caritas/cob/agencyservice/api/repository/agency/Agency.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/repository/agency/Agency.java
@@ -78,6 +78,34 @@ public class Agency implements TenantAware {
   @Column(name = "city")
   private String city;
 
+  @Size(max = 255)
+  @Column(name = "street")
+  private String street;
+
+  @Size(max = 20)
+  @Column(name = "house_number")
+  private String houseNumber;
+
+  @Size(max = 100)
+  @Column(name = "floor_building")
+  private String floorBuilding;
+
+  @Size(max = 100)
+  @Column(name = "country")
+  private String country;
+
+  @Size(max = 30)
+  @Column(name = "phone")
+  private String phone;
+
+  @Size(max = 30)
+  @Column(name = "phone_secondary")
+  private String phoneSecondary;
+
+  @Size(max = 255)
+  @Column(name = "email")
+  private String email;
+
   @Column(name = "is_team_agency", nullable = false)
   @Convert(converter = NumericBooleanConverter.class)
   private boolean teamAgency;

--- a/src/main/java/de/caritas/cob/agencyservice/api/repository/agencytopic/AgencyTopic.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/repository/agencytopic/AgencyTopic.java
@@ -5,6 +5,8 @@ import de.caritas.cob.agencyservice.api.repository.agency.Agency;
 import java.time.LocalDateTime;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -47,6 +49,15 @@ public class AgencyTopic {
 
   @Column(name = "update_date")
   private LocalDateTime updateDate;
+
+  /** This department's (Fachbereich) own data privacy policy (Datenschutzerklärung) text. */
+  @Column(name = "content_dpp")
+  private String contentDpp;
+
+  @Builder.Default
+  @Enumerated(EnumType.STRING)
+  @Column(name = "publication_status", nullable = false)
+  private PublicationStatus publicationStatus = PublicationStatus.DRAFT;
 
   @Transient TopicDTO topicData = new TopicDTO();
 }

--- a/src/main/java/de/caritas/cob/agencyservice/api/repository/agencytopic/AgencyTopic.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/repository/agencytopic/AgencyTopic.java
@@ -13,6 +13,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
 import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
@@ -60,4 +61,15 @@ public class AgencyTopic {
   private PublicationStatus publicationStatus = PublicationStatus.DRAFT;
 
   @Transient TopicDTO topicData = new TopicDTO();
+
+  /**
+   * Guarantees the NOT NULL publication_status is never null on the no-arg / all-args construction
+   * paths (Lombok's @Builder.Default only applies to the builder).
+   */
+  @PrePersist
+  void applyDefaults() {
+    if (publicationStatus == null) {
+      publicationStatus = PublicationStatus.DRAFT;
+    }
+  }
 }

--- a/src/main/java/de/caritas/cob/agencyservice/api/repository/agencytopic/PublicationStatus.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/repository/agencytopic/PublicationStatus.java
@@ -1,0 +1,12 @@
+package de.caritas.cob.agencyservice.api.repository.agencytopic;
+
+/**
+ * Publication state of a department's (Fachbereich = agency × topic) legal text. Mirrors the {@code
+ * agency_topic.publication_status} column (default {@code DRAFT}) and aligns with ADR-003. A
+ * {@code DRAFT} department-level data privacy policy may exist while counselling starts; only a
+ * {@code PUBLISHED} one is presented to clients as a finalised legal document.
+ */
+public enum PublicationStatus {
+  DRAFT,
+  PUBLISHED
+}

--- a/src/main/resources/db/changelog/agencyservice-dev-master.xml
+++ b/src/main/resources/db/changelog/agencyservice-dev-master.xml
@@ -28,4 +28,5 @@
 	<include file="db/changelog/changeset/0019_agency_admin_control/0019_changeSet.xml"/>
 	<include file="db/changelog/changeset/0020_agency_settings/0020_changeSet.xml"/>
 	<include file="db/changelog/changeset/0021_agency_topic_legal/0021_changeSet.xml"/>
+	<include file="db/changelog/changeset/0022_agency_address_contact/0022_changeSet.xml"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/agencyservice-dev-master.xml
+++ b/src/main/resources/db/changelog/agencyservice-dev-master.xml
@@ -27,4 +27,5 @@
 	<include file="db/changelog/changeset/0017_add_agency_logo/0017_changeSet.xml"/>
 	<include file="db/changelog/changeset/0019_agency_admin_control/0019_changeSet.xml"/>
 	<include file="db/changelog/changeset/0020_agency_settings/0020_changeSet.xml"/>
+	<include file="db/changelog/changeset/0021_agency_topic_legal/0021_changeSet.xml"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/agencyservice-local-master.xml
+++ b/src/main/resources/db/changelog/agencyservice-local-master.xml
@@ -27,4 +27,5 @@
   <include file="db/changelog/changeset/0019_agency_admin_control/0019_changeSet.xml"/>
   <include file="db/changelog/changeset/0020_agency_settings/0020_changeSet.xml"/>
   <include file="db/changelog/changeset/0021_agency_topic_legal/0021_changeSet.xml"/>
+  <include file="db/changelog/changeset/0022_agency_address_contact/0022_changeSet.xml"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/agencyservice-local-master.xml
+++ b/src/main/resources/db/changelog/agencyservice-local-master.xml
@@ -26,4 +26,5 @@
   <include file="db/changelog/changeset/0017_add_agency_logo/0017_changeSet.xml"/>
   <include file="db/changelog/changeset/0019_agency_admin_control/0019_changeSet.xml"/>
   <include file="db/changelog/changeset/0020_agency_settings/0020_changeSet.xml"/>
+  <include file="db/changelog/changeset/0021_agency_topic_legal/0021_changeSet.xml"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/agencyservice-prod-master.xml
+++ b/src/main/resources/db/changelog/agencyservice-prod-master.xml
@@ -23,4 +23,5 @@
 	<include file="db/changelog/changeset/0017_add_agency_logo/0017_changeSet.xml"/>
 	<include file="db/changelog/changeset/0019_agency_admin_control/0019_changeSet.xml"/>
 	<include file="db/changelog/changeset/0020_agency_settings/0020_changeSet.xml"/>
+	<include file="db/changelog/changeset/0021_agency_topic_legal/0021_changeSet.xml"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/agencyservice-prod-master.xml
+++ b/src/main/resources/db/changelog/agencyservice-prod-master.xml
@@ -24,4 +24,5 @@
 	<include file="db/changelog/changeset/0019_agency_admin_control/0019_changeSet.xml"/>
 	<include file="db/changelog/changeset/0020_agency_settings/0020_changeSet.xml"/>
 	<include file="db/changelog/changeset/0021_agency_topic_legal/0021_changeSet.xml"/>
+	<include file="db/changelog/changeset/0022_agency_address_contact/0022_changeSet.xml"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/agencyservice-staging-master.xml
+++ b/src/main/resources/db/changelog/agencyservice-staging-master.xml
@@ -23,4 +23,5 @@
 	<include file="db/changelog/changeset/0017_add_agency_logo/0017_changeSet.xml"/>
 	<include file="db/changelog/changeset/0019_agency_admin_control/0019_changeSet.xml"/>
 	<include file="db/changelog/changeset/0020_agency_settings/0020_changeSet.xml"/>
+	<include file="db/changelog/changeset/0021_agency_topic_legal/0021_changeSet.xml"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/agencyservice-staging-master.xml
+++ b/src/main/resources/db/changelog/agencyservice-staging-master.xml
@@ -24,4 +24,5 @@
 	<include file="db/changelog/changeset/0019_agency_admin_control/0019_changeSet.xml"/>
 	<include file="db/changelog/changeset/0020_agency_settings/0020_changeSet.xml"/>
 	<include file="db/changelog/changeset/0021_agency_topic_legal/0021_changeSet.xml"/>
+	<include file="db/changelog/changeset/0022_agency_address_contact/0022_changeSet.xml"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/changeset/0021_agency_topic_legal/0021_changeSet.xml
+++ b/src/main/resources/db/changelog/changeset/0021_agency_topic_legal/0021_changeSet.xml
@@ -1,0 +1,11 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd">
+    <changeSet author="oriso" id="addAgencyTopicLegal">
+        <sqlFile path="db/changelog/changeset/0021_agency_topic_legal/addAgencyTopicLegal.sql" stripComments="true"/>
+        <rollback>
+            <sqlFile path="db/changelog/changeset/0021_agency_topic_legal/addAgencyTopicLegal-rollback.sql" stripComments="true"/>
+        </rollback>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changeset/0021_agency_topic_legal/addAgencyTopicLegal-rollback.sql
+++ b/src/main/resources/db/changelog/changeset/0021_agency_topic_legal/addAgencyTopicLegal-rollback.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `agencyservice`.`agency_topic` DROP COLUMN IF EXISTS content_dpp;
+ALTER TABLE `agencyservice`.`agency_topic` DROP COLUMN IF EXISTS publication_status;

--- a/src/main/resources/db/changelog/changeset/0021_agency_topic_legal/addAgencyTopicLegal.sql
+++ b/src/main/resources/db/changelog/changeset/0021_agency_topic_legal/addAgencyTopicLegal.sql
@@ -1,0 +1,5 @@
+ALTER TABLE `agencyservice`.`agency_topic`
+ADD COLUMN IF NOT EXISTS content_dpp longtext NULL;
+
+ALTER TABLE `agencyservice`.`agency_topic`
+ADD COLUMN IF NOT EXISTS publication_status varchar(20) NOT NULL DEFAULT 'DRAFT';

--- a/src/main/resources/db/changelog/changeset/0022_agency_address_contact/0022_changeSet.xml
+++ b/src/main/resources/db/changelog/changeset/0022_agency_address_contact/0022_changeSet.xml
@@ -1,0 +1,11 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd">
+    <changeSet author="oriso" id="addAgencyAddressContact">
+        <sqlFile path="db/changelog/changeset/0022_agency_address_contact/addAgencyAddressContact.sql" stripComments="true"/>
+        <rollback>
+            <sqlFile path="db/changelog/changeset/0022_agency_address_contact/addAgencyAddressContact-rollback.sql" stripComments="true"/>
+        </rollback>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changeset/0022_agency_address_contact/addAgencyAddressContact-rollback.sql
+++ b/src/main/resources/db/changelog/changeset/0022_agency_address_contact/addAgencyAddressContact-rollback.sql
@@ -1,0 +1,7 @@
+ALTER TABLE `agencyservice`.`agency` DROP COLUMN IF EXISTS street;
+ALTER TABLE `agencyservice`.`agency` DROP COLUMN IF EXISTS house_number;
+ALTER TABLE `agencyservice`.`agency` DROP COLUMN IF EXISTS floor_building;
+ALTER TABLE `agencyservice`.`agency` DROP COLUMN IF EXISTS country;
+ALTER TABLE `agencyservice`.`agency` DROP COLUMN IF EXISTS phone;
+ALTER TABLE `agencyservice`.`agency` DROP COLUMN IF EXISTS phone_secondary;
+ALTER TABLE `agencyservice`.`agency` DROP COLUMN IF EXISTS email;

--- a/src/main/resources/db/changelog/changeset/0022_agency_address_contact/addAgencyAddressContact.sql
+++ b/src/main/resources/db/changelog/changeset/0022_agency_address_contact/addAgencyAddressContact.sql
@@ -1,0 +1,7 @@
+ALTER TABLE `agencyservice`.`agency` ADD COLUMN IF NOT EXISTS street varchar(255) NULL;
+ALTER TABLE `agencyservice`.`agency` ADD COLUMN IF NOT EXISTS house_number varchar(20) NULL;
+ALTER TABLE `agencyservice`.`agency` ADD COLUMN IF NOT EXISTS floor_building varchar(100) NULL;
+ALTER TABLE `agencyservice`.`agency` ADD COLUMN IF NOT EXISTS country varchar(100) NULL;
+ALTER TABLE `agencyservice`.`agency` ADD COLUMN IF NOT EXISTS phone varchar(30) NULL;
+ALTER TABLE `agencyservice`.`agency` ADD COLUMN IF NOT EXISTS phone_secondary varchar(30) NULL;
+ALTER TABLE `agencyservice`.`agency` ADD COLUMN IF NOT EXISTS email varchar(255) NULL;

--- a/src/test/java/de/caritas/cob/agencyservice/api/repository/agency/AgencyAddressRepositoryTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/repository/agency/AgencyAddressRepositoryTest.java
@@ -1,0 +1,70 @@
+package de.caritas.cob.agencyservice.api.repository.agency;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+/**
+ * Self-contained persistence test for the Beratungszentrum (agency centre) address/contact fields
+ * that the admin create/edit forms need. Overrides the dialect to H2 so Hibernate builds the schema
+ * from the entities and the test is runnable in a bare local build.
+ */
+@TestPropertySource(
+    properties = {
+      "spring.profiles.active=testing",
+      "spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect",
+      "spring.jpa.hibernate.ddl-auto=create-drop"
+    })
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.ANY)
+@ExtendWith(SpringExtension.class)
+@DataJpaTest
+class AgencyAddressRepositoryTest {
+
+  @Autowired private TestEntityManager em;
+
+  @Test
+  void persist_Should_storeAddressAndContactFields() {
+    // given
+    var now = LocalDateTime.now();
+    Agency agency =
+        Agency.builder()
+            .name("Beratungszentrum")
+            .consultingTypeId(1)
+            .dataProtectionResponsibleEntity(DataProtectionResponsibleEntity.AGENCY_RESPONSIBLE)
+            .dataProtectionOfficerContactData("officer")
+            .dataProtectionAlternativeContactData("alternative")
+            .dataProtectionAgencyResponsibleContactData("agency")
+            .street("Musterstraße")
+            .houseNumber("12a")
+            .floorBuilding("2. Stock, Haus A")
+            .country("Deutschland")
+            .phone("+49301234567")
+            .phoneSecondary("+49301234568")
+            .email("kontakt@zentrum.de")
+            .createDate(now)
+            .updateDate(now)
+            .build();
+
+    // when
+    Long id = em.persistFlushFind(agency).getId();
+    em.clear();
+
+    // then
+    Agency reloaded = em.find(Agency.class, id);
+    assertThat(reloaded.getStreet()).isEqualTo("Musterstraße");
+    assertThat(reloaded.getHouseNumber()).isEqualTo("12a");
+    assertThat(reloaded.getFloorBuilding()).isEqualTo("2. Stock, Haus A");
+    assertThat(reloaded.getCountry()).isEqualTo("Deutschland");
+    assertThat(reloaded.getPhone()).isEqualTo("+49301234567");
+    assertThat(reloaded.getPhoneSecondary()).isEqualTo("+49301234568");
+    assertThat(reloaded.getEmail()).isEqualTo("kontakt@zentrum.de");
+  }
+}

--- a/src/test/java/de/caritas/cob/agencyservice/api/repository/agencytopic/AgencyTopicLegalRepositoryTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/repository/agencytopic/AgencyTopicLegalRepositoryTest.java
@@ -1,0 +1,93 @@
+package de.caritas.cob.agencyservice.api.repository.agencytopic;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import de.caritas.cob.agencyservice.api.repository.agency.Agency;
+import de.caritas.cob.agencyservice.api.repository.agency.DataProtectionResponsibleEntity;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+/**
+ * Self-contained persistence test for the per-Fachbereich (department = agency × topic) legal model:
+ * each {@code agency_topic} carries its own data privacy policy ({@code content_dpp}) and a
+ * publication status. The module's other {@code @DataJpaTest} tests assume an externally provisioned
+ * schema (MariaDB dialect), so this test overrides the dialect to H2 and lets Hibernate build the
+ * schema from the entities — runnable and meaningful in a bare local build.
+ */
+@TestPropertySource(
+    properties = {
+      "spring.profiles.active=testing",
+      "spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect",
+      "spring.jpa.hibernate.ddl-auto=create-drop"
+    })
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.ANY)
+@ExtendWith(SpringExtension.class)
+@DataJpaTest
+class AgencyTopicLegalRepositoryTest {
+
+  @Autowired private TestEntityManager em;
+
+  private Agency persistAgency(String name) {
+    var now = LocalDateTime.now();
+    return em.persistFlushFind(
+        Agency.builder()
+            .name(name)
+            .consultingTypeId(1)
+            .dataProtectionResponsibleEntity(DataProtectionResponsibleEntity.AGENCY_RESPONSIBLE)
+            .dataProtectionOfficerContactData("officer")
+            .dataProtectionAlternativeContactData("alternative")
+            .dataProtectionAgencyResponsibleContactData("agency")
+            .createDate(now)
+            .updateDate(now)
+            .build());
+  }
+
+  @Test
+  void persist_Should_storeFachbereichDppAndPublicationStatus() {
+    // given a Beratungszentrum (agency) and a Fachbereich (agency × topic) with its own DSE
+    var now = LocalDateTime.now();
+    Agency agency = persistAgency("Beratungszentrum Test");
+    AgencyTopic department =
+        AgencyTopic.builder()
+            .agency(agency)
+            .topicId(42L)
+            .contentDpp("<p>Datenschutzerklärung Fachbereich</p>")
+            .publicationStatus(PublicationStatus.PUBLISHED)
+            .createDate(now)
+            .updateDate(now)
+            .build();
+
+    // when
+    Long id = em.persistFlushFind(department).getId();
+    em.clear();
+
+    // then
+    AgencyTopic reloaded = em.find(AgencyTopic.class, id);
+    assertThat(reloaded.getContentDpp()).isEqualTo("<p>Datenschutzerklärung Fachbereich</p>");
+    assertThat(reloaded.getPublicationStatus()).isEqualTo(PublicationStatus.PUBLISHED);
+  }
+
+  @Test
+  void publicationStatus_Should_defaultToDraft_When_notSet() {
+    // given
+    var now = LocalDateTime.now();
+    Agency agency = persistAgency("Zentrum 2");
+    AgencyTopic department =
+        AgencyTopic.builder().agency(agency).topicId(7L).createDate(now).updateDate(now).build();
+
+    // when
+    Long id = em.persistFlushFind(department).getId();
+    em.clear();
+
+    // then
+    assertThat(em.find(AgencyTopic.class, id).getPublicationStatus())
+        .isEqualTo(PublicationStatus.DRAFT);
+  }
+}

--- a/src/test/java/de/caritas/cob/agencyservice/api/repository/agencytopic/AgencyTopicTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/repository/agencytopic/AgencyTopicTest.java
@@ -1,0 +1,29 @@
+package de.caritas.cob.agencyservice.api.repository.agencytopic;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+/** Pure unit test for the @PrePersist NOT-NULL defaulting of publication_status (no DB). */
+class AgencyTopicTest {
+
+  @Test
+  void applyDefaults_Should_defaultPublicationStatusToDraft_When_null() {
+    var topic = new AgencyTopic();
+    topic.setPublicationStatus(null);
+
+    topic.applyDefaults();
+
+    assertThat(topic.getPublicationStatus()).isEqualTo(PublicationStatus.DRAFT);
+  }
+
+  @Test
+  void applyDefaults_Should_notOverwrite_When_alreadySet() {
+    var topic = new AgencyTopic();
+    topic.setPublicationStatus(PublicationStatus.PUBLISHED);
+
+    topic.applyDefaults();
+
+    assertThat(topic.getPublicationStatus()).isEqualTo(PublicationStatus.PUBLISHED);
+  }
+}


### PR DESCRIPTION
## ⚠️ Review-only — not merge-ready yet
AgencyService part of the AVV / Legal EPIC (OpenResilienceInitiative/ORISO-TenantService#46): per-Fachbereich data privacy policy + Beratungszentrum (agency centre) address/contact. Opened for early **CodeRabbit + @shazia-k** review.

## What
- `agency_topic`: `content_dpp` (the department's own Datenschutzerklärung) + `publication_status` (DRAFT/PUBLISHED, default DRAFT) — Liquibase 0021. Implements "DSE per Fachbereich" (department = agency × topic), aligned with ADR-003.
- `agency` (Beratungszentrum): `street`, `house_number`, `floor_building`, `country`, `phone`, `phone_secondary`, `email` — Liquibase 0022 (the structured address/contact data the admin create/edit forms need).
- `@PrePersist` guards the NOT-NULL `publication_status` default (Lombok `@Builder.Default` only covers the builder path, not the no-arg/all-args JPA paths).

## Review status
Reviewed by 3 agents + hardened. `ADD COLUMN IF NOT EXISTS` keeps this collision-safe vs the parallel ADR-003 work in ORISO-Database. Full context in #46.

## Tests
Self-sufficient `@DataJpaTest` mapping tests (H2 dialect override) + `@PrePersist` unit tests — green (JDK 17).

Part of EPIC OpenResilienceInitiative/ORISO-TenantService#46. Sibling PR: OpenResilienceInitiative/ORISO-TenantService#47.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
