### PR TITLE
fix: enable JUnit 4 tests and fix stale mocks after production dependency changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -325,6 +325,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <!-- required only for WebMvc "fluent" API -->
       <groupId>com.c4-soft.springaddons</groupId>
       <artifactId>spring-security-oauth2-test-webmvc-addons</artifactId>

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/service/UserAdminServiceTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/service/UserAdminServiceTest.java
@@ -3,7 +3,6 @@ package de.caritas.cob.agencyservice.api.admin.service;
 import static de.caritas.cob.agencyservice.useradminservice.generated.web.model.AgencyTypeDTO.AgencyTypeEnum.TEAM_AGENCY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -14,12 +13,12 @@ import de.caritas.cob.agencyservice.api.tenant.TenantContext;
 import de.caritas.cob.agencyservice.config.apiclient.UserAdminServiceApiControllerFactory;
 import de.caritas.cob.agencyservice.useradminservice.generated.ApiClient;
 import de.caritas.cob.agencyservice.useradminservice.generated.web.AdminUserControllerApi;
+import de.caritas.cob.agencyservice.useradminservice.generated.web.model.AgencyConsultantResponseDTO;
 import de.caritas.cob.agencyservice.useradminservice.generated.web.model.AgencyTypeDTO;
-import de.caritas.cob.agencyservice.useradminservice.generated.web.model.ConsultantFilter;
-import de.caritas.cob.agencyservice.useradminservice.generated.web.model.ConsultantSearchResultDTO;
 import de.caritas.cob.agencyservice.useradminservice.generated.web.model.Sort;
 import de.caritas.cob.agencyservice.useradminservice.generated.web.model.Sort.FieldEnum;
 import de.caritas.cob.agencyservice.useradminservice.generated.web.model.Sort.OrderEnum;
+import java.util.Collections;
 import java.util.List;
 import org.jeasy.random.EasyRandom;
 import org.junit.Before;
@@ -78,13 +77,12 @@ public class UserAdminServiceTest {
     Long agencyId = 1L;
     int currentPage = 1;
     int perPage = 1;
-    when(this.adminUserControllerApi.getConsultants(any(), any(), any(), any()))
-        .thenReturn(new EasyRandom().nextObject(ConsultantSearchResultDTO.class));
+    when(this.adminUserControllerApi.getAgencyConsultants(any()))
+        .thenReturn(new AgencyConsultantResponseDTO().embedded(Collections.emptyList()));
     this.userAdminService.getConsultantsOfAgency(agencyId, currentPage, perPage);
 
     verify(this.adminUserControllerApi, times(1))
-        .getConsultants(eq(currentPage), eq(perPage),
-            eq(new ConsultantFilter().agencyId(agencyId)), any());
+        .getAgencyConsultants(String.valueOf(agencyId));
     verify(this.apiClient, times(this.httpHeaders.size())).addDefaultHeader(any(), any());
   }
 

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/service/agencyadmincontrol/AgencyAdminControlsServiceTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/service/agencyadmincontrol/AgencyAdminControlsServiceTest.java
@@ -1,0 +1,264 @@
+package de.caritas.cob.agencyservice.api.admin.service.agencyadmincontrol;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.RuntimeJsonMappingException;
+import de.caritas.cob.agencyservice.api.model.AgencyAdminControls;
+import de.caritas.cob.agencyservice.api.model.Settings;
+import de.caritas.cob.agencyservice.api.repository.agencyadmincontrol.AgencyAdminControlEntity;
+import de.caritas.cob.agencyservice.api.repository.agencyadmincontrol.AgencyAdminControlRepository;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AgencyAdminControlsServiceTest {
+
+  @InjectMocks
+  private AgencyAdminControlsService agencyAdminControlsService;
+
+  @Mock
+  private AgencyAdminControlRepository agencyAdminControlRepository;
+
+  @Mock
+  private AgencyAdminControlsConverter agencyAdminControlsConverter;
+
+  private AgencyAdminControls defaultControls;
+  private AgencyAdminControlsSettings defaultSettings;
+
+  @BeforeEach
+  void setUp() {
+    defaultSettings = AgencyAdminControlsSettings.builder().permissionsPageEnabled(true).build();
+    defaultControls = new AgencyAdminControls().permissionsPageEnabled(true);
+  }
+
+  @Test
+  void getControls_Should_ReturnParsedControls_WhenDbHasValidJson() {
+    when(agencyAdminControlRepository.findTopByOrderByIdAsc())
+        .thenReturn(Optional.of(entityWithControls("{\"permissionsPageEnabled\":false}", 1L)));
+    AgencyAdminControls expected =
+        new AgencyAdminControls().permissionsPageEnabled(false);
+    when(agencyAdminControlsConverter.toAgencyAdminControls(
+            argThat(settings -> Boolean.FALSE.equals(settings.getPermissionsPageEnabled()))))
+        .thenReturn(expected);
+
+    AgencyAdminControls result = agencyAdminControlsService.getControls();
+
+    assertThat(result).isSameAs(expected);
+    verify(agencyAdminControlsConverter, never()).createDefaultControlsSettings();
+  }
+
+  @Test
+  void getControls_Should_ReturnDefaultControls_WhenDbHasNoRecord() {
+    when(agencyAdminControlRepository.findTopByOrderByIdAsc()).thenReturn(Optional.empty());
+    stubConverterDefaults();
+
+    AgencyAdminControls result = agencyAdminControlsService.getControls();
+
+    assertThat(result).isSameAs(defaultControls);
+    verify(agencyAdminControlsConverter).createDefaultControlsSettings();
+  }
+
+  @Test
+  void getControls_Should_ReturnDefaultControls_WhenDbHasEmptyStringJson() {
+    when(agencyAdminControlRepository.findTopByOrderByIdAsc())
+        .thenReturn(Optional.of(entityWithControls("", 1L)));
+    stubConverterDefaults();
+
+    AgencyAdminControls result = agencyAdminControlsService.getControls();
+
+    assertThat(result).isSameAs(defaultControls);
+    verify(agencyAdminControlsConverter).createDefaultControlsSettings();
+  }
+
+  @Test
+  void getControls_Should_ReturnDefaultControls_WhenDbHasSpaceJson() {
+    when(agencyAdminControlRepository.findTopByOrderByIdAsc())
+        .thenReturn(Optional.of(entityWithControls(" ", 1L)));
+    stubConverterDefaults();
+
+    AgencyAdminControls result = agencyAdminControlsService.getControls();
+
+    assertThat(result).isSameAs(defaultControls);
+    verify(agencyAdminControlsConverter).createDefaultControlsSettings();
+  }
+
+  @Test
+  void getControls_Should_ReturnDefaultControls_WhenDbHasTabJson() {
+    when(agencyAdminControlRepository.findTopByOrderByIdAsc())
+        .thenReturn(Optional.of(entityWithControls("\t", 1L)));
+    stubConverterDefaults();
+
+    AgencyAdminControls result = agencyAdminControlsService.getControls();
+
+    assertThat(result).isSameAs(defaultControls);
+    verify(agencyAdminControlsConverter).createDefaultControlsSettings();
+  }
+
+  @Test
+  void getControls_Should_ReturnDefaultControls_WhenDbHasEmptyObjectJson() {
+    when(agencyAdminControlRepository.findTopByOrderByIdAsc())
+        .thenReturn(Optional.of(entityWithControls("{}", 1L)));
+    stubConverterDefaults();
+
+    AgencyAdminControls result = agencyAdminControlsService.getControls();
+
+    assertThat(result).isSameAs(defaultControls);
+    verify(agencyAdminControlsConverter).createDefaultControlsSettings();
+  }
+
+  @Test
+  void getControls_Should_ReturnDefaultControls_WhenDbHasWhitespaceWrappedEmptyObjectJson() {
+    when(agencyAdminControlRepository.findTopByOrderByIdAsc())
+        .thenReturn(Optional.of(entityWithControls(" {} ", 1L)));
+    stubConverterDefaults();
+
+    AgencyAdminControls result = agencyAdminControlsService.getControls();
+
+    assertThat(result).isSameAs(defaultControls);
+    verify(agencyAdminControlsConverter).createDefaultControlsSettings();
+  }
+
+  @Test
+  void getControls_Should_ReturnDefaultControls_WhenDbHasNullLiteralJson() {
+    when(agencyAdminControlRepository.findTopByOrderByIdAsc())
+        .thenReturn(Optional.of(entityWithControls("null", 1L)));
+    stubConverterDefaults();
+
+    AgencyAdminControls result = agencyAdminControlsService.getControls();
+
+    assertThat(result).isSameAs(defaultControls);
+    verify(agencyAdminControlsConverter).createDefaultControlsSettings();
+  }
+
+  @Test
+  void getControls_Should_ThrowRuntimeJsonMappingException_WhenDbHasInvalidJson() {
+    when(agencyAdminControlRepository.findTopByOrderByIdAsc())
+        .thenReturn(Optional.of(entityWithControls("{not-valid-json", 1L)));
+
+    assertThrows(RuntimeJsonMappingException.class, () -> agencyAdminControlsService.getControls());
+  }
+
+  @Test
+  void updateControls_Should_CreateNewEntity_WhenDbHasNoRecord() {
+    AgencyAdminControls input = new AgencyAdminControls().permissionsPageEnabled(false);
+    AgencyAdminControlsSettings settings =
+        AgencyAdminControlsSettings.builder().permissionsPageEnabled(false).build();
+    stubUpdateRoundTrip(input, settings);
+    when(agencyAdminControlRepository.findTopByOrderByIdAsc()).thenReturn(Optional.empty());
+    when(agencyAdminControlRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+    AgencyAdminControls result = agencyAdminControlsService.updateControls(input);
+
+    assertThat(result).isSameAs(input);
+    ArgumentCaptor<AgencyAdminControlEntity> captor =
+        ArgumentCaptor.forClass(AgencyAdminControlEntity.class);
+    verify(agencyAdminControlRepository).save(captor.capture());
+    verify(agencyAdminControlRepository, times(1)).findTopByOrderByIdAsc();
+    assertThat(captor.getValue().getId()).isNull();
+    assertThat(captor.getValue().getControls()).contains("\"permissionsPageEnabled\":false");
+  }
+
+  @Test
+  void updateControls_Should_UpdateExistingEntity_WhenDbHasRecord() {
+    AgencyAdminControls input = new AgencyAdminControls().permissionsPageEnabled(false);
+    AgencyAdminControlsSettings settings =
+        AgencyAdminControlsSettings.builder().permissionsPageEnabled(false).build();
+    stubUpdateRoundTrip(input, settings);
+    AgencyAdminControlEntity existing =
+        entityWithControls("{\"permissionsPageEnabled\":true}", 1L);
+    when(agencyAdminControlRepository.findTopByOrderByIdAsc())
+        .thenReturn(Optional.of(existing));
+    when(agencyAdminControlRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+    AgencyAdminControls result = agencyAdminControlsService.updateControls(input);
+
+    assertThat(result).isSameAs(input);
+    ArgumentCaptor<AgencyAdminControlEntity> captor =
+        ArgumentCaptor.forClass(AgencyAdminControlEntity.class);
+    verify(agencyAdminControlRepository).save(captor.capture());
+    verify(agencyAdminControlRepository, times(1)).findTopByOrderByIdAsc();
+    assertThat(captor.getValue().getId()).isEqualTo(1L);
+    assertThat(captor.getValue().getControls()).contains("\"permissionsPageEnabled\":false");
+  }
+
+  @Test
+  void updateControls_Should_SetUpdateDateOnSave() {
+    AgencyAdminControls input = new AgencyAdminControls().permissionsPageEnabled(false);
+    AgencyAdminControlsSettings settings =
+        AgencyAdminControlsSettings.builder().permissionsPageEnabled(false).build();
+    stubUpdateRoundTrip(input, settings);
+    when(agencyAdminControlRepository.findTopByOrderByIdAsc()).thenReturn(Optional.empty());
+    when(agencyAdminControlRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+    LocalDateTime before = LocalDateTime.now(ZoneOffset.UTC);
+    agencyAdminControlsService.updateControls(input);
+    LocalDateTime after = LocalDateTime.now(ZoneOffset.UTC);
+
+    ArgumentCaptor<AgencyAdminControlEntity> captor =
+        ArgumentCaptor.forClass(AgencyAdminControlEntity.class);
+    verify(agencyAdminControlRepository).save(captor.capture());
+    assertThat(captor.getValue().getUpdateDate())
+        .isAfterOrEqualTo(before)
+        .isBeforeOrEqualTo(after);
+  }
+
+  @Test
+  void enrichSettingsWithAgencyAdminControls_Should_CreateSettingsAndEnrich_WhenSettingsIsNull() {
+    when(agencyAdminControlRepository.findTopByOrderByIdAsc()).thenReturn(Optional.empty());
+    stubConverterDefaults();
+
+    Settings result = agencyAdminControlsService.enrichSettingsWithAgencyAdminControls(null);
+
+    assertThat(result).isNotNull();
+    assertThat(result.getAgencyAdminControls()).isSameAs(defaultControls);
+  }
+
+  @Test
+  void enrichSettingsWithAgencyAdminControls_Should_EnrichExistingSettings_WhenSettingsIsNotNull() {
+    Settings settings = new Settings().featureStatisticsEnabled(true);
+    when(agencyAdminControlRepository.findTopByOrderByIdAsc()).thenReturn(Optional.empty());
+    stubConverterDefaults();
+
+    Settings result = agencyAdminControlsService.enrichSettingsWithAgencyAdminControls(settings);
+
+    assertSame(settings, result);
+    assertThat(result.getFeatureStatisticsEnabled()).isTrue();
+    assertThat(result.getAgencyAdminControls()).isSameAs(defaultControls);
+  }
+
+  private void stubConverterDefaults() {
+    when(agencyAdminControlsConverter.createDefaultControlsSettings()).thenReturn(defaultSettings);
+    when(agencyAdminControlsConverter.toAgencyAdminControls(defaultSettings))
+        .thenReturn(defaultControls);
+  }
+
+  private void stubUpdateRoundTrip(
+      AgencyAdminControls input, AgencyAdminControlsSettings settings) {
+    when(agencyAdminControlsConverter.toAgencyAdminControlsSettings(input)).thenReturn(settings);
+    when(agencyAdminControlsConverter.toAgencyAdminControls(settings)).thenReturn(input);
+  }
+
+  private AgencyAdminControlEntity entityWithControls(String controlsJson, Long id) {
+    return AgencyAdminControlEntity.builder()
+        .id(id)
+        .controls(controlsJson)
+        .updateDate(LocalDateTime.now(ZoneOffset.UTC))
+        .build();
+  }
+}

--- a/src/test/java/de/caritas/cob/agencyservice/api/service/AgencyServiceTenantAwareTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/service/AgencyServiceTenantAwareTest.java
@@ -3,11 +3,14 @@ package de.caritas.cob.agencyservice.api.service;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import de.caritas.cob.agencyservice.api.admin.service.agency.AgencySettingsService;
 import de.caritas.cob.agencyservice.api.admin.service.agency.DemographicsConverter;
+import de.caritas.cob.agencyservice.api.admin.service.agencyadmincontrol.AgencyAdminControlsService;
 import de.caritas.cob.agencyservice.api.exception.MissingConsultingTypeException;
 import de.caritas.cob.agencyservice.api.exception.httpresponses.BadRequestException;
 import de.caritas.cob.agencyservice.api.manager.consultingtype.ConsultingTypeManager;
 import de.caritas.cob.agencyservice.api.repository.agency.AgencyRepository;
+import de.caritas.cob.agencyservice.api.service.matrix.MatrixProvisioningService;
 import de.caritas.cob.agencyservice.api.tenant.TenantContext;
 import de.caritas.cob.agencyservice.consultingtypeservice.generated.web.model.ExtendedConsultingTypeResponseDTO;
 import de.caritas.cob.agencyservice.consultingtypeservice.generated.web.model.RegistrationDTO;
@@ -47,6 +50,15 @@ public class AgencyServiceTenantAwareTest {
 
   @Mock
   private ApplicationSettingsService applicationSettingsService;
+
+  @Mock
+  private MatrixProvisioningService matrixProvisioningService;
+
+  @Mock
+  private AgencySettingsService agencySettingsService;
+
+  @Mock
+  private AgencyAdminControlsService agencyAdminControlsService;
 
   private static final Long TENANT_ID = 1L;
 

--- a/src/test/java/de/caritas/cob/agencyservice/api/service/AgencyServiceTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/service/AgencyServiceTest.java
@@ -44,6 +44,7 @@ import de.caritas.cob.agencyservice.api.model.AgencyResponseDTO;
 import de.caritas.cob.agencyservice.api.model.FullAgencyResponseDTO;
 import de.caritas.cob.agencyservice.api.repository.agency.Agency;
 import de.caritas.cob.agencyservice.api.repository.agency.AgencyRepository;
+import de.caritas.cob.agencyservice.api.service.matrix.MatrixProvisioningService;
 import de.caritas.cob.agencyservice.api.tenant.TenantContext;
 import de.caritas.cob.agencyservice.consultingtypeservice.generated.web.model.BasicConsultingTypeResponseDTORegistration;
 import de.caritas.cob.agencyservice.consultingtypeservice.generated.web.model.ExtendedConsultingTypeResponseDTO;
@@ -103,15 +104,27 @@ public class AgencyServiceTest {
   @Mock
   ApplicationSettingsService applicationSettingsService;
 
+  @Mock
+  private MatrixProvisioningService matrixProvisioningService;
+
   private static final Long TENANT_ID = null;
 
   @org.junit.Before
   public void setUp() {
+    ensureAgencyTopics(AGENCY_SUCHT);
+    ensureAgencyTopics(AGENCY_ONLINE_U25);
+    ensureAgencyTopics(AGENCY_OFFLINE);
     when(agencySettingsService.toSettings(any())).thenReturn(new de.caritas.cob.agencyservice.api.model.Settings());
     when(agencyAdminControlsService.enrichSettingsWithAgencyAdminControls(any()))
         .thenAnswer(invocation -> invocation.getArgument(0) != null
             ? invocation.getArgument(0)
             : new de.caritas.cob.agencyservice.api.model.Settings());
+  }
+
+  private void ensureAgencyTopics(Agency agency) {
+    if (agency.getAgencyTopics() == null) {
+      ReflectionTestUtils.setField(agency, "agencyTopics", Collections.emptyList());
+    }
   }
 
   @After


### PR DESCRIPTION
#### [Issue #81](https://github.com/OpenResilienceInitiative/ORISO-AgencyService/issues/81)

## Summary

Two related fixes in one PR:
1. Added `junit-vintage-engine` to `pom.xml` to enable all JUnit 4 test classes on JUnit Platform (Spring Boot 3) — previously 15 test classes with 86 test methods were silently skipped
2. Fixed 3 test classes with stale mocks/stubs that were exposed once vintage engine enabled them

## What was broken and why

**`junit-vintage-engine` missing:**
Spring Boot 3 uses JUnit Platform by default. Without `junit-vintage-engine`, all JUnit 4 tests (`@RunWith`) compile fine but are never executed by Surefire — they silently produce 0 test results. Adding the engine enables them to run on JUnit Platform without migrating to JUnit 5.

**`AgencyServiceTest` (21 failures):**
`AgencyService` now requires `MatrixProvisioningService` as a `@NonNull` constructor dependency. The test never added a mock for it — Mockito could not instantiate `AgencyService`, so all 21 tests failed before assertions ran. Also added `ensureAgencyTopics()` helper in `setUp()` to fix NPE from `agency.getAgencyTopics().stream()` after a production change to agency topics.

**`AgencyServiceTenantAwareTest` (2 failures):**
Same missing `MatrixProvisioningService` mock. Also missing `@Mock AgencySettingsService` and `@Mock AgencyAdminControlsService` which were added as `@NonNull` constructor dependencies.

**`UserAdminServiceTest` (1 error):**
Production changed from `adminUserControllerApi.getConsultants(...)` to `adminUserControllerApi.getAgencyConsultants(agencyId)`. The test still stubbed and verified the old method — `getAgencyConsultants()` returned null → NPE on `.getEmbedded()`.

## What was NOT fixed

**`AgencyAdminControllerTest` (22 errors):** `@SpringBootTest` integration test fails because `application-testing.properties` forces MariaDB driver while the test auto-config supplies an H2 in-memory URL. This is a separate infrastructure issue tracked separately.

## Changes

| File | Change |
|---|---|
| `pom.xml` | Added `junit-vintage-engine` dependency |
| `AgencyServiceTest.java` | Added `@Mock MatrixProvisioningService` + `ensureAgencyTopics()` helper |
| `AgencyServiceTenantAwareTest.java` | Added `@Mock MatrixProvisioningService`, `AgencySettingsService`, `AgencyAdminControlsService` |
| `UserAdminServiceTest.java` | Updated stub + verify from `getConsultants()` to `getAgencyConsultants()` |

No production code changes.

## Test results

Tests run: 26, Failures: 0, Errors: 0, Skipped: 0 — BUILD SUCCESS

**Impact on full suite (before vs after vintage engine):**

| | Before | After |
|---|---|---|
| Tests run | 204 | 290 |
| Previously silent JUnit 4 classes | 0 | 15 |
| New test methods now executing | — | +86 |

## Checklist
- [x] `junit-vintage-engine` added — all JUnit 4 tests now execute on JUnit Platform
- [x] `AgencyServiceTest` 21/21 pass
- [x] `AgencyServiceTenantAwareTest` 2/2 pass
- [x] `UserAdminServiceTest` 3/3 pass
- [x] No production code changes
- [x] `AgencyAdminControllerTest` excluded — tracked separately