### PR TITLE
fix(test): migrate last 2 @MockBean tests to @MockitoBean so the SB4 test tree compiles

### DIFF
--- a/src/test/java/de/caritas/cob/agencyservice/api/service/TenantServiceGetRestrictedTenantDataByTenantIdCacheTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/service/TenantServiceGetRestrictedTenantDataByTenantIdCacheTest.java
@@ -11,7 +11,7 @@ import de.caritas.cob.agencyservice.tenantservice.generated.web.model.Restricted
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
@@ -44,9 +44,9 @@ class TenantServiceGetRestrictedTenantDataByTenantIdCacheTest {
     }
   }
 
-  @MockBean private TenantServiceApiControllerFactory tenantServiceApiControllerFactory;
+  @MockitoBean private TenantServiceApiControllerFactory tenantServiceApiControllerFactory;
 
-  @MockBean private ApplicationSettingsService applicationSettingsService;
+  @MockitoBean private ApplicationSettingsService applicationSettingsService;
 
   @Autowired private TenantService tenantService;
 

--- a/src/test/java/de/caritas/cob/agencyservice/api/service/TenantServiceGetRestrictedTenantDataForSingleTenantCacheTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/service/TenantServiceGetRestrictedTenantDataForSingleTenantCacheTest.java
@@ -11,7 +11,7 @@ import de.caritas.cob.agencyservice.tenantservice.generated.web.model.Restricted
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
@@ -42,9 +42,9 @@ class TenantServiceGetRestrictedTenantDataForSingleTenantCacheTest {
     }
   }
 
-  @MockBean private TenantServiceApiControllerFactory tenantServiceApiControllerFactory;
+  @MockitoBean private TenantServiceApiControllerFactory tenantServiceApiControllerFactory;
 
-  @MockBean private ApplicationSettingsService applicationSettingsService;
+  @MockitoBean private ApplicationSettingsService applicationSettingsService;
 
   @Autowired private TenantService tenantService;
 


### PR DESCRIPTION
## Why

The Spring Boot 4 upgrade removed `org.springframework.boot.test.mock.mockito.MockBean`. The recent SB4 test-compilation repairs (`35aad2d`, `567d803`) fixed almost all of it, but **two files were missed** and still import the removed package:

- `TenantServiceGetRestrictedTenantDataByTenantIdCacheTest`
- `TenantServiceGetRestrictedTenantDataForSingleTenantCacheTest`

Because a single "package not found" fails the **whole** test-compile, `src/test` does not compile on `dev` today. It hasn't been noticed because CI runs `-Dmaven.test.skip=true` (which also skips test compilation), so `mvnw test` / any local run fails before executing a single test.

## What

Migrate the two files: `@MockBean` → `@MockitoBean` (`org.springframework.test.context.bean.override.mockito.MockitoBean`). Test-only change; no production code touched.

## Verification (JDK 21, locally)

- With this change, `./mvnw -B test` compiles and runs: **438 tests, 0 failures**, 5 errors — and those 5 are all pre-existing in the new ADR-003 test `AgencyTopicDepartmentConstraintRepositoryTest` (`NULL not allowed for DATA_PROTECTION_OFFICER_CONTACT`), unrelated to this change.
- The current CI command `./mvnw -B -Dmaven.test.skip=true package` stays green (0 Checkstyle violations, BUILD SUCCESS).

## Note (not in this PR)

This is a prerequisite for turning CI test execution back on. Two follow-ups surfaced while verifying and are tracked separately: the 5 ADR-003 `AgencyTopicDepartmentConstraintRepositoryTest` errors (a nullability decision), and a runtime caching bug under SB4 (`CacheManagerConfig` still wires the ehcache2→Spring bridge removed in Spring 6).

Affected repos: ORISO-AgencyService