### PR TITLE
test: consolidate agency service test coverage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -325,6 +325,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <!-- required only for WebMvc "fluent" API -->
       <groupId>com.c4-soft.springaddons</groupId>
       <artifactId>spring-security-oauth2-test-webmvc-addons</artifactId>

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/service/UserAdminServiceTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/service/UserAdminServiceTest.java
@@ -3,7 +3,6 @@ package de.caritas.cob.agencyservice.api.admin.service;
 import static de.caritas.cob.agencyservice.useradminservice.generated.web.model.AgencyTypeDTO.AgencyTypeEnum.TEAM_AGENCY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -14,12 +13,12 @@ import de.caritas.cob.agencyservice.api.tenant.TenantContext;
 import de.caritas.cob.agencyservice.config.apiclient.UserAdminServiceApiControllerFactory;
 import de.caritas.cob.agencyservice.useradminservice.generated.ApiClient;
 import de.caritas.cob.agencyservice.useradminservice.generated.web.AdminUserControllerApi;
+import de.caritas.cob.agencyservice.useradminservice.generated.web.model.AgencyConsultantResponseDTO;
 import de.caritas.cob.agencyservice.useradminservice.generated.web.model.AgencyTypeDTO;
-import de.caritas.cob.agencyservice.useradminservice.generated.web.model.ConsultantFilter;
-import de.caritas.cob.agencyservice.useradminservice.generated.web.model.ConsultantSearchResultDTO;
 import de.caritas.cob.agencyservice.useradminservice.generated.web.model.Sort;
 import de.caritas.cob.agencyservice.useradminservice.generated.web.model.Sort.FieldEnum;
 import de.caritas.cob.agencyservice.useradminservice.generated.web.model.Sort.OrderEnum;
+import java.util.Collections;
 import java.util.List;
 import org.jeasy.random.EasyRandom;
 import org.junit.Before;
@@ -78,13 +77,12 @@ public class UserAdminServiceTest {
     Long agencyId = 1L;
     int currentPage = 1;
     int perPage = 1;
-    when(this.adminUserControllerApi.getConsultants(any(), any(), any(), any()))
-        .thenReturn(new EasyRandom().nextObject(ConsultantSearchResultDTO.class));
+    when(this.adminUserControllerApi.getAgencyConsultants(any()))
+        .thenReturn(new AgencyConsultantResponseDTO().embedded(Collections.emptyList()));
     this.userAdminService.getConsultantsOfAgency(agencyId, currentPage, perPage);
 
     verify(this.adminUserControllerApi, times(1))
-        .getConsultants(eq(currentPage), eq(perPage),
-            eq(new ConsultantFilter().agencyId(agencyId)), any());
+        .getAgencyConsultants(String.valueOf(agencyId));
     verify(this.apiClient, times(this.httpHeaders.size())).addDefaultHeader(any(), any());
   }
 

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/service/agencyadmincontrol/AgencyAdminControlsFacadeTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/service/agencyadmincontrol/AgencyAdminControlsFacadeTest.java
@@ -1,0 +1,75 @@
+package de.caritas.cob.agencyservice.api.admin.service.agencyadmincontrol;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import de.caritas.cob.agencyservice.api.model.AgencyAdminControls;
+import de.caritas.cob.agencyservice.api.util.AuthenticatedUser;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.access.AccessDeniedException;
+
+@ExtendWith(MockitoExtension.class)
+class AgencyAdminControlsFacadeTest {
+
+  @InjectMocks
+  AgencyAdminControlsFacade agencyAdminControlsFacade;
+
+  @Mock
+  AgencyAdminControlsService agencyAdminControlsService;
+
+  @Mock
+  AuthenticatedUser authenticatedUser;
+
+  @Test
+  void getAgencyAdminControls_Should_ReturnControls_When_UserIsSuperAdmin() {
+    when(authenticatedUser.isTenantSuperAdmin()).thenReturn(true);
+    AgencyAdminControls expected = new AgencyAdminControls();
+    when(agencyAdminControlsService.getControls()).thenReturn(expected);
+
+    AgencyAdminControls result = agencyAdminControlsFacade.getAgencyAdminControls();
+
+    assertThat(result).isEqualTo(expected);
+    verify(agencyAdminControlsService).getControls();
+  }
+
+  @Test
+  void getAgencyAdminControls_Should_ThrowAccessDeniedException_When_UserIsNotSuperAdmin() {
+    when(authenticatedUser.isTenantSuperAdmin()).thenReturn(false);
+
+    assertThatThrownBy(() -> agencyAdminControlsFacade.getAgencyAdminControls())
+        .isInstanceOf(AccessDeniedException.class);
+
+    verify(agencyAdminControlsService, never()).getControls();
+  }
+
+  @Test
+  void updateAgencyAdminControls_Should_ReturnUpdatedControls_When_UserIsSuperAdmin() {
+    when(authenticatedUser.isTenantSuperAdmin()).thenReturn(true);
+    AgencyAdminControls controls = new AgencyAdminControls();
+    when(agencyAdminControlsService.updateControls(controls)).thenReturn(controls);
+
+    AgencyAdminControls result = agencyAdminControlsFacade.updateAgencyAdminControls(controls);
+
+    assertThat(result).isEqualTo(controls);
+    verify(agencyAdminControlsService).updateControls(controls);
+  }
+
+  @Test
+  void updateAgencyAdminControls_Should_ThrowAccessDeniedException_When_UserIsNotSuperAdmin() {
+    when(authenticatedUser.isTenantSuperAdmin()).thenReturn(false);
+    AgencyAdminControls controls = new AgencyAdminControls();
+
+    assertThatThrownBy(() -> agencyAdminControlsFacade.updateAgencyAdminControls(controls))
+        .isInstanceOf(AccessDeniedException.class);
+
+    verify(agencyAdminControlsService, never()).updateControls(any());
+  }
+}

--- a/src/test/java/de/caritas/cob/agencyservice/api/service/AgencyServiceTenantAwareTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/service/AgencyServiceTenantAwareTest.java
@@ -3,11 +3,14 @@ package de.caritas.cob.agencyservice.api.service;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import de.caritas.cob.agencyservice.api.admin.service.agency.AgencySettingsService;
 import de.caritas.cob.agencyservice.api.admin.service.agency.DemographicsConverter;
+import de.caritas.cob.agencyservice.api.admin.service.agencyadmincontrol.AgencyAdminControlsService;
 import de.caritas.cob.agencyservice.api.exception.MissingConsultingTypeException;
 import de.caritas.cob.agencyservice.api.exception.httpresponses.BadRequestException;
 import de.caritas.cob.agencyservice.api.manager.consultingtype.ConsultingTypeManager;
 import de.caritas.cob.agencyservice.api.repository.agency.AgencyRepository;
+import de.caritas.cob.agencyservice.api.service.matrix.MatrixProvisioningService;
 import de.caritas.cob.agencyservice.api.tenant.TenantContext;
 import de.caritas.cob.agencyservice.consultingtypeservice.generated.web.model.ExtendedConsultingTypeResponseDTO;
 import de.caritas.cob.agencyservice.consultingtypeservice.generated.web.model.RegistrationDTO;
@@ -47,6 +50,15 @@ public class AgencyServiceTenantAwareTest {
 
   @Mock
   private ApplicationSettingsService applicationSettingsService;
+
+  @Mock
+  private MatrixProvisioningService matrixProvisioningService;
+
+  @Mock
+  private AgencySettingsService agencySettingsService;
+
+  @Mock
+  private AgencyAdminControlsService agencyAdminControlsService;
 
   private static final Long TENANT_ID = 1L;
 

--- a/src/test/java/de/caritas/cob/agencyservice/api/service/AgencyServiceTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/service/AgencyServiceTest.java
@@ -44,6 +44,7 @@ import de.caritas.cob.agencyservice.api.model.AgencyResponseDTO;
 import de.caritas.cob.agencyservice.api.model.FullAgencyResponseDTO;
 import de.caritas.cob.agencyservice.api.repository.agency.Agency;
 import de.caritas.cob.agencyservice.api.repository.agency.AgencyRepository;
+import de.caritas.cob.agencyservice.api.service.matrix.MatrixProvisioningService;
 import de.caritas.cob.agencyservice.api.tenant.TenantContext;
 import de.caritas.cob.agencyservice.consultingtypeservice.generated.web.model.BasicConsultingTypeResponseDTORegistration;
 import de.caritas.cob.agencyservice.consultingtypeservice.generated.web.model.ExtendedConsultingTypeResponseDTO;
@@ -103,15 +104,27 @@ public class AgencyServiceTest {
   @Mock
   ApplicationSettingsService applicationSettingsService;
 
+  @Mock
+  private MatrixProvisioningService matrixProvisioningService;
+
   private static final Long TENANT_ID = null;
 
   @org.junit.Before
   public void setUp() {
+    ensureAgencyTopics(AGENCY_SUCHT);
+    ensureAgencyTopics(AGENCY_ONLINE_U25);
+    ensureAgencyTopics(AGENCY_OFFLINE);
     when(agencySettingsService.toSettings(any())).thenReturn(new de.caritas.cob.agencyservice.api.model.Settings());
     when(agencyAdminControlsService.enrichSettingsWithAgencyAdminControls(any()))
         .thenAnswer(invocation -> invocation.getArgument(0) != null
             ? invocation.getArgument(0)
             : new de.caritas.cob.agencyservice.api.model.Settings());
+  }
+
+  private void ensureAgencyTopics(Agency agency) {
+    if (agency.getAgencyTopics() == null) {
+      ReflectionTestUtils.setField(agency, "agencyTopics", Collections.emptyList());
+    }
   }
 
   @After

--- a/src/test/java/de/caritas/cob/agencyservice/api/service/AppointmentServiceTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/service/AppointmentServiceTest.java
@@ -1,28 +1,30 @@
 package de.caritas.cob.agencyservice.api.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.util.ReflectionTestUtils.setField;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import de.caritas.cob.agencyservice.api.repository.agency.Agency;
 import de.caritas.cob.agencyservice.api.service.securityheader.SecurityHeaderSupplier;
+import de.caritas.cob.agencyservice.appointmentservice.generated.web.model.AgencyMasterDataSyncRequestDTO;
 import de.caritas.cob.agencyservice.config.apiclient.AppointmentServiceAgencyApiControllerFactory;
-import lombok.NonNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT) // To allow "UnnecessaryStubbing" to keep tests clean
@@ -34,37 +36,33 @@ class AppointmentServiceTest {
   @InjectMocks
   AppointmentService appointmentService;
 
-  // Mock dependencies
   @Mock
   de.caritas.cob.agencyservice.appointmentservice.generated.web.AgencyApi appointmentAgencyApi;
   @Mock
   SecurityHeaderSupplier securityHeaderSupplier;
   @Mock
   TenantHeaderSupplier tenantHeaderSupplier;
-
-  // Mock test objects
-  @Mock
-  org.springframework.http.HttpHeaders httpHeaders;
-
   @Mock
   Agency agency;
-
   @Mock
   AppointmentServiceAgencyApiControllerFactory appointmentServiceAgencyApiControllerFactory;
 
+  @Spy
+  de.caritas.cob.agencyservice.appointmentservice.generated.ApiClient apiClient;
+
   @BeforeEach
   public void beforeEach() {
-    when(securityHeaderSupplier.getKeycloakAndCsrfHttpHeaders()).thenReturn(httpHeaders);
+    when(securityHeaderSupplier.getKeycloakAndCsrfHttpHeaders()).thenReturn(new HttpHeaders());
     when(appointmentServiceAgencyApiControllerFactory.createControllerApi()).thenReturn(appointmentAgencyApi);
+    when(appointmentAgencyApi.getApiClient()).thenReturn(apiClient);
   }
-
 
   @Test
   void syncAgencyDataToAppointmentService_Should_NotCallAppointmentService_WhenAppointmentsIsDisabled() {
     setField(appointmentService, FIELD_NAME_APPOINTMENTS_ENABLED, false);
     appointmentService.syncAgencyDataToAppointmentService(agency);
     verify(appointmentAgencyApi, never()).agencyMasterDataSync(any(
-        de.caritas.cob.agencyservice.appointmentservice.generated.web.model.AgencyMasterDataSyncRequestDTO.class));
+        AgencyMasterDataSyncRequestDTO.class));
   }
 
   @Test
@@ -75,17 +73,48 @@ class AppointmentServiceTest {
   }
 
   @Test
-  void syncAgencyDataToAppointmentService_Should_CallAppointmentService_WhenAppointmentsIsDisabled() {
+  void syncAgencyDataToAppointmentService_Should_CallAppointmentService_WhenAppointmentsIsEnabled() {
     setField(appointmentService, FIELD_NAME_APPOINTMENTS_ENABLED, true);
     appointmentService.syncAgencyDataToAppointmentService(agency);
     verify(appointmentAgencyApi, times(1)).agencyMasterDataSync(any(
-        de.caritas.cob.agencyservice.appointmentservice.generated.web.model.AgencyMasterDataSyncRequestDTO.class));
+        AgencyMasterDataSyncRequestDTO.class));
   }
 
   @Test
-  void deleteAgency_Should_CallAppointmentService_WhenAppointmentsIsDisabled() {
+  void deleteAgency_Should_CallAppointmentService_WhenAppointmentsIsEnabled() {
     setField(appointmentService, FIELD_NAME_APPOINTMENTS_ENABLED, true);
     appointmentService.deleteAgency(agency);
     verify(appointmentAgencyApi, times(1)).deleteAgency(anyLong());
+  }
+
+  @Test
+  void syncAgencyDataToAppointmentService_Should_SendCorrectAgencyIdAndName_When_AppointmentEnabled() {
+    setField(appointmentService, FIELD_NAME_APPOINTMENTS_ENABLED, true);
+    when(agency.getId()).thenReturn(42L);
+    when(agency.getName()).thenReturn("Test Agency");
+
+    appointmentService.syncAgencyDataToAppointmentService(agency);
+
+    ArgumentCaptor<AgencyMasterDataSyncRequestDTO> captor =
+        ArgumentCaptor.forClass(AgencyMasterDataSyncRequestDTO.class);
+    verify(appointmentAgencyApi).agencyMasterDataSync(captor.capture());
+    assertThat(captor.getValue().getId()).isEqualTo(42L);
+    assertThat(captor.getValue().getName()).isEqualTo("Test Agency");
+  }
+
+  @Test
+  void syncAgencyDataToAppointmentService_Should_AddSecurityHeaders_When_AppointmentEnabled() {
+    setField(appointmentService, FIELD_NAME_APPOINTMENTS_ENABLED, true);
+    HttpHeaders headers = new HttpHeaders();
+    headers.add("Authorization", "Bearer token");
+    when(securityHeaderSupplier.getKeycloakAndCsrfHttpHeaders()).thenReturn(headers);
+
+    appointmentService.syncAgencyDataToAppointmentService(agency);
+
+    verify(securityHeaderSupplier, times(1)).getKeycloakAndCsrfHttpHeaders();
+    verify(tenantHeaderSupplier, times(1)).addTenantHeader(any(HttpHeaders.class));
+    HttpHeaders apiClientHeaders =
+        (HttpHeaders) ReflectionTestUtils.getField(apiClient, "defaultHeaders");
+    assertThat(apiClientHeaders.get("Authorization").get(0)).isEqualTo("Bearer token");
   }
 }

--- a/src/test/java/de/caritas/cob/agencyservice/api/service/TopicServiceTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/service/TopicServiceTest.java
@@ -1,0 +1,112 @@
+package de.caritas.cob.agencyservice.api.service;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.when;
+
+import de.caritas.cob.agencyservice.api.service.securityheader.SecurityHeaderSupplier;
+import de.caritas.cob.agencyservice.api.tenant.TenantContext;
+import de.caritas.cob.agencyservice.api.util.AuthenticatedUser;
+import de.caritas.cob.agencyservice.config.apiclient.TopicServiceApiControllerFactory;
+import de.caritas.cob.agencyservice.topicservice.generated.ApiClient;
+import de.caritas.cob.agencyservice.topicservice.generated.web.TopicControllerApi;
+import de.caritas.cob.agencyservice.topicservice.generated.web.model.TopicDTO;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class TopicServiceTest {
+
+  @InjectMocks
+  TopicService topicService;
+
+  @Mock
+  TopicServiceApiControllerFactory topicServiceApiControllerFactory;
+
+  @Mock
+  TopicControllerApi topicControllerApi;
+
+  @Mock
+  SecurityHeaderSupplier securityHeaderSupplier;
+
+  @Mock
+  AuthenticatedUser authenticatedUser;
+
+  @Spy
+  TenantHeaderSupplier tenantHeaderSupplier;
+
+  @Spy
+  ApiClient apiClient;
+
+  @AfterEach
+  void tearDown() {
+    TenantContext.clear();
+  }
+
+  @Test
+  void getAllTopics_Should_ReturnTopicsFromApi() {
+    when(topicServiceApiControllerFactory.createControllerApi()).thenReturn(topicControllerApi);
+    when(topicControllerApi.getApiClient()).thenReturn(apiClient);
+    when(authenticatedUser.getAccessToken()).thenReturn("test-token");
+    when(topicControllerApi.getAllTopics()).thenReturn(List.of(new TopicDTO()));
+
+    var result = topicService.getAllTopics();
+
+    assertEquals(1, result.size());
+  }
+
+  @Test
+  void getAllTopics_Should_AddAuthorizationHeader() {
+    when(authenticatedUser.getAccessToken()).thenReturn("test-bearer-token");
+    when(topicServiceApiControllerFactory.createControllerApi()).thenReturn(topicControllerApi);
+    when(topicControllerApi.getApiClient()).thenReturn(apiClient);
+    when(topicControllerApi.getAllTopics()).thenReturn(List.of());
+
+    topicService.getAllTopics();
+
+    HttpHeaders apiClientHeaders = (HttpHeaders) ReflectionTestUtils
+        .getField(apiClient, "defaultHeaders");
+    assertEquals("Bearer test-bearer-token", apiClientHeaders.get("Authorization").get(0));
+  }
+
+  @Test
+  void getAllTopics_Should_AddTenantHeader_When_MultitenancyEnabled() {
+    TenantContext.setCurrentTenant(1L);
+    ReflectionTestUtils.setField(tenantHeaderSupplier, "multitenancy", true);
+    when(authenticatedUser.getAccessToken()).thenReturn("token");
+    when(topicServiceApiControllerFactory.createControllerApi()).thenReturn(topicControllerApi);
+    when(topicControllerApi.getApiClient()).thenReturn(apiClient);
+    when(topicControllerApi.getAllTopics()).thenReturn(List.of());
+
+    topicService.getAllTopics();
+
+    HttpHeaders apiClientHeaders = (HttpHeaders) ReflectionTestUtils
+        .getField(apiClient, "defaultHeaders");
+    assertEquals("1", apiClientHeaders.get("tenantId").get(0));
+  }
+
+  @Test
+  void getAllTopics_Should_NotAddTenantHeader_When_MultitenancyDisabled() {
+    TenantContext.setCurrentTenant(1L);
+    ReflectionTestUtils.setField(tenantHeaderSupplier, "multitenancy", false);
+    when(authenticatedUser.getAccessToken()).thenReturn("token");
+    when(topicServiceApiControllerFactory.createControllerApi()).thenReturn(topicControllerApi);
+    when(topicControllerApi.getApiClient()).thenReturn(apiClient);
+    when(topicControllerApi.getAllTopics()).thenReturn(List.of());
+
+    topicService.getAllTopics();
+
+    HttpHeaders apiClientHeaders = (HttpHeaders) ReflectionTestUtils
+        .getField(apiClient, "defaultHeaders");
+    assertNull(apiClientHeaders.get("tenantId"));
+  }
+
+}


### PR DESCRIPTION
## Summary
Consolidates 4 test coverage PRs into one.

Closes [#75](https://github.com/OpenResilienceInitiative/ORISO-AgencyService/issues/75), [#77](https://github.com/OpenResilienceInitiative/ORISO-AgencyService/issues/77), [#79](https://github.com/OpenResilienceInitiative/ORISO-AgencyService/issues/79), [#81](https://github.com/OpenResilienceInitiative/ORISO-AgencyService/issues/81)

## What's included

- **TopicService** (4 tests) — API delegation, Authorization header, tenant header on/off
- **AgencyAdminControlsFacade** (4 tests) — super-admin gate for get and update endpoints
- **AppointmentService** (extended 4→6 tests) — DTO field mapping via ArgumentCaptor, header propagation; fixed 2 misnamed tests
- **Fix JUnit 4 + junit-vintage-engine** — enables 86 previously-silent tests; fixed AgencyServiceTest, AgencyServiceTenantAwareTest, UserAdminServiceTest broken by production dependency changes

## Test results

Tests run: 40, Failures: 0, Errors: 0 — BUILD SUCCESS