### PR TITLE
AVV / Legal flow — Fachbereich DPP publish endpoint (part of #46)

### DIFF
--- a/api/agencyadminservice.yaml
+++ b/api/agencyadminservice.yaml
@@ -258,6 +258,55 @@ paths:
       security:
         - Bearer: [ ]
 
+  /agencyadmin/agencies/{agencyId}/topics/{topicId}/dpp:
+    put:
+      tags:
+        - admin-agency-controller
+      summary: 'Publish or draft-save a department''s (Fachbereich = agency x topic) own data
+      privacy policy (DSE). [Authorization: Role: agency-admin or restricted-agency-admin scoped to
+      its own agencies]'
+      operationId: publishDepartmentDataProtection
+      parameters:
+        - name: agencyId
+          in: path
+          description: Agency Id (Beratungszentrum)
+          required: true
+          schema:
+            type: integer
+            format: int64
+        - name: topicId
+          in: path
+          description: Topic Id (Fachbereich)
+          required: true
+          schema:
+            type: integer
+            format: int64
+      requestBody:
+        content:
+          'application/json':
+            schema:
+              $ref: '#/components/schemas/DepartmentDataProtectionDTO'
+        required: true
+      responses:
+        200:
+          description: OK - department data privacy policy stored
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/DepartmentDataProtectionResponseDTO'
+        400:
+          description: BAD REQUEST - invalid/incomplete request
+        401:
+          description: UNAUTHORIZED - no/invalid role/authorization
+        403:
+          description: FORBIDDEN - caller may not edit this agency
+        404:
+          description: NOT FOUND - department (agency x topic) not found
+        500:
+          description: INTERNAL SERVER ERROR - server encountered unexpected condition
+      security:
+        - Bearer: [ ]
+
   /agencyadmin/controls:
     get:
       tags:
@@ -878,6 +927,36 @@ components:
           enum:
             - 'ASC'
             - 'DESC'
+
+    DepartmentDataProtectionDTO:
+      type: object
+      required:
+        - content
+      properties:
+        content:
+          type: object
+          description: Language code (e.g. de, en) to HTML data privacy policy text (multilingual map)
+          additionalProperties:
+            type: string
+          example:
+            de: '<p>Datenschutzerklärung des Fachbereichs ...</p>'
+            en: '<p>Data privacy policy of the department ...</p>'
+        publish:
+          type: boolean
+          description: 'true = mark PUBLISHED (final legal document); false/absent = keep as DRAFT (draft-save)'
+          default: false
+
+    DepartmentDataProtectionResponseDTO:
+      type: object
+      required:
+        - publicationStatus
+      properties:
+        publicationStatus:
+          type: string
+          description: Resulting publication status of the department's data privacy policy
+          enum:
+            - DRAFT
+            - PUBLISHED
 
     AgencyAdminAllowedPermissionToggles:
       $ref: './components/agency-settings.yaml#/components/schemas/AgencyAdminAllowedPermissionToggles'

--- a/api/agencyadminservice.yaml
+++ b/api/agencyadminservice.yaml
@@ -295,11 +295,9 @@ paths:
               schema:
                 $ref: '#/components/schemas/DepartmentDataProtectionResponseDTO'
         400:
-          description: BAD REQUEST - invalid/incomplete request
+          description: BAD REQUEST - invalid/incomplete request, or caller may not edit this agency
         401:
           description: UNAUTHORIZED - no/invalid role/authorization
-        403:
-          description: FORBIDDEN - caller may not edit this agency
         404:
           description: NOT FOUND - department (agency x topic) not found
         500:

--- a/pom.xml
+++ b/pom.xml
@@ -51,9 +51,16 @@
     <hibernate.search.version>6.1.1.Final</hibernate.search.version>
     <springfox.boot.starter.version>3.0.0</springfox.boot.starter.version>
     <sentry.version>8.43.2</sentry.version>
+    <owasp.java.html.sanitizer>20211018.1</owasp.java.html.sanitizer>
   </properties>
 
   <dependencies>
+    <!-- OWASP HTML sanitizer for user-supplied legal/DPP HTML (mirrors ORISO-TenantService) -->
+    <dependency>
+      <groupId>com.googlecode.owasp-java-html-sanitizer</groupId>
+      <artifactId>owasp-java-html-sanitizer</artifactId>
+      <version>${owasp.java.html.sanitizer}</version>
+    </dependency>
     <!-- Spring Boot dependencies -->
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/src/main/java/de/caritas/cob/agencyservice/api/admin/controller/AgencyAdminController.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/admin/controller/AgencyAdminController.java
@@ -6,6 +6,7 @@ import de.caritas.cob.agencyservice.api.admin.service.agencyadmincontrol.AgencyA
 import de.caritas.cob.agencyservice.api.admin.service.agency.AgencyAdminFullResponseDTOBuilder;
 import de.caritas.cob.agencyservice.api.admin.service.agency.AgencyAdminSearchService;
 import de.caritas.cob.agencyservice.api.admin.service.agencypostcoderange.AgencyPostcodeRangeAdminService;
+import de.caritas.cob.agencyservice.api.admin.service.legal.DepartmentDataProtectionService;
 import de.caritas.cob.agencyservice.api.admin.validation.AgencyValidator;
 import de.caritas.cob.agencyservice.api.model.AgencyAdminControls;
 import de.caritas.cob.agencyservice.api.model.AgencyAdminFullResponseDTO;
@@ -13,6 +14,8 @@ import de.caritas.cob.agencyservice.api.model.AgencyAdminSearchResultDTO;
 import de.caritas.cob.agencyservice.api.model.AgencyDTO;
 import de.caritas.cob.agencyservice.api.model.AgencyPostcodeRangeResponseDTO;
 import de.caritas.cob.agencyservice.api.model.AgencyTypeRequestDTO;
+import de.caritas.cob.agencyservice.api.model.DepartmentDataProtectionDTO;
+import de.caritas.cob.agencyservice.api.model.DepartmentDataProtectionResponseDTO;
 import de.caritas.cob.agencyservice.api.model.PostcodeRangeDTO;
 import de.caritas.cob.agencyservice.api.model.RootDTO;
 import de.caritas.cob.agencyservice.api.model.Sort;
@@ -44,6 +47,7 @@ public class AgencyAdminController implements AgencyadminApi {
   private final @NonNull AgencyAdminService agencyAdminService;
   private final @NonNull AgencyValidator agencyValidator;
   private final @NonNull AgencyAdminControlsFacade agencyAdminControlsFacade;
+  private final @NonNull DepartmentDataProtectionService departmentDataProtectionService;
 
   /**
    * Creates the root hal based navigation entity.
@@ -216,6 +220,32 @@ public class AgencyAdminController implements AgencyadminApi {
             .fromAgency()).toList();
 
     return new ResponseEntity<>(agenciesResponse, HttpStatus.OK);
+  }
+
+  /**
+   * Entry point to publish (or draft-save) a department's (Fachbereich = agency × topic) own data
+   * privacy policy. Authorisation is scoped to the caller's agencies inside the service (IDOR
+   * guard) so a restricted agency admin can only edit its own Fachbereiche.
+   *
+   * @param agencyId Agency Id (Beratungszentrum)
+   * @param topicId  Topic Id (Fachbereich)
+   * @param departmentDataProtectionDTO multilingual content + publish flag
+   * @return the resulting {@link DepartmentDataProtectionResponseDTO} publication status
+   */
+  @Override
+  public ResponseEntity<DepartmentDataProtectionResponseDTO> publishDepartmentDataProtection(
+      Long agencyId, Long topicId, DepartmentDataProtectionDTO departmentDataProtectionDTO) {
+    var status =
+        departmentDataProtectionService.publishDepartmentDataPrivacy(
+            agencyId,
+            topicId,
+            departmentDataProtectionDTO.getContent(),
+            Boolean.TRUE.equals(departmentDataProtectionDTO.getPublish()));
+    var response =
+        new DepartmentDataProtectionResponseDTO()
+            .publicationStatus(
+                DepartmentDataProtectionResponseDTO.PublicationStatusEnum.fromValue(status.name()));
+    return ResponseEntity.ok(response);
   }
 
   @Override

--- a/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/DepartmentDataProtectionService.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/DepartmentDataProtectionService.java
@@ -6,12 +6,15 @@ import de.caritas.cob.agencyservice.api.admin.service.UserAdminService;
 import de.caritas.cob.agencyservice.api.exception.httpresponses.AgencyAccessDeniedException;
 import de.caritas.cob.agencyservice.api.exception.httpresponses.InternalServerErrorException;
 import de.caritas.cob.agencyservice.api.exception.httpresponses.NotFoundException;
+import de.caritas.cob.agencyservice.api.repository.agency.Agency;
 import de.caritas.cob.agencyservice.api.repository.agencytopic.AgencyTopic;
 import de.caritas.cob.agencyservice.api.repository.agencytopic.AgencyTopicRepository;
 import de.caritas.cob.agencyservice.api.repository.agencytopic.PublicationStatus;
+import de.caritas.cob.agencyservice.api.tenant.TenantContext;
 import de.caritas.cob.agencyservice.api.util.AuthenticatedUser;
 import de.caritas.cob.agencyservice.api.validation.InputSanitizer;
 import java.time.LocalDateTime;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.NonNull;
@@ -52,12 +55,14 @@ public class DepartmentDataProtectionService {
   @Transactional
   public PublicationStatus publishDepartmentDataPrivacy(
       Long agencyId, Long topicId, Map<String, String> content, boolean publish) {
-    assertUserMayEditAgency(agencyId);
+    assertRestrictedAdminOwnsAgency(agencyId);
 
     AgencyTopic department =
         agencyTopicRepository
             .findByAgency_IdAndTopicId(agencyId, topicId)
             .orElseThrow(NotFoundException::new);
+
+    assertCallerTenantMatches(department.getAgency());
 
     department.setContentDpp(toJson(sanitizeTranslations(content)));
     department.setPublicationStatus(
@@ -68,7 +73,11 @@ public class DepartmentDataProtectionService {
     return department.getPublicationStatus();
   }
 
-  private void assertUserMayEditAgency(Long agencyId) {
+  /**
+   * Restricted agency admins may only touch agencies they administer (mirrors {@code
+   * AgencyUpdatePermissionValidator}). Full agency admins are handled by the tenant guard below.
+   */
+  private void assertRestrictedAdminOwnsAgency(Long agencyId) {
     if (authenticatedUser.hasRestrictedAgencyPriviliges()) {
       var adminAgencyIds = userAdminService.getAdminUserAgencyIds(authenticatedUser.getUserId());
       if (adminAgencyIds == null || !adminAgencyIds.contains(agencyId)) {
@@ -79,6 +88,34 @@ public class DepartmentDataProtectionService {
         throw new AgencyAccessDeniedException();
       }
     }
+  }
+
+  /**
+   * Cross-tenant guard (mirrors {@code AgencyTenantValidator}): a full agency admin of tenant A must
+   * not edit tenant B's Fachbereich. Necessary because the Hibernate tenant filter is not installed
+   * when {@code multitenancy.enabled=false} (all deployed profiles), so agency-id membership alone
+   * does not scope full admins. Tenant {@code 0} (super/technical) and single-tenant mode (no tenant
+   * in context) are unrestricted.
+   */
+  private void assertCallerTenantMatches(Agency agency) {
+    Long effectiveTenantId = resolveEffectiveTenantId();
+    if (effectiveTenantId == null || effectiveTenantId.equals(0L)) {
+      return;
+    }
+    if (agency == null || !effectiveTenantId.equals(agency.getTenantId())) {
+      log.warn(
+          "Admin user {} (tenant {}) may not edit the data privacy policy of agency {} (tenant {})",
+          authenticatedUser.getUserId(),
+          effectiveTenantId,
+          agency == null ? null : agency.getId(),
+          agency == null ? null : agency.getTenantId());
+      throw new AgencyAccessDeniedException();
+    }
+  }
+
+  private Long resolveEffectiveTenantId() {
+    Long tenantIdFromAuth = authenticatedUser.getTenantId();
+    return tenantIdFromAuth != null ? tenantIdFromAuth : TenantContext.getCurrentTenant();
   }
 
   private Map<String, String> sanitizeTranslations(Map<String, String> content) {
@@ -92,7 +129,9 @@ public class DepartmentDataProtectionService {
                 Map.Entry::getKey,
                 entry ->
                     inputSanitizer.sanitizeAllowingFormattingAndLinks(
-                        entry.getValue() == null ? "" : entry.getValue())));
+                        entry.getValue() == null ? "" : entry.getValue()),
+                (existing, replacement) -> replacement,
+                LinkedHashMap::new));
   }
 
   private String toJson(Map<String, String> sanitized) {

--- a/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/DepartmentDataProtectionService.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/DepartmentDataProtectionService.java
@@ -1,0 +1,106 @@
+package de.caritas.cob.agencyservice.api.admin.service.legal;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import de.caritas.cob.agencyservice.api.admin.service.UserAdminService;
+import de.caritas.cob.agencyservice.api.exception.httpresponses.AgencyAccessDeniedException;
+import de.caritas.cob.agencyservice.api.exception.httpresponses.InternalServerErrorException;
+import de.caritas.cob.agencyservice.api.exception.httpresponses.NotFoundException;
+import de.caritas.cob.agencyservice.api.repository.agencytopic.AgencyTopic;
+import de.caritas.cob.agencyservice.api.repository.agencytopic.AgencyTopicRepository;
+import de.caritas.cob.agencyservice.api.repository.agencytopic.PublicationStatus;
+import de.caritas.cob.agencyservice.api.util.AuthenticatedUser;
+import de.caritas.cob.agencyservice.api.validation.InputSanitizer;
+import java.time.LocalDateTime;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Publishes a department's ({@code Fachbereich} = agency × topic) own data privacy policy (DPP).
+ *
+ * <p>This is the AgencyService counterpart to the TenantService DPA publish flow: the admin authors
+ * multilingual HTML in the panel's editor; here it is (a) authorised against the caller's agencies
+ * so a restricted agency admin cannot write another agency's Fachbereich (IDOR guard), (b) OWASP
+ * sanitised per translation, and (c) stored as a JSON language→HTML map in {@code
+ * agency_topic.content_dpp} — mirroring how the tenant privacy/DPA content is persisted so the admin
+ * UI can reuse the same language-aware viewer.
+ */
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class DepartmentDataProtectionService {
+
+  private final @NonNull AgencyTopicRepository agencyTopicRepository;
+  private final @NonNull InputSanitizer inputSanitizer;
+  private final @NonNull AuthenticatedUser authenticatedUser;
+  private final @NonNull UserAdminService userAdminService;
+
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  /**
+   * Sanitises and stores the department's DPP for the given agency × topic. When {@code publish} is
+   * true the department is marked {@link PublicationStatus#PUBLISHED}, otherwise it is kept as a
+   * {@link PublicationStatus#DRAFT} (draft-save).
+   *
+   * @return the resulting publication status
+   */
+  @Transactional
+  public PublicationStatus publishDepartmentDataPrivacy(
+      Long agencyId, Long topicId, Map<String, String> content, boolean publish) {
+    assertUserMayEditAgency(agencyId);
+
+    AgencyTopic department =
+        agencyTopicRepository
+            .findByAgency_IdAndTopicId(agencyId, topicId)
+            .orElseThrow(NotFoundException::new);
+
+    department.setContentDpp(toJson(sanitizeTranslations(content)));
+    department.setPublicationStatus(
+        publish ? PublicationStatus.PUBLISHED : PublicationStatus.DRAFT);
+    department.setUpdateDate(LocalDateTime.now());
+    agencyTopicRepository.save(department);
+
+    return department.getPublicationStatus();
+  }
+
+  private void assertUserMayEditAgency(Long agencyId) {
+    if (authenticatedUser.hasRestrictedAgencyPriviliges()) {
+      var adminAgencyIds = userAdminService.getAdminUserAgencyIds(authenticatedUser.getUserId());
+      if (adminAgencyIds == null || !adminAgencyIds.contains(agencyId)) {
+        log.warn(
+            "Admin user {} may not edit the data privacy policy of agency {}",
+            authenticatedUser.getUserId(),
+            agencyId);
+        throw new AgencyAccessDeniedException();
+      }
+    }
+  }
+
+  private Map<String, String> sanitizeTranslations(Map<String, String> content) {
+    if (content == null) {
+      return Map.of();
+    }
+    return content.entrySet().stream()
+        .filter(entry -> entry.getKey() != null)
+        .collect(
+            Collectors.toMap(
+                Map.Entry::getKey,
+                entry ->
+                    inputSanitizer.sanitizeAllowingFormattingAndLinks(
+                        entry.getValue() == null ? "" : entry.getValue())));
+  }
+
+  private String toJson(Map<String, String> sanitized) {
+    try {
+      return objectMapper.writeValueAsString(sanitized);
+    } catch (JsonProcessingException e) {
+      throw new InternalServerErrorException(
+          "Could not serialize department data privacy policy content", e);
+    }
+  }
+}

--- a/src/main/java/de/caritas/cob/agencyservice/api/repository/agencytopic/AgencyTopicRepository.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/repository/agencytopic/AgencyTopicRepository.java
@@ -1,0 +1,15 @@
+package de.caritas.cob.agencyservice.api.repository.agencytopic;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * Repository for the department-level ({@code Fachbereich} = agency × topic) rows, used by the
+ * per-department data privacy policy (DPP) flow to load and update a single {@code agency_topic}
+ * without going through the parent {@code Agency} aggregate.
+ */
+public interface AgencyTopicRepository extends JpaRepository<AgencyTopic, Long> {
+
+  /** Finds the department row for a given agency and topic (the natural key of a Fachbereich). */
+  Optional<AgencyTopic> findByAgency_IdAndTopicId(Long agencyId, Long topicId);
+}

--- a/src/main/java/de/caritas/cob/agencyservice/api/validation/InputSanitizer.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/validation/InputSanitizer.java
@@ -1,0 +1,45 @@
+package de.caritas.cob.agencyservice.api.validation;
+
+import org.owasp.html.HtmlPolicyBuilder;
+import org.springframework.stereotype.Component;
+
+/**
+ * OWASP-backed HTML sanitizer for user-supplied legal text (e.g. a Fachbereich's data privacy
+ * policy). Mirrors ORISO-TenantService's {@code InputSanitizer} so both services strip the same
+ * classes of markup before persisting rich text authored in the admin panel's editor.
+ */
+@Component
+public class InputSanitizer {
+
+  public String sanitize(String input) {
+    var sanitizer = new HtmlPolicyBuilder().toFactory();
+    return sanitizer.sanitize(input);
+  }
+
+  public String sanitizeAllowingFormatting(String input) {
+    var sanitizer =
+        new HtmlPolicyBuilder()
+            .allowStyling()
+            .allowCommonInlineFormattingElements()
+            .allowCommonBlockElements()
+            .toFactory();
+    return sanitizer.sanitize(input);
+  }
+
+  public String sanitizeAllowingFormattingAndLinks(String input) {
+    var sanitizer =
+        new HtmlPolicyBuilder()
+            .allowStyling()
+            .allowStandardUrlProtocols()
+            .allowCommonInlineFormattingElements()
+            .allowCommonBlockElements()
+            .allowElements("a")
+            .allowAttributes("href", "target")
+            .onElements("a")
+            .allowElements("img")
+            .allowAttributes("src", "width", "height")
+            .onElements("img")
+            .toFactory();
+    return sanitizer.sanitize(input);
+  }
+}

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/controller/AgencyAdminControllerDepartmentDppTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/controller/AgencyAdminControllerDepartmentDppTest.java
@@ -1,0 +1,64 @@
+package de.caritas.cob.agencyservice.api.admin.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import de.caritas.cob.agencyservice.api.admin.service.AgencyAdminService;
+import de.caritas.cob.agencyservice.api.admin.service.agency.AgencyAdminSearchService;
+import de.caritas.cob.agencyservice.api.admin.service.agencyadmincontrol.AgencyAdminControlsFacade;
+import de.caritas.cob.agencyservice.api.admin.service.agencypostcoderange.AgencyPostcodeRangeAdminService;
+import de.caritas.cob.agencyservice.api.admin.service.legal.DepartmentDataProtectionService;
+import de.caritas.cob.agencyservice.api.admin.validation.AgencyValidator;
+import de.caritas.cob.agencyservice.api.model.DepartmentDataProtectionDTO;
+import de.caritas.cob.agencyservice.api.model.DepartmentDataProtectionResponseDTO;
+import de.caritas.cob.agencyservice.api.repository.agencytopic.PublicationStatus;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+
+@ExtendWith(MockitoExtension.class)
+class AgencyAdminControllerDepartmentDppTest {
+
+  @Mock private AgencyAdminSearchService agencyAdminSearchService;
+  @Mock private AgencyPostcodeRangeAdminService agencyPostcodeRangeAdminService;
+  @Mock private AgencyAdminService agencyAdminService;
+  @Mock private AgencyValidator agencyValidator;
+  @Mock private AgencyAdminControlsFacade agencyAdminControlsFacade;
+  @Mock private DepartmentDataProtectionService departmentDataProtectionService;
+
+  @InjectMocks private AgencyAdminController controller;
+
+  @Test
+  void publishDepartmentDataProtection_Should_delegate_andMapStatusTo200() {
+    var body = new DepartmentDataProtectionDTO().content(Map.of("de", "<p>DSE</p>")).publish(true);
+    when(departmentDataProtectionService.publishDepartmentDataPrivacy(
+            eq(7L), eq(42L), eq(Map.of("de", "<p>DSE</p>")), eq(true)))
+        .thenReturn(PublicationStatus.PUBLISHED);
+
+    var response = controller.publishDepartmentDataProtection(7L, 42L, body);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody()).isNotNull();
+    assertThat(response.getBody().getPublicationStatus())
+        .isEqualTo(DepartmentDataProtectionResponseDTO.PublicationStatusEnum.PUBLISHED);
+  }
+
+  @Test
+  void publishDepartmentDataProtection_Should_treatAbsentPublishFlagAsDraftSave() {
+    // publish flag omitted -> Boolean null -> service receives false (draft-save)
+    var body = new DepartmentDataProtectionDTO().content(Map.of("de", "<p>Entwurf</p>"));
+    when(departmentDataProtectionService.publishDepartmentDataPrivacy(
+            eq(7L), eq(42L), eq(Map.of("de", "<p>Entwurf</p>")), eq(false)))
+        .thenReturn(PublicationStatus.DRAFT);
+
+    var response = controller.publishDepartmentDataProtection(7L, 42L, body);
+
+    assertThat(response.getBody().getPublicationStatus())
+        .isEqualTo(DepartmentDataProtectionResponseDTO.PublicationStatusEnum.DRAFT);
+  }
+}

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/service/legal/DepartmentDataProtectionServiceTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/service/legal/DepartmentDataProtectionServiceTest.java
@@ -11,14 +11,17 @@ import static org.mockito.Mockito.when;
 import de.caritas.cob.agencyservice.api.admin.service.UserAdminService;
 import de.caritas.cob.agencyservice.api.exception.httpresponses.AgencyAccessDeniedException;
 import de.caritas.cob.agencyservice.api.exception.httpresponses.NotFoundException;
+import de.caritas.cob.agencyservice.api.repository.agency.Agency;
 import de.caritas.cob.agencyservice.api.repository.agencytopic.AgencyTopic;
 import de.caritas.cob.agencyservice.api.repository.agencytopic.AgencyTopicRepository;
 import de.caritas.cob.agencyservice.api.repository.agencytopic.PublicationStatus;
+import de.caritas.cob.agencyservice.api.tenant.TenantContext;
 import de.caritas.cob.agencyservice.api.util.AuthenticatedUser;
 import de.caritas.cob.agencyservice.api.validation.InputSanitizer;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -37,14 +40,37 @@ class DepartmentDataProtectionServiceTest {
 
   @BeforeEach
   void setUp() {
+    TenantContext.clear(); // no ThreadLocal tenant leaks into the tenant guard
     // real sanitizer so we actually verify markup stripping, not a mock
     service =
         new DepartmentDataProtectionService(
             agencyTopicRepository, new InputSanitizer(), authenticatedUser, userAdminService);
   }
 
+  @AfterEach
+  void tearDown() {
+    TenantContext.clear();
+  }
+
   private AgencyTopic existingDepartment() {
     var department = AgencyTopic.builder().topicId(42L).build();
+    when(agencyTopicRepository.findByAgency_IdAndTopicId(7L, 42L))
+        .thenReturn(Optional.of(department));
+    return department;
+  }
+
+  private AgencyTopic existingDepartmentInTenant(Long agencyTenantId) {
+    var department =
+        AgencyTopic.builder()
+            .topicId(42L)
+            .agency(
+                Agency.builder()
+                    .id(7L)
+                    .name("Test-Zentrum")
+                    .consultingTypeId(1)
+                    .tenantId(agencyTenantId)
+                    .build())
+            .build();
     when(agencyTopicRepository.findByAgency_IdAndTopicId(7L, 42L))
         .thenReturn(Optional.of(department));
     return department;
@@ -127,5 +153,100 @@ class DepartmentDataProtectionServiceTest {
             () ->
                 service.publishDepartmentDataPrivacy(7L, 99L, Map.of("de", "<p>x</p>"), true));
     verify(agencyTopicRepository, never()).save(any());
+  }
+
+  @Test
+  void publish_Should_throwAccessDenied_When_fullAdminEditsAnotherTenantsAgency() {
+    // full admin (not restricted) of tenant 1 tries to edit an agency belonging to tenant 2
+    when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(false);
+    when(authenticatedUser.getTenantId()).thenReturn(1L);
+    existingDepartmentInTenant(2L);
+
+    assertThatExceptionOfType(AgencyAccessDeniedException.class)
+        .isThrownBy(
+            () ->
+                service.publishDepartmentDataPrivacy(7L, 42L, Map.of("de", "<p>x</p>"), true));
+    verify(agencyTopicRepository, never()).save(any());
+  }
+
+  @Test
+  void publish_Should_allow_When_fullAdminEditsOwnTenantsAgency() {
+    when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(false);
+    when(authenticatedUser.getTenantId()).thenReturn(1L);
+    existingDepartmentInTenant(1L);
+
+    var status =
+        service.publishDepartmentDataPrivacy(7L, 42L, Map.of("de", "<p>ok</p>"), true);
+
+    assertThat(status).isEqualTo(PublicationStatus.PUBLISHED);
+    verify(agencyTopicRepository).save(any());
+  }
+
+  @Test
+  void publish_Should_keepAllowedFormattingAndLinks() {
+    when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(false);
+    var department = existingDepartment();
+
+    service.publishDepartmentDataPrivacy(
+        7L, 42L, Map.of("de", "<strong>Wichtig</strong> <a href=\"https://caritas.de\">Info</a>"),
+        true);
+
+    // guards against a regression to the strip-everything sanitize() policy
+    var stored = department.getContentDpp();
+    assertThat(stored).contains("<strong>").contains("Wichtig");
+    assertThat(stored).contains("href").contains("https://caritas.de");
+  }
+
+  @Test
+  void publish_Should_storeAllLanguagesInJsonMap() {
+    when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(false);
+    var department = existingDepartment();
+
+    service.publishDepartmentDataPrivacy(
+        7L, 42L, Map.of("de", "<p>Datenschutz</p>", "en", "<p>Privacy</p>"), true);
+
+    var stored = department.getContentDpp();
+    assertThat(stored).contains("\"de\":").contains("Datenschutz");
+    assertThat(stored).contains("\"en\":").contains("Privacy");
+  }
+
+  @Test
+  void publish_Should_overwriteContent_andFlipPublishedBackToDraft_When_republishedAsDraft() {
+    when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(false);
+    var department = existingDepartment();
+
+    service.publishDepartmentDataPrivacy(7L, 42L, Map.of("de", "<p>final</p>"), true);
+    assertThat(department.getPublicationStatus()).isEqualTo(PublicationStatus.PUBLISHED);
+
+    // a second call as draft overwrites the content and reverts the status
+    var status =
+        service.publishDepartmentDataPrivacy(7L, 42L, Map.of("de", "<p>revised</p>"), false);
+
+    assertThat(status).isEqualTo(PublicationStatus.DRAFT);
+    assertThat(department.getPublicationStatus()).isEqualTo(PublicationStatus.DRAFT);
+    assertThat(department.getContentDpp()).contains("revised").doesNotContain("final");
+  }
+
+  @Test
+  void publish_Should_storeEmptyJsonObject_When_contentIsNull() {
+    when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(false);
+    var department = existingDepartment();
+
+    var status = service.publishDepartmentDataPrivacy(7L, 42L, null, true);
+
+    assertThat(status).isEqualTo(PublicationStatus.PUBLISHED);
+    assertThat(department.getContentDpp()).isEqualTo("{}");
+  }
+
+  @Test
+  void publish_Should_coerceNullTranslationValueToEmptyString() {
+    when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(false);
+    var department = existingDepartment();
+    var content = new java.util.HashMap<String, String>();
+    content.put("de", null);
+
+    service.publishDepartmentDataPrivacy(7L, 42L, content, true);
+
+    assertThat(department.getContentDpp()).isEqualTo("{\"de\":\"\"}");
   }
 }

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/service/legal/DepartmentDataProtectionServiceTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/service/legal/DepartmentDataProtectionServiceTest.java
@@ -1,0 +1,131 @@
+package de.caritas.cob.agencyservice.api.admin.service.legal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import de.caritas.cob.agencyservice.api.admin.service.UserAdminService;
+import de.caritas.cob.agencyservice.api.exception.httpresponses.AgencyAccessDeniedException;
+import de.caritas.cob.agencyservice.api.exception.httpresponses.NotFoundException;
+import de.caritas.cob.agencyservice.api.repository.agencytopic.AgencyTopic;
+import de.caritas.cob.agencyservice.api.repository.agencytopic.AgencyTopicRepository;
+import de.caritas.cob.agencyservice.api.repository.agencytopic.PublicationStatus;
+import de.caritas.cob.agencyservice.api.util.AuthenticatedUser;
+import de.caritas.cob.agencyservice.api.validation.InputSanitizer;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class DepartmentDataProtectionServiceTest {
+
+  @Mock private AgencyTopicRepository agencyTopicRepository;
+  @Mock private AuthenticatedUser authenticatedUser;
+  @Mock private UserAdminService userAdminService;
+
+  private DepartmentDataProtectionService service;
+
+  @BeforeEach
+  void setUp() {
+    // real sanitizer so we actually verify markup stripping, not a mock
+    service =
+        new DepartmentDataProtectionService(
+            agencyTopicRepository, new InputSanitizer(), authenticatedUser, userAdminService);
+  }
+
+  private AgencyTopic existingDepartment() {
+    var department = AgencyTopic.builder().topicId(42L).build();
+    when(agencyTopicRepository.findByAgency_IdAndTopicId(7L, 42L))
+        .thenReturn(Optional.of(department));
+    return department;
+  }
+
+  @Test
+  void publish_Should_sanitizeStoreAsJsonMap_andSetPublished_ForFullAgencyAdmin() {
+    when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(false);
+    existingDepartment();
+
+    var status =
+        service.publishDepartmentDataPrivacy(
+            7L,
+            42L,
+            Map.of("de", "<p onclick=\"steal()\">Datenschutz <script>bad()</script></p>"),
+            true);
+
+    // a full admin is never scoped-checked against agency ids
+    verifyNoInteractions(userAdminService);
+    assertThat(status).isEqualTo(PublicationStatus.PUBLISHED);
+
+    var saved = ArgumentCaptor.forClass(AgencyTopic.class);
+    verify(agencyTopicRepository).save(saved.capture());
+    assertThat(saved.getValue().getPublicationStatus()).isEqualTo(PublicationStatus.PUBLISHED);
+    var storedJson = saved.getValue().getContentDpp();
+    assertThat(storedJson).startsWith("{").contains("\"de\":");
+    // dangerous markup removed, text kept
+    assertThat(storedJson).contains("Datenschutz").doesNotContain("script").doesNotContain("onclick");
+    assertThat(saved.getValue().getUpdateDate()).isNotNull();
+  }
+
+  @Test
+  void publish_Should_setDraft_When_publishFalse() {
+    when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(false);
+    existingDepartment();
+
+    var status =
+        service.publishDepartmentDataPrivacy(7L, 42L, Map.of("de", "<p>Entwurf</p>"), false);
+
+    assertThat(status).isEqualTo(PublicationStatus.DRAFT);
+  }
+
+  @Test
+  void publish_Should_allow_When_restrictedAdminOwnsTheAgency() {
+    when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(true);
+    when(authenticatedUser.getUserId()).thenReturn("admin-1");
+    when(userAdminService.getAdminUserAgencyIds("admin-1")).thenReturn(List.of(7L, 9L));
+    existingDepartment();
+
+    var status =
+        service.publishDepartmentDataPrivacy(7L, 42L, Map.of("de", "<p>ok</p>"), true);
+
+    assertThat(status).isEqualTo(PublicationStatus.PUBLISHED);
+    verify(agencyTopicRepository).save(any());
+  }
+
+  @Test
+  void publish_Should_throwAccessDenied_When_restrictedAdminDoesNotOwnTheAgency() {
+    when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(true);
+    when(authenticatedUser.getUserId()).thenReturn("admin-1");
+    when(userAdminService.getAdminUserAgencyIds("admin-1")).thenReturn(List.of(9L));
+
+    assertThatExceptionOfType(AgencyAccessDeniedException.class)
+        .isThrownBy(
+            () ->
+                service.publishDepartmentDataPrivacy(7L, 42L, Map.of("de", "<p>x</p>"), true));
+
+    // IDOR guard runs before any load or write
+    verify(agencyTopicRepository, never()).findByAgency_IdAndTopicId(any(), any());
+    verify(agencyTopicRepository, never()).save(any());
+  }
+
+  @Test
+  void publish_Should_throwNotFound_When_departmentMissing() {
+    when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(false);
+    when(agencyTopicRepository.findByAgency_IdAndTopicId(7L, 99L)).thenReturn(Optional.empty());
+
+    assertThatExceptionOfType(NotFoundException.class)
+        .isThrownBy(
+            () ->
+                service.publishDepartmentDataPrivacy(7L, 99L, Map.of("de", "<p>x</p>"), true));
+    verify(agencyTopicRepository, never()).save(any());
+  }
+}

--- a/src/test/java/de/caritas/cob/agencyservice/api/repository/agencytopic/AgencyTopicLegalRepositoryTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/repository/agencytopic/AgencyTopicLegalRepositoryTest.java
@@ -33,6 +33,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 class AgencyTopicLegalRepositoryTest {
 
   @Autowired private TestEntityManager em;
+  @Autowired private AgencyTopicRepository agencyTopicRepository;
 
   private Agency persistAgency(String name) {
     var now = LocalDateTime.now();
@@ -89,5 +90,36 @@ class AgencyTopicLegalRepositoryTest {
     // then
     assertThat(em.find(AgencyTopic.class, id).getPublicationStatus())
         .isEqualTo(PublicationStatus.DRAFT);
+  }
+
+  @Test
+  void findByAgencyIdAndTopicId_Should_returnTheMatchingFachbereich() {
+    // given two departments on the same agency plus one on another agency
+    var now = LocalDateTime.now();
+    Agency agency = persistAgency("Zentrum 3");
+    Agency otherAgency = persistAgency("Zentrum 4");
+    em.persist(
+        AgencyTopic.builder().agency(agency).topicId(10L).createDate(now).updateDate(now).build());
+    em.persist(
+        AgencyTopic.builder().agency(agency).topicId(20L).createDate(now).updateDate(now).build());
+    em.persist(
+        AgencyTopic.builder()
+            .agency(otherAgency)
+            .topicId(10L)
+            .createDate(now)
+            .updateDate(now)
+            .build());
+    em.flush();
+    em.clear();
+
+    // when
+    var found = agencyTopicRepository.findByAgency_IdAndTopicId(agency.getId(), 20L);
+    var wrongTopic = agencyTopicRepository.findByAgency_IdAndTopicId(agency.getId(), 99L);
+
+    // then only the exact (agency, topic) pair matches
+    assertThat(found).isPresent();
+    assertThat(found.get().getTopicId()).isEqualTo(20L);
+    assertThat(found.get().getAgency().getId()).isEqualTo(agency.getId());
+    assertThat(wrongTopic).isEmpty();
   }
 }

--- a/src/test/java/de/caritas/cob/agencyservice/api/repository/agencytopic/AgencyTopicLegalRepositoryTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/repository/agencytopic/AgencyTopicLegalRepositoryTest.java
@@ -122,4 +122,30 @@ class AgencyTopicLegalRepositoryTest {
     assertThat(found.get().getAgency().getId()).isEqualTo(agency.getId());
     assertThat(wrongTopic).isEmpty();
   }
+
+  @Test
+  void findByAgencyIdAndTopicId_Should_notReturnOtherAgencysDepartmentWithSameTopic() {
+    // given the same topicId 10 on two different agencies (the case a topicId-only query would leak)
+    var now = LocalDateTime.now();
+    Agency agency = persistAgency("Zentrum 5");
+    Agency otherAgency = persistAgency("Zentrum 6");
+    em.persist(
+        AgencyTopic.builder().agency(agency).topicId(10L).createDate(now).updateDate(now).build());
+    em.persist(
+        AgencyTopic.builder()
+            .agency(otherAgency)
+            .topicId(10L)
+            .createDate(now)
+            .updateDate(now)
+            .build());
+    em.flush();
+    em.clear();
+
+    // when querying agency's (10) it must return agency's row, never otherAgency's
+    var found = agencyTopicRepository.findByAgency_IdAndTopicId(agency.getId(), 10L);
+
+    assertThat(found).isPresent();
+    assertThat(found.get().getAgency().getId()).isEqualTo(agency.getId());
+    assertThat(found.get().getAgency().getId()).isNotEqualTo(otherAgency.getId());
+  }
 }


### PR DESCRIPTION
Second slice of the AVV / Legal flow (EPIC OpenResilienceInitiative/ORISO-TenantService#46), continuing after the review-only #74 (agency_topic content_dpp column + Beratungszentrum address) which is already merged. Built locally, TDD-green; brings `feat/avv-legal-flow` up to date with `dev`.

## What's in this PR
Per-department (Fachbereich = agency × topic) data privacy policy **write flow**:
- `InputSanitizer` (OWASP html-sanitizer, same policy as TenantService) + `AgencyTopicRepository.findByAgency_IdAndTopicId`.
- `DepartmentDataProtectionService.publishDepartmentDataPrivacy`: sanitizes each translation, stores a JSON language→HTML map in `agency_topic.content_dpp`, sets PUBLISHED/DRAFT (draft-save).
- Endpoint `PUT /agencyadmin/agencies/{agencyId}/topics/{topicId}/dpp` (`DepartmentDataProtectionDTO {content, publish}` → `{publicationStatus}`).
- **Access control**: restricted agency admins scoped to their own agencies **and** a cross-tenant guard (mirrors `AgencyTenantValidator`) so a full agency admin of tenant A cannot edit tenant B's Fachbereich — necessary because the Hibernate tenant filter is off in prod (`multitenancy.enabled=false`).

## Tests
18 green: service 12 (real sanitizer strips script/onclick and keeps links/formatting; PUBLISHED vs DRAFT; IDOR + cross-tenant allow/deny before load; multilingual; re-draft; null/empty content), repo 4 (self-sufficient `@DataJpaTest`, cross-agency exclusion), controller 2.

Affected repos: ORISO-AgencyService.

🤖 Generated with [Claude Code](https://claude.com/claude-code)