### PR TITLE
AVV: Fachbereich DPP read endpoint (prefill editor, part of #46)

### DIFF
--- a/api/agencyadminservice.yaml
+++ b/api/agencyadminservice.yaml
@@ -259,6 +259,45 @@ paths:
         - Bearer: [ ]
 
   /agencyadmin/agencies/{agencyId}/topics/{topicId}/dpp:
+    get:
+      tags:
+        - admin-agency-controller
+      summary: 'Read a department''s (Fachbereich = agency x topic) own data privacy policy (DSE) to
+      prefill the editor. [Authorization: Role: agency-admin or restricted-agency-admin scoped to
+      its own agencies]'
+      operationId: getDepartmentDataProtection
+      parameters:
+        - name: agencyId
+          in: path
+          description: Agency Id (Beratungszentrum)
+          required: true
+          schema:
+            type: integer
+            format: int64
+        - name: topicId
+          in: path
+          description: Topic Id (Fachbereich)
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        200:
+          description: OK - department data privacy policy content and status
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/DepartmentDataProtectionContentDTO'
+        400:
+          description: BAD REQUEST - caller may not access this agency
+        401:
+          description: UNAUTHORIZED - no/invalid role/authorization
+        404:
+          description: NOT FOUND - department (agency x topic) not found
+        500:
+          description: INTERNAL SERVER ERROR - server encountered unexpected condition
+      security:
+        - Bearer: [ ]
     put:
       tags:
         - admin-agency-controller
@@ -952,6 +991,22 @@ components:
         publicationStatus:
           type: string
           description: Resulting publication status of the department's data privacy policy
+          enum:
+            - DRAFT
+            - PUBLISHED
+
+    DepartmentDataProtectionContentDTO:
+      type: object
+      required:
+        - publicationStatus
+      properties:
+        content:
+          type: string
+          nullable: true
+          description: Stored multilingual content as a JSON language->HTML map string; null if never authored
+        publicationStatus:
+          type: string
+          description: Current publication status of the department's data privacy policy
           enum:
             - DRAFT
             - PUBLISHED

--- a/src/main/java/de/caritas/cob/agencyservice/api/admin/controller/AgencyAdminController.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/admin/controller/AgencyAdminController.java
@@ -14,6 +14,7 @@ import de.caritas.cob.agencyservice.api.model.AgencyAdminSearchResultDTO;
 import de.caritas.cob.agencyservice.api.model.AgencyDTO;
 import de.caritas.cob.agencyservice.api.model.AgencyPostcodeRangeResponseDTO;
 import de.caritas.cob.agencyservice.api.model.AgencyTypeRequestDTO;
+import de.caritas.cob.agencyservice.api.model.DepartmentDataProtectionContentDTO;
 import de.caritas.cob.agencyservice.api.model.DepartmentDataProtectionDTO;
 import de.caritas.cob.agencyservice.api.model.DepartmentDataProtectionResponseDTO;
 import de.caritas.cob.agencyservice.api.model.PostcodeRangeDTO;
@@ -232,6 +233,27 @@ public class AgencyAdminController implements AgencyadminApi {
    * @param departmentDataProtectionDTO multilingual content + publish flag
    * @return the resulting {@link DepartmentDataProtectionResponseDTO} publication status
    */
+  /**
+   * Entry point to read a department's (Fachbereich = agency × topic) own data privacy policy, used
+   * to prefill the admin editor. Same agency/tenant scoping as the publish endpoint.
+   *
+   * @param agencyId Agency Id (Beratungszentrum)
+   * @param topicId  Topic Id (Fachbereich)
+   * @return the stored {@link DepartmentDataProtectionContentDTO} content + publication status
+   */
+  @Override
+  public ResponseEntity<DepartmentDataProtectionContentDTO> getDepartmentDataProtection(
+      Long agencyId, Long topicId) {
+    var view = departmentDataProtectionService.getDepartmentDataPrivacy(agencyId, topicId);
+    var response =
+        new DepartmentDataProtectionContentDTO()
+            .content(view.content())
+            .publicationStatus(
+                DepartmentDataProtectionContentDTO.PublicationStatusEnum.fromValue(
+                    view.publicationStatus().name()));
+    return ResponseEntity.ok(response);
+  }
+
   @Override
   public ResponseEntity<DepartmentDataProtectionResponseDTO> publishDepartmentDataProtection(
       Long agencyId, Long topicId, DepartmentDataProtectionDTO departmentDataProtectionDTO) {

--- a/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/DepartmentDataProtectionService.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/DepartmentDataProtectionService.java
@@ -74,6 +74,26 @@ public class DepartmentDataProtectionService {
   }
 
   /**
+   * Reads the department's stored DPP (content + status) to prefill the admin editor. Same
+   * authorisation as the write path: restricted admins scoped to their own agencies plus the
+   * cross-tenant guard.
+   */
+  @Transactional(readOnly = true)
+  public DepartmentDataProtectionView getDepartmentDataPrivacy(Long agencyId, Long topicId) {
+    assertRestrictedAdminOwnsAgency(agencyId);
+
+    AgencyTopic department =
+        agencyTopicRepository
+            .findByAgency_IdAndTopicId(agencyId, topicId)
+            .orElseThrow(NotFoundException::new);
+
+    assertCallerTenantMatches(department.getAgency());
+
+    return new DepartmentDataProtectionView(
+        department.getContentDpp(), department.getPublicationStatus());
+  }
+
+  /**
    * Restricted agency admins may only touch agencies they administer (mirrors {@code
    * AgencyUpdatePermissionValidator}). Full agency admins are handled by the tenant guard below.
    */

--- a/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/DepartmentDataProtectionView.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/DepartmentDataProtectionView.java
@@ -1,0 +1,10 @@
+package de.caritas.cob.agencyservice.api.admin.service.legal;
+
+import de.caritas.cob.agencyservice.api.repository.agencytopic.PublicationStatus;
+
+/**
+ * Read view of a department's (Fachbereich = agency × topic) data privacy policy: the stored
+ * multilingual JSON language→HTML {@code content} (may be {@code null} if never authored) and its
+ * current {@link PublicationStatus}. Used to prefill the admin editor.
+ */
+public record DepartmentDataProtectionView(String content, PublicationStatus publicationStatus) {}

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/controller/AgencyAdminControllerDepartmentDppTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/controller/AgencyAdminControllerDepartmentDppTest.java
@@ -9,7 +9,9 @@ import de.caritas.cob.agencyservice.api.admin.service.agency.AgencyAdminSearchSe
 import de.caritas.cob.agencyservice.api.admin.service.agencyadmincontrol.AgencyAdminControlsFacade;
 import de.caritas.cob.agencyservice.api.admin.service.agencypostcoderange.AgencyPostcodeRangeAdminService;
 import de.caritas.cob.agencyservice.api.admin.service.legal.DepartmentDataProtectionService;
+import de.caritas.cob.agencyservice.api.admin.service.legal.DepartmentDataProtectionView;
 import de.caritas.cob.agencyservice.api.admin.validation.AgencyValidator;
+import de.caritas.cob.agencyservice.api.model.DepartmentDataProtectionContentDTO;
 import de.caritas.cob.agencyservice.api.model.DepartmentDataProtectionDTO;
 import de.caritas.cob.agencyservice.api.model.DepartmentDataProtectionResponseDTO;
 import de.caritas.cob.agencyservice.api.repository.agencytopic.PublicationStatus;
@@ -46,6 +48,22 @@ class AgencyAdminControllerDepartmentDppTest {
     assertThat(response.getBody()).isNotNull();
     assertThat(response.getBody().getPublicationStatus())
         .isEqualTo(DepartmentDataProtectionResponseDTO.PublicationStatusEnum.PUBLISHED);
+  }
+
+  @Test
+  void getDepartmentDataProtection_Should_delegate_andMapContentAndStatus() {
+    when(departmentDataProtectionService.getDepartmentDataPrivacy(7L, 42L))
+        .thenReturn(
+            new DepartmentDataProtectionView(
+                "{\"de\":\"<p>x</p>\"}", PublicationStatus.PUBLISHED));
+
+    var response = controller.getDepartmentDataProtection(7L, 42L);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody()).isNotNull();
+    assertThat(response.getBody().getContent().get()).isEqualTo("{\"de\":\"<p>x</p>\"}");
+    assertThat(response.getBody().getPublicationStatus())
+        .isEqualTo(DepartmentDataProtectionContentDTO.PublicationStatusEnum.PUBLISHED);
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/service/legal/DepartmentDataProtectionServiceTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/service/legal/DepartmentDataProtectionServiceTest.java
@@ -156,6 +156,39 @@ class DepartmentDataProtectionServiceTest {
   }
 
   @Test
+  void getDepartmentDataPrivacy_Should_returnStoredContentAndStatus() {
+    when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(false);
+    var department = existingDepartment();
+    department.setContentDpp("{\"de\":\"<p>DSE</p>\"}");
+    department.setPublicationStatus(PublicationStatus.PUBLISHED);
+
+    var view = service.getDepartmentDataPrivacy(7L, 42L);
+
+    assertThat(view.content()).isEqualTo("{\"de\":\"<p>DSE</p>\"}");
+    assertThat(view.publicationStatus()).isEqualTo(PublicationStatus.PUBLISHED);
+  }
+
+  @Test
+  void getDepartmentDataPrivacy_Should_throwAccessDenied_When_restrictedAdminDoesNotOwnTheAgency() {
+    when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(true);
+    when(authenticatedUser.getUserId()).thenReturn("admin-1");
+    when(userAdminService.getAdminUserAgencyIds("admin-1")).thenReturn(List.of(9L));
+
+    assertThatExceptionOfType(AgencyAccessDeniedException.class)
+        .isThrownBy(() -> service.getDepartmentDataPrivacy(7L, 42L));
+    verify(agencyTopicRepository, never()).findByAgency_IdAndTopicId(any(), any());
+  }
+
+  @Test
+  void getDepartmentDataPrivacy_Should_throwNotFound_When_departmentMissing() {
+    when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(false);
+    when(agencyTopicRepository.findByAgency_IdAndTopicId(7L, 99L)).thenReturn(Optional.empty());
+
+    assertThatExceptionOfType(NotFoundException.class)
+        .isThrownBy(() -> service.getDepartmentDataPrivacy(7L, 99L));
+  }
+
+  @Test
   void publish_Should_throwAccessDenied_When_fullAdminEditsAnotherTenantsAgency() {
     // full admin (not restricted) of tenant 1 tries to edit an agency belonging to tenant 2
     when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(false);


### PR DESCRIPTION
Adds the read side of the per-department (Fachbereich = agency × topic) data privacy policy so the admin editor can be prefilled instead of overwriting on publish.

- `GET /agencyadmin/agencies/{agencyId}/topics/{topicId}/dpp` → `{content, publicationStatus}` (content = multilingual JSON language→HTML map string, null if never authored).
- `DepartmentDataProtectionService.getDepartmentDataPrivacy` (read-only) reuses the write path's authorisation: restricted admins scoped to their own agencies + cross-tenant guard.
- Tests: service 15 total (3 new: content+status, restricted-admin deny before load, 404), controller 3 (1 new mapping), repo 4.

Affected repos: ORISO-AgencyService.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new admin API to retrieve department data protection content for a specific agency topic.
  * The response now includes the saved policy text and its publication status, supporting prefilled editing in the admin UI.

* **Bug Fixes**
  * Added access checks and not-found handling for invalid or unauthorized agency/topic requests.

* **Tests**
  * Expanded controller and service coverage for successful retrieval, access denial, and missing data cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->