### PR TITLE
fix: add spring-boot-liquibase module so boot-time migrations run again

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -262,6 +262,13 @@
       <version>${liquibase-core.version}</version>
     </dependency>
 
+    <!-- Spring Boot 4 moved LiquibaseAutoConfiguration into its own module;
+         without this, spring.liquibase.* is silently ignored at boot. -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-liquibase</artifactId>
+    </dependency>
+
 
     <dependency>
       <groupId>org.apache.httpcomponents.client5</groupId>


### PR DESCRIPTION
## What breaks without this

Since the Spring Boot 4 upgrade, turning Liquibase on does nothing. Spring Boot 4 moved `LiquibaseAutoConfiguration` out of `spring-boot-autoconfigure` into the separate `spring-boot-liquibase` module. AgencyService only depends on `liquibase-core`, so `spring.liquibase.enabled=true` is silently a no-op — no migrations run at startup and nothing warns about it.

## Fix

Add the `spring-boot-liquibase` dependency (version managed by the Spring Boot parent, resolves to 4.0.1). One pom.xml change, nothing else.

## How it was found

Full-platform bootstrap from empty databases on the local fast-track stack (2026-07-04): AgencyService booted against an empty schema without running a single changeset. With this dependency added, the full chain (26/26 changesets, including the ones repaired in #91) runs at boot and bootstraps the schema from scratch — AgencyService is the only service whose chain then even passes `ddl-auto=validate`.

## Validation

- `./mvnw -B compile` green (JDK 21)
- `mvn dependency:tree` now shows `org.springframework.boot:spring-boot-liquibase:jar:4.0.1:compile`
- Boot-level: on the fast-track stack the same change made the AgencyService Liquibase chain execute 26/26 changesets against a fresh MariaDB 10.11

Sibling fixes: same change for TenantService, and #91 for the changelog-chain repair this pairs with.

🤖 Generated with [Claude Code](https://claude.com/claude-code)