### PR TITLE
test: AS-TEST-07 add unit test for topic service

### DIFF
--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/service/agencyadmincontrol/AgencyAdminControlsServiceTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/service/agencyadmincontrol/AgencyAdminControlsServiceTest.java
@@ -1,0 +1,264 @@
+package de.caritas.cob.agencyservice.api.admin.service.agencyadmincontrol;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.RuntimeJsonMappingException;
+import de.caritas.cob.agencyservice.api.model.AgencyAdminControls;
+import de.caritas.cob.agencyservice.api.model.Settings;
+import de.caritas.cob.agencyservice.api.repository.agencyadmincontrol.AgencyAdminControlEntity;
+import de.caritas.cob.agencyservice.api.repository.agencyadmincontrol.AgencyAdminControlRepository;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AgencyAdminControlsServiceTest {
+
+  @InjectMocks
+  private AgencyAdminControlsService agencyAdminControlsService;
+
+  @Mock
+  private AgencyAdminControlRepository agencyAdminControlRepository;
+
+  @Mock
+  private AgencyAdminControlsConverter agencyAdminControlsConverter;
+
+  private AgencyAdminControls defaultControls;
+  private AgencyAdminControlsSettings defaultSettings;
+
+  @BeforeEach
+  void setUp() {
+    defaultSettings = AgencyAdminControlsSettings.builder().permissionsPageEnabled(true).build();
+    defaultControls = new AgencyAdminControls().permissionsPageEnabled(true);
+  }
+
+  @Test
+  void getControls_Should_ReturnParsedControls_WhenDbHasValidJson() {
+    when(agencyAdminControlRepository.findTopByOrderByIdAsc())
+        .thenReturn(Optional.of(entityWithControls("{\"permissionsPageEnabled\":false}", 1L)));
+    AgencyAdminControls expected =
+        new AgencyAdminControls().permissionsPageEnabled(false);
+    when(agencyAdminControlsConverter.toAgencyAdminControls(
+            argThat(settings -> Boolean.FALSE.equals(settings.getPermissionsPageEnabled()))))
+        .thenReturn(expected);
+
+    AgencyAdminControls result = agencyAdminControlsService.getControls();
+
+    assertThat(result).isSameAs(expected);
+    verify(agencyAdminControlsConverter, never()).createDefaultControlsSettings();
+  }
+
+  @Test
+  void getControls_Should_ReturnDefaultControls_WhenDbHasNoRecord() {
+    when(agencyAdminControlRepository.findTopByOrderByIdAsc()).thenReturn(Optional.empty());
+    stubConverterDefaults();
+
+    AgencyAdminControls result = agencyAdminControlsService.getControls();
+
+    assertThat(result).isSameAs(defaultControls);
+    verify(agencyAdminControlsConverter).createDefaultControlsSettings();
+  }
+
+  @Test
+  void getControls_Should_ReturnDefaultControls_WhenDbHasEmptyStringJson() {
+    when(agencyAdminControlRepository.findTopByOrderByIdAsc())
+        .thenReturn(Optional.of(entityWithControls("", 1L)));
+    stubConverterDefaults();
+
+    AgencyAdminControls result = agencyAdminControlsService.getControls();
+
+    assertThat(result).isSameAs(defaultControls);
+    verify(agencyAdminControlsConverter).createDefaultControlsSettings();
+  }
+
+  @Test
+  void getControls_Should_ReturnDefaultControls_WhenDbHasSpaceJson() {
+    when(agencyAdminControlRepository.findTopByOrderByIdAsc())
+        .thenReturn(Optional.of(entityWithControls(" ", 1L)));
+    stubConverterDefaults();
+
+    AgencyAdminControls result = agencyAdminControlsService.getControls();
+
+    assertThat(result).isSameAs(defaultControls);
+    verify(agencyAdminControlsConverter).createDefaultControlsSettings();
+  }
+
+  @Test
+  void getControls_Should_ReturnDefaultControls_WhenDbHasTabJson() {
+    when(agencyAdminControlRepository.findTopByOrderByIdAsc())
+        .thenReturn(Optional.of(entityWithControls("\t", 1L)));
+    stubConverterDefaults();
+
+    AgencyAdminControls result = agencyAdminControlsService.getControls();
+
+    assertThat(result).isSameAs(defaultControls);
+    verify(agencyAdminControlsConverter).createDefaultControlsSettings();
+  }
+
+  @Test
+  void getControls_Should_ReturnDefaultControls_WhenDbHasEmptyObjectJson() {
+    when(agencyAdminControlRepository.findTopByOrderByIdAsc())
+        .thenReturn(Optional.of(entityWithControls("{}", 1L)));
+    stubConverterDefaults();
+
+    AgencyAdminControls result = agencyAdminControlsService.getControls();
+
+    assertThat(result).isSameAs(defaultControls);
+    verify(agencyAdminControlsConverter).createDefaultControlsSettings();
+  }
+
+  @Test
+  void getControls_Should_ReturnDefaultControls_WhenDbHasWhitespaceWrappedEmptyObjectJson() {
+    when(agencyAdminControlRepository.findTopByOrderByIdAsc())
+        .thenReturn(Optional.of(entityWithControls(" {} ", 1L)));
+    stubConverterDefaults();
+
+    AgencyAdminControls result = agencyAdminControlsService.getControls();
+
+    assertThat(result).isSameAs(defaultControls);
+    verify(agencyAdminControlsConverter).createDefaultControlsSettings();
+  }
+
+  @Test
+  void getControls_Should_ReturnDefaultControls_WhenDbHasNullLiteralJson() {
+    when(agencyAdminControlRepository.findTopByOrderByIdAsc())
+        .thenReturn(Optional.of(entityWithControls("null", 1L)));
+    stubConverterDefaults();
+
+    AgencyAdminControls result = agencyAdminControlsService.getControls();
+
+    assertThat(result).isSameAs(defaultControls);
+    verify(agencyAdminControlsConverter).createDefaultControlsSettings();
+  }
+
+  @Test
+  void getControls_Should_ThrowRuntimeJsonMappingException_WhenDbHasInvalidJson() {
+    when(agencyAdminControlRepository.findTopByOrderByIdAsc())
+        .thenReturn(Optional.of(entityWithControls("{not-valid-json", 1L)));
+
+    assertThrows(RuntimeJsonMappingException.class, () -> agencyAdminControlsService.getControls());
+  }
+
+  @Test
+  void updateControls_Should_CreateNewEntity_WhenDbHasNoRecord() {
+    AgencyAdminControls input = new AgencyAdminControls().permissionsPageEnabled(false);
+    AgencyAdminControlsSettings settings =
+        AgencyAdminControlsSettings.builder().permissionsPageEnabled(false).build();
+    stubUpdateRoundTrip(input, settings);
+    when(agencyAdminControlRepository.findTopByOrderByIdAsc()).thenReturn(Optional.empty());
+    when(agencyAdminControlRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+    AgencyAdminControls result = agencyAdminControlsService.updateControls(input);
+
+    assertThat(result).isSameAs(input);
+    ArgumentCaptor<AgencyAdminControlEntity> captor =
+        ArgumentCaptor.forClass(AgencyAdminControlEntity.class);
+    verify(agencyAdminControlRepository).save(captor.capture());
+    verify(agencyAdminControlRepository, times(1)).findTopByOrderByIdAsc();
+    assertThat(captor.getValue().getId()).isNull();
+    assertThat(captor.getValue().getControls()).contains("\"permissionsPageEnabled\":false");
+  }
+
+  @Test
+  void updateControls_Should_UpdateExistingEntity_WhenDbHasRecord() {
+    AgencyAdminControls input = new AgencyAdminControls().permissionsPageEnabled(false);
+    AgencyAdminControlsSettings settings =
+        AgencyAdminControlsSettings.builder().permissionsPageEnabled(false).build();
+    stubUpdateRoundTrip(input, settings);
+    AgencyAdminControlEntity existing =
+        entityWithControls("{\"permissionsPageEnabled\":true}", 1L);
+    when(agencyAdminControlRepository.findTopByOrderByIdAsc())
+        .thenReturn(Optional.of(existing));
+    when(agencyAdminControlRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+    AgencyAdminControls result = agencyAdminControlsService.updateControls(input);
+
+    assertThat(result).isSameAs(input);
+    ArgumentCaptor<AgencyAdminControlEntity> captor =
+        ArgumentCaptor.forClass(AgencyAdminControlEntity.class);
+    verify(agencyAdminControlRepository).save(captor.capture());
+    verify(agencyAdminControlRepository, times(1)).findTopByOrderByIdAsc();
+    assertThat(captor.getValue().getId()).isEqualTo(1L);
+    assertThat(captor.getValue().getControls()).contains("\"permissionsPageEnabled\":false");
+  }
+
+  @Test
+  void updateControls_Should_SetUpdateDateOnSave() {
+    AgencyAdminControls input = new AgencyAdminControls().permissionsPageEnabled(false);
+    AgencyAdminControlsSettings settings =
+        AgencyAdminControlsSettings.builder().permissionsPageEnabled(false).build();
+    stubUpdateRoundTrip(input, settings);
+    when(agencyAdminControlRepository.findTopByOrderByIdAsc()).thenReturn(Optional.empty());
+    when(agencyAdminControlRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+    LocalDateTime before = LocalDateTime.now(ZoneOffset.UTC);
+    agencyAdminControlsService.updateControls(input);
+    LocalDateTime after = LocalDateTime.now(ZoneOffset.UTC);
+
+    ArgumentCaptor<AgencyAdminControlEntity> captor =
+        ArgumentCaptor.forClass(AgencyAdminControlEntity.class);
+    verify(agencyAdminControlRepository).save(captor.capture());
+    assertThat(captor.getValue().getUpdateDate())
+        .isAfterOrEqualTo(before)
+        .isBeforeOrEqualTo(after);
+  }
+
+  @Test
+  void enrichSettingsWithAgencyAdminControls_Should_CreateSettingsAndEnrich_WhenSettingsIsNull() {
+    when(agencyAdminControlRepository.findTopByOrderByIdAsc()).thenReturn(Optional.empty());
+    stubConverterDefaults();
+
+    Settings result = agencyAdminControlsService.enrichSettingsWithAgencyAdminControls(null);
+
+    assertThat(result).isNotNull();
+    assertThat(result.getAgencyAdminControls()).isSameAs(defaultControls);
+  }
+
+  @Test
+  void enrichSettingsWithAgencyAdminControls_Should_EnrichExistingSettings_WhenSettingsIsNotNull() {
+    Settings settings = new Settings().featureStatisticsEnabled(true);
+    when(agencyAdminControlRepository.findTopByOrderByIdAsc()).thenReturn(Optional.empty());
+    stubConverterDefaults();
+
+    Settings result = agencyAdminControlsService.enrichSettingsWithAgencyAdminControls(settings);
+
+    assertSame(settings, result);
+    assertThat(result.getFeatureStatisticsEnabled()).isTrue();
+    assertThat(result.getAgencyAdminControls()).isSameAs(defaultControls);
+  }
+
+  private void stubConverterDefaults() {
+    when(agencyAdminControlsConverter.createDefaultControlsSettings()).thenReturn(defaultSettings);
+    when(agencyAdminControlsConverter.toAgencyAdminControls(defaultSettings))
+        .thenReturn(defaultControls);
+  }
+
+  private void stubUpdateRoundTrip(
+      AgencyAdminControls input, AgencyAdminControlsSettings settings) {
+    when(agencyAdminControlsConverter.toAgencyAdminControlsSettings(input)).thenReturn(settings);
+    when(agencyAdminControlsConverter.toAgencyAdminControls(settings)).thenReturn(input);
+  }
+
+  private AgencyAdminControlEntity entityWithControls(String controlsJson, Long id) {
+    return AgencyAdminControlEntity.builder()
+        .id(id)
+        .controls(controlsJson)
+        .updateDate(LocalDateTime.now(ZoneOffset.UTC))
+        .build();
+  }
+}

--- a/src/test/java/de/caritas/cob/agencyservice/api/service/TopicServiceTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/service/TopicServiceTest.java
@@ -1,0 +1,112 @@
+package de.caritas.cob.agencyservice.api.service;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.when;
+
+import de.caritas.cob.agencyservice.api.service.securityheader.SecurityHeaderSupplier;
+import de.caritas.cob.agencyservice.api.tenant.TenantContext;
+import de.caritas.cob.agencyservice.api.util.AuthenticatedUser;
+import de.caritas.cob.agencyservice.config.apiclient.TopicServiceApiControllerFactory;
+import de.caritas.cob.agencyservice.topicservice.generated.ApiClient;
+import de.caritas.cob.agencyservice.topicservice.generated.web.TopicControllerApi;
+import de.caritas.cob.agencyservice.topicservice.generated.web.model.TopicDTO;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class TopicServiceTest {
+
+  @InjectMocks
+  TopicService topicService;
+
+  @Mock
+  TopicServiceApiControllerFactory topicServiceApiControllerFactory;
+
+  @Mock
+  TopicControllerApi topicControllerApi;
+
+  @Mock
+  SecurityHeaderSupplier securityHeaderSupplier;
+
+  @Mock
+  AuthenticatedUser authenticatedUser;
+
+  @Spy
+  TenantHeaderSupplier tenantHeaderSupplier;
+
+  @Spy
+  ApiClient apiClient;
+
+  @AfterEach
+  void tearDown() {
+    TenantContext.clear();
+  }
+
+  @Test
+  void getAllTopics_Should_ReturnTopicsFromApi() {
+    when(topicServiceApiControllerFactory.createControllerApi()).thenReturn(topicControllerApi);
+    when(topicControllerApi.getApiClient()).thenReturn(apiClient);
+    when(authenticatedUser.getAccessToken()).thenReturn("test-token");
+    when(topicControllerApi.getAllTopics()).thenReturn(List.of(new TopicDTO()));
+
+    var result = topicService.getAllTopics();
+
+    assertEquals(1, result.size());
+  }
+
+  @Test
+  void getAllTopics_Should_AddAuthorizationHeader() {
+    when(authenticatedUser.getAccessToken()).thenReturn("test-bearer-token");
+    when(topicServiceApiControllerFactory.createControllerApi()).thenReturn(topicControllerApi);
+    when(topicControllerApi.getApiClient()).thenReturn(apiClient);
+    when(topicControllerApi.getAllTopics()).thenReturn(List.of());
+
+    topicService.getAllTopics();
+
+    HttpHeaders apiClientHeaders = (HttpHeaders) ReflectionTestUtils
+        .getField(apiClient, "defaultHeaders");
+    assertEquals("Bearer test-bearer-token", apiClientHeaders.get("Authorization").get(0));
+  }
+
+  @Test
+  void getAllTopics_Should_AddTenantHeader_When_MultitenancyEnabled() {
+    TenantContext.setCurrentTenant(1L);
+    ReflectionTestUtils.setField(tenantHeaderSupplier, "multitenancy", true);
+    when(authenticatedUser.getAccessToken()).thenReturn("token");
+    when(topicServiceApiControllerFactory.createControllerApi()).thenReturn(topicControllerApi);
+    when(topicControllerApi.getApiClient()).thenReturn(apiClient);
+    when(topicControllerApi.getAllTopics()).thenReturn(List.of());
+
+    topicService.getAllTopics();
+
+    HttpHeaders apiClientHeaders = (HttpHeaders) ReflectionTestUtils
+        .getField(apiClient, "defaultHeaders");
+    assertEquals("1", apiClientHeaders.get("tenantId").get(0));
+  }
+
+  @Test
+  void getAllTopics_Should_NotAddTenantHeader_When_MultitenancyDisabled() {
+    TenantContext.setCurrentTenant(1L);
+    ReflectionTestUtils.setField(tenantHeaderSupplier, "multitenancy", false);
+    when(authenticatedUser.getAccessToken()).thenReturn("token");
+    when(topicServiceApiControllerFactory.createControllerApi()).thenReturn(topicControllerApi);
+    when(topicControllerApi.getApiClient()).thenReturn(apiClient);
+    when(topicControllerApi.getAllTopics()).thenReturn(List.of());
+
+    topicService.getAllTopics();
+
+    HttpHeaders apiClientHeaders = (HttpHeaders) ReflectionTestUtils
+        .getField(apiClient, "defaultHeaders");
+    assertNull(apiClientHeaders.get("tenantId"));
+  }
+
+}


### PR DESCRIPTION
#### [Issue #75 ](https://github.com/OpenResilienceInitiative/ORISO-AgencyService/issues/75)

## Summary

Adds 4 unit tests for `TopicService` — previously had zero dedicated test coverage despite being used by `TopicEnrichmentService` and `AgencyTopicEnrichmentService` for topic lookups across the agency flow.

## What was tested

- **Delegation**: `getAllTopics()` correctly delegates to the generated `TopicControllerApi` and returns the topic list
- **Authorization header**: Keycloak bearer token from `AuthenticatedUser.getAccessToken()` is correctly propagated to the API client's default headers — this service uses auth token directly, unlike `ApplicationSettingsService` which uses CSRF headers
- **Tenant header (enabled)**: `tenantId` header is added when multitenancy is enabled and `TenantContext` has a current tenant set
- **Tenant header (disabled)**: `tenantId` header is **not** added when multitenancy is disabled, even with a tenant context present

## Approach

Unit tests with mocked `TopicServiceApiControllerFactory`, `TopicControllerApi`, `SecurityHeaderSupplier`, and `AuthenticatedUser`. Real `@Spy TenantHeaderSupplier` and `@Spy ApiClient` used so actual header-propagation logic executes. `ReflectionTestUtils` used to inspect `apiClient`'s `defaultHeaders` field and toggle the `multitenancy` flag. Follows the existing `ConsultingTypeServiceTest` and `ApplicationSettingsServiceTest` patterns.

`@Cacheable` on `getAllTopics()` is not tested — inactive without a Spring proxy, out of scope per the team's focused-unit-test approach.

## Notable findings

- `SecurityHeaderSupplier` is injected into `TopicService` but **never used** in `addDefaultHeaders()` — dead dependency, included as `@Mock` for `@InjectMocks` completeness only. Flagged as a cleanup candidate.
- `TopicServiceApiControllerFactory` uses `${consulting.type.service.api.url}` — may be intentional shared URL or a copy-paste from consulting-type config, worth confirming.
- `TopicServiceApiClient` exists but is unused in the factory (factory uses plain generated `ApiClient`).

## Test results

Tests run: 4, Failures: 0, Errors: 0, Skipped: 0 — BUILD SUCCESS

## Files changed

| File | Action |
|---|---|
| `src/test/java/de/caritas/cob/agencyservice/api/service/TopicServiceTest.java` | Created |

No production code changes.

## Checklist
- [x] API delegation covered
- [x] Authorization header propagation covered
- [x] Tenant header propagation covered (both enabled and disabled)
- [x] No production code changes
- [x] All 4 tests pass locally