### PR TITLE
test: extend DeleteAgencyServiceTest to cover exception path

### DIFF
--- a/src/test/java/de/caritas/cob/agencyservice/api/workflow/DeleteAgencyServiceTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/workflow/DeleteAgencyServiceTest.java
@@ -5,6 +5,7 @@ import de.caritas.cob.agencyservice.api.repository.agency.Agency;
 import de.caritas.cob.agencyservice.api.repository.agency.AgencyRepository;
 
 import de.caritas.cob.agencyservice.api.repository.agencypostcoderange.AgencyPostcodeRangeRepository;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -38,6 +39,25 @@ class DeleteAgencyServiceTest {
     // then
     Mockito.verify(agencyPostcodeRangeRepository).deleteAllByAgencyId(agency1.getId());
     Mockito.verify(agencyRepository).delete(agency1);
+    Mockito.verify(agencyPostcodeRangeRepository).deleteAllByAgencyId(agency2.getId());
+    Mockito.verify(agencyRepository).delete(agency2);
+  }
+
+  @Test
+  void deleteAgenciesMarkedForDeletion_Should_continueWithOtherAgencies_When_OneAgencyDeletionFails() {
+    // given
+    Agency agency1 = new Agency();
+    agency1.setId(1L);
+    Agency agency2 = new Agency();
+    agency2.setId(2L);
+    Mockito.when(agencyRepository.findAllByDeleteDateNotNull()).thenReturn(List.of(agency1, agency2));
+    Mockito.doThrow(new RuntimeException("DB error"))
+        .when(agencyPostcodeRangeRepository).deleteAllByAgencyId(agency1.getId());
+    // when
+    deleteAgencyService.deleteAgenciesMarkedForDeletion();
+    // then
+    Mockito.verify(agencyPostcodeRangeRepository).deleteAllByAgencyId(agency1.getId());
+    Mockito.verify(agencyRepository, Mockito.never()).delete(agency1);
     Mockito.verify(agencyPostcodeRangeRepository).deleteAllByAgencyId(agency2.getId());
     Mockito.verify(agencyRepository).delete(agency2);
   }


### PR DESCRIPTION
## Summary

Extends `DeleteAgencyServiceTest` from 1 to 2 tests to cover the exception-handling path in `deleteAgency()`.

## What was missing

The `catch (Exception ex)` block in `deleteAgency()` was never exercised — if one agency deletion fails, the service should log the error and continue deleting remaining agencies. This behavior was untested.

## What was added

`deleteAgenciesMarkedForDeletion_Should_continueWithOtherAgencies_When_OneAgencyDeletionFails`
- Stubs `agencyPostcodeRangeRepository.deleteAllByAgencyId()` to throw `RuntimeException` for agency 1
- Verifies agency 1 is never deleted (exception swallowed)
- Verifies agency 2 is still deleted (processing continues)

## Test results

Tests run: 2, Failures: 0, Errors: 0 — BUILD SUCCESS

## Files changed

| File | Action |
|---|---|
| `src/test/java/de/caritas/cob/agencyservice/api/workflow/DeleteAgencyServiceTest.java` | Modified |

No production code changes.