### PR TITLE
fix(cache): migrate AgencyService caching to Caffeine for Spring Boot 4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,6 @@
     <liquibase-maven-plugin.version>4.23.2</liquibase-maven-plugin.version>
     <h2.version>1.4.200</h2.version>
     <powermock-module-junit4.version>2.0.9</powermock-module-junit4.version>
-    <ehcache.version>2.10.6</ehcache.version>
     <easy-random-core.version>5.0.0</easy-random-core.version>
     <spring-boot-autoconfigure.version>4.0.1</spring-boot-autoconfigure.version>
     <liquibase-core.version>4.23.2</liquibase-core.version>
@@ -83,6 +82,11 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-cache</artifactId>
+    </dependency>
+    <dependency>
+      <!-- Native Spring Boot 4 cache provider; version managed by the Spring Boot parent BOM. -->
+      <groupId>com.github.ben-manes.caffeine</groupId>
+      <artifactId>caffeine</artifactId>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
@@ -273,18 +277,6 @@
     <dependency>
       <groupId>org.apache.httpcomponents.client5</groupId>
       <artifactId>httpclient5</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>net.sf.ehcache</groupId>
-      <artifactId>ehcache</artifactId>
-      <version>2.10.9.2</version>
-      <exclusions>
-        <exclusion>
-          <groupId>com.fasterxml.jackson.core</groupId>
-          <artifactId>jackson-databind</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
 
     <!-- https://mvnrepository.com/artifact/org.mariadb.jdbc/mariadb-java-client -->

--- a/src/main/java/de/caritas/cob/agencyservice/config/CacheManagerConfig.java
+++ b/src/main/java/de/caritas/cob/agencyservice/config/CacheManagerConfig.java
@@ -1,13 +1,32 @@
 package de.caritas.cob.agencyservice.config;
 
-import net.sf.ehcache.config.CacheConfiguration;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import java.time.Duration;
+import java.util.List;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
-
+import org.springframework.cache.caffeine.CaffeineCacheManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+/**
+ * Caching configuration for the agency service.
+ *
+ * <p>Backed by Caffeine, which is the native cache provider on Spring Boot 4. Previously this class
+ * defined only a {@code net.sf.ehcache.CacheManager} (ehcache2) bean and relied on the Spring bridge
+ * {@code org.springframework.cache.ehcache.EhCacheCacheManager} to expose it as a Spring
+ * {@link CacheManager}. That bridge was removed in Spring Framework 6 (Spring Boot 3+), so under
+ * Spring Boot 4 no Spring {@link CacheManager} SPI bean was produced and every {@code @Cacheable}
+ * call failed at runtime with {@code NoSuchBeanDefinitionException: No qualifying bean of type
+ * 'org.springframework.cache.CacheManager' available}. Caffeine restores a correct SPI bean while
+ * preserving every cache name and its time-to-live / time-to-idle / maximum-size semantics.
+ *
+ * <p>ehcache-to-Caffeine mapping: {@code maxEntriesLocalHeap} -&gt; {@code maximumSize},
+ * {@code timeToLiveSeconds} -&gt; {@code expireAfterWrite}, {@code timeToIdleSeconds} -&gt;
+ * {@code expireAfterAccess}. A value of {@code 0} for a TTL means "no expiry" in ehcache and is
+ * therefore not applied. When {@code eternal=true}, no expiry policy is applied at all.
+ */
 @Configuration
 @EnableCaching
 public class CacheManagerConfig {
@@ -66,53 +85,65 @@ public class CacheManagerConfig {
   @Value("${cache.applicationsettings.configuration.timeToLiveSeconds}")
   private long applicationSettingsTimeToLiveSeconds;
 
-  @Bean(destroyMethod = "shutdown")
-  public net.sf.ehcache.CacheManager ehCacheManager() {
-    var config = new net.sf.ehcache.config.Configuration();
-    config.addCache(buildConsultingTypeCacheConfiguration());
-    config.addCache(buildTenantCacheConfiguration());
-    config.addCache(buildTopicCacheConfiguration());
-    config.addCache(buildApplicationSettingsCacheConfiguration());
-    return net.sf.ehcache.CacheManager.newInstance(config);
+  @Bean
+  public CacheManager cacheManager() {
+    var cacheManager = new CaffeineCacheManager();
+    // Restrict to the explicitly registered caches; dynamic creation of unknown cache names is
+    // disabled, mirroring the previous ehcache behaviour where only declared caches existed.
+    cacheManager.setCacheNames(
+        List.of(CONSULTING_TYPE_CACHE, TENANT_CACHE, TOPICS_CACHE, APPLICATION_SETTINGS_CACHE));
+    cacheManager.registerCustomCache(
+        CONSULTING_TYPE_CACHE,
+        buildCache(
+                consultingTypeMaxEntriesLocalHeap,
+                consultingTypeEternal,
+                consultingTypeTimeToIdleSeconds,
+                consultingTypeTimeToLiveSeconds)
+            .build());
+    cacheManager.registerCustomCache(
+        TENANT_CACHE,
+        buildCache(
+                tenantMaxEntriesLocalHeap,
+                tenantEternal,
+                tenantTimeToIdleSeconds,
+                tenantTimeToLiveSeconds)
+            .build());
+    cacheManager.registerCustomCache(
+        TOPICS_CACHE,
+        buildCache(
+                topicMaxEntriesLocalHeap,
+                topicEternal,
+                topicTimeToIdleSeconds,
+                topicTimeToLiveSeconds)
+            .build());
+    cacheManager.registerCustomCache(
+        APPLICATION_SETTINGS_CACHE,
+        buildCache(
+                applicationSettingsMaxEntriesLocalHeap,
+                applicationSettingsEternal,
+                applicationSettingsTimeToIdleSeconds,
+                applicationSettingsTimeToLiveSeconds)
+            .build());
+    return cacheManager;
   }
 
-  private CacheConfiguration buildTopicCacheConfiguration() {
-    var topicCacheConfiguration = new CacheConfiguration();
-    topicCacheConfiguration.setName(TOPICS_CACHE);
-    topicCacheConfiguration.setMaxEntriesLocalHeap(topicMaxEntriesLocalHeap);
-    topicCacheConfiguration.setEternal(topicEternal);
-    topicCacheConfiguration.setTimeToIdleSeconds(topicTimeToIdleSeconds);
-    topicCacheConfiguration.setTimeToLiveSeconds(topicTimeToLiveSeconds);
-    return topicCacheConfiguration;
-  }
-
-  private CacheConfiguration buildApplicationSettingsCacheConfiguration() {
-    var topicCacheConfiguration = new CacheConfiguration();
-    topicCacheConfiguration.setName(APPLICATION_SETTINGS_CACHE);
-    topicCacheConfiguration.setMaxEntriesLocalHeap(topicMaxEntriesLocalHeap);
-    topicCacheConfiguration.setEternal(topicEternal);
-    topicCacheConfiguration.setTimeToIdleSeconds(topicTimeToIdleSeconds);
-    topicCacheConfiguration.setTimeToLiveSeconds(topicTimeToLiveSeconds);
-    return topicCacheConfiguration;
-  }
-
-  private CacheConfiguration buildConsultingTypeCacheConfiguration() {
-    var consultingTypeCacheConfiguration = new CacheConfiguration();
-    consultingTypeCacheConfiguration.setName(CONSULTING_TYPE_CACHE);
-    consultingTypeCacheConfiguration.setMaxEntriesLocalHeap(consultingTypeMaxEntriesLocalHeap);
-    consultingTypeCacheConfiguration.setEternal(consultingTypeEternal);
-    consultingTypeCacheConfiguration.setTimeToIdleSeconds(consultingTypeTimeToIdleSeconds);
-    consultingTypeCacheConfiguration.setTimeToLiveSeconds(consultingTypeTimeToLiveSeconds);
-    return consultingTypeCacheConfiguration;
-  }
-
-  private CacheConfiguration buildTenantCacheConfiguration() {
-    var tenantCacheConfiguration = new CacheConfiguration();
-    tenantCacheConfiguration.setName(TENANT_CACHE);
-    tenantCacheConfiguration.setMaxEntriesLocalHeap(tenantMaxEntriesLocalHeap);
-    tenantCacheConfiguration.setEternal(tenantEternal);
-    tenantCacheConfiguration.setTimeToIdleSeconds(tenantTimeToIdleSeconds);
-    tenantCacheConfiguration.setTimeToLiveSeconds(tenantTimeToLiveSeconds);
-    return tenantCacheConfiguration;
+  /**
+   * Builds a Caffeine spec preserving the ehcache semantics: a {@code maxEntriesLocalHeap} bound,
+   * and — unless the cache is eternal — a time-to-live ({@code expireAfterWrite}) and a
+   * time-to-idle ({@code expireAfterAccess}). A TTL of {@code 0} means "no expiry" in ehcache and
+   * is therefore skipped.
+   */
+  private Caffeine<Object, Object> buildCache(
+      long maxEntriesLocalHeap, boolean eternal, long timeToIdleSeconds, long timeToLiveSeconds) {
+    var caffeine = Caffeine.newBuilder().maximumSize(maxEntriesLocalHeap);
+    if (!eternal) {
+      if (timeToLiveSeconds > 0) {
+        caffeine.expireAfterWrite(Duration.ofSeconds(timeToLiveSeconds));
+      }
+      if (timeToIdleSeconds > 0) {
+        caffeine.expireAfterAccess(Duration.ofSeconds(timeToIdleSeconds));
+      }
+    }
+    return caffeine;
   }
 }

--- a/src/test/java/de/caritas/cob/agencyservice/api/service/TenantServiceGetRestrictedTenantDataByTenantIdCacheTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/service/TenantServiceGetRestrictedTenantDataByTenantIdCacheTest.java
@@ -11,7 +11,7 @@ import de.caritas.cob.agencyservice.tenantservice.generated.web.model.Restricted
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
@@ -44,9 +44,9 @@ class TenantServiceGetRestrictedTenantDataByTenantIdCacheTest {
     }
   }
 
-  @MockBean private TenantServiceApiControllerFactory tenantServiceApiControllerFactory;
+  @MockitoBean private TenantServiceApiControllerFactory tenantServiceApiControllerFactory;
 
-  @MockBean private ApplicationSettingsService applicationSettingsService;
+  @MockitoBean private ApplicationSettingsService applicationSettingsService;
 
   @Autowired private TenantService tenantService;
 

--- a/src/test/java/de/caritas/cob/agencyservice/api/service/TenantServiceGetRestrictedTenantDataForSingleTenantCacheTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/service/TenantServiceGetRestrictedTenantDataForSingleTenantCacheTest.java
@@ -11,7 +11,7 @@ import de.caritas.cob.agencyservice.tenantservice.generated.web.model.Restricted
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
@@ -42,9 +42,9 @@ class TenantServiceGetRestrictedTenantDataForSingleTenantCacheTest {
     }
   }
 
-  @MockBean private TenantServiceApiControllerFactory tenantServiceApiControllerFactory;
+  @MockitoBean private TenantServiceApiControllerFactory tenantServiceApiControllerFactory;
 
-  @MockBean private ApplicationSettingsService applicationSettingsService;
+  @MockitoBean private ApplicationSettingsService applicationSettingsService;
 
   @Autowired private TenantService tenantService;
 

--- a/src/test/java/de/caritas/cob/agencyservice/config/CacheManagerConfigIT.java
+++ b/src/test/java/de/caritas/cob/agencyservice/config/CacheManagerConfigIT.java
@@ -1,0 +1,93 @@
+package de.caritas.cob.agencyservice.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import de.caritas.cob.agencyservice.api.service.ApplicationSettingsService;
+import de.caritas.cob.agencyservice.api.service.TenantService;
+import de.caritas.cob.agencyservice.config.apiclient.TenantServiceApiControllerFactory;
+import de.caritas.cob.agencyservice.tenantservice.generated.web.TenantControllerApi;
+import de.caritas.cob.agencyservice.tenantservice.generated.web.model.RestrictedTenantDTO;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cache.CacheManager;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+/**
+ * Integration test that boots the <b>real</b> {@link CacheManagerConfig} — not a test-local
+ * cache manager — and asserts that a Spring {@link CacheManager} SPI bean actually exists and
+ * resolves every named cache, and that a real {@code @Cacheable} method is cached.
+ *
+ * <p>This is the test the "Test Quality Audit 2026-07-04 — live AgencyService ehcache/SB4 finding"
+ * flagged as missing: the existing {@code *CacheTest} classes each supply their own
+ * {@code ConcurrentMapCacheManager} and therefore never exercise the production
+ * {@code CacheManagerConfig}. Under Spring Boot 4 that config wired only a
+ * {@code net.sf.ehcache.CacheManager} (ehcache2) bean, but the Spring bridge
+ * {@code org.springframework.cache.ehcache.EhCacheCacheManager} was removed in Spring Framework 6,
+ * so no Spring {@link CacheManager} SPI bean existed and every {@code @Cacheable} call threw
+ * {@code IllegalArgumentException: Cannot find cache named ...} at runtime.
+ */
+@SpringBootTest(
+    classes = {
+      CacheManagerConfig.class,
+      TenantService.class
+    },
+    webEnvironment = SpringBootTest.WebEnvironment.NONE)
+@TestPropertySource(
+    properties = {
+      "multitenancy.enabled=false",
+      "feature.multitenancy.with.single.domain.enabled=false",
+      "cache.consulting.type.configuration.maxEntriesLocalHeap=1000",
+      "cache.consulting.type.configuration.eternal=false",
+      "cache.consulting.type.configuration.timeToIdleSeconds=300",
+      "cache.consulting.type.configuration.timeToLiveSeconds=600",
+      "cache.tenant.configuration.maxEntriesLocalHeap=1000",
+      "cache.tenant.configuration.eternal=false",
+      "cache.tenant.configuration.timeToIdleSeconds=300",
+      "cache.tenant.configuration.timeToLiveSeconds=600",
+      "cache.topic.configuration.maxEntriesLocalHeap=1000",
+      "cache.topic.configuration.eternal=false",
+      "cache.topic.configuration.timeToIdleSeconds=300",
+      "cache.topic.configuration.timeToLiveSeconds=600",
+      "cache.applicationsettings.configuration.maxEntriesLocalHeap=100",
+      "cache.applicationsettings.configuration.eternal=false",
+      "cache.applicationsettings.configuration.timeToIdleSeconds=300",
+      "cache.applicationsettings.configuration.timeToLiveSeconds=600"
+    })
+class CacheManagerConfigIT {
+
+  @Autowired private CacheManager cacheManager;
+
+  @Autowired private TenantService tenantService;
+
+  @MockitoBean private TenantServiceApiControllerFactory tenantServiceApiControllerFactory;
+
+  @MockitoBean private ApplicationSettingsService applicationSettingsService;
+
+  @Test
+  void springCacheManagerSpiBean_shouldExistAndResolveEveryNamedCache() {
+    assertThat(cacheManager).isNotNull();
+    assertThat(cacheManager.getCache(CacheManagerConfig.CONSULTING_TYPE_CACHE)).isNotNull();
+    assertThat(cacheManager.getCache(CacheManagerConfig.TENANT_CACHE)).isNotNull();
+    assertThat(cacheManager.getCache(CacheManagerConfig.TOPICS_CACHE)).isNotNull();
+    assertThat(cacheManager.getCache(CacheManagerConfig.APPLICATION_SETTINGS_CACHE)).isNotNull();
+  }
+
+  @Test
+  void cacheableMethod_shouldServeSecondCallFromCache() {
+    TenantControllerApi controllerApi = org.mockito.Mockito.mock(TenantControllerApi.class);
+    when(tenantServiceApiControllerFactory.createControllerApi()).thenReturn(controllerApi);
+    when(controllerApi.getRestrictedSingleTenancyTenantData())
+        .thenReturn(new RestrictedTenantDTO().id(1L));
+
+    tenantService.getRestrictedTenantDataForSingleTenant();
+    tenantService.getRestrictedTenantDataForSingleTenant();
+
+    // Second invocation must be served from the cache, so the collaborator is hit only once.
+    verify(controllerApi, times(1)).getRestrictedSingleTenancyTenantData();
+  }
+}


### PR DESCRIPTION
## Summary

Fixes a **verified live production bug**: under Spring Boot 4, AgencyService's `@Cacheable` caching is completely broken — every cache call fails at runtime.

Reference: **Test Quality Audit 2026-07-04 — live AgencyService ehcache/SB4 finding.**

## The runtime failure

`config/CacheManagerConfig.java` is `@Configuration @EnableCaching` (no `@Profile`, so **all environments incl. prod**) and defined **only** a `net.sf.ehcache.CacheManager` (ehcache2) bean. It relied on the Spring bridge `org.springframework.cache.ehcache.EhCacheCacheManager` to expose that as a Spring `CacheManager`.

**That bridge was removed in Spring Framework 6 (Spring Boot 3+)** and is not on the SB4 classpath. So no Spring `CacheManager` SPI bean existed. Every `@Cacheable` method — `topicsCache`, `tenantCache`, `consultingTypeCache`, `applicationSettingsCache` (in `TopicService`, `TenantService`, `ConsultingTypeService`, `ApplicationSettingsService`) — failed. AgencyService went SB4 in #67; this config was simply missed.

Proven root cause (from the new IT booting the real config against the old ehcache2 code):

```
Caused by: org.springframework.beans.factory.NoSuchBeanDefinitionException:
  No qualifying bean of type 'org.springframework.cache.CacheManager' available:
  no CacheResolver specified - register a CacheManager bean or remove the
  @EnableCaching annotation from your configuration.
```

## The fix — migrate to Caffeine

Caffeine is the **native Spring Boot 4 cache provider**: it produces a correct `CacheManager` SPI bean, needs no XML, and is version-managed by the SB4 parent BOM (resolves **3.2.3**). Chosen over ehcache3/JCache for simplicity and because it needs no config file.

Every cache name and its semantics are **preserved**, mapping ehcache → Caffeine:

| ehcache | Caffeine |
|---|---|
| `maxEntriesLocalHeap` | `maximumSize` |
| `timeToLiveSeconds` | `expireAfterWrite` |
| `timeToIdleSeconds` | `expireAfterAccess` |
| `eternal=true` | no expiry policy |
| TTL value `0` | no expiry (skipped) |

Cache names are restricted to the four declared caches (dynamic creation disabled), mirroring the previous fail-fast-on-unknown-name behaviour.

### Preserved per-cache TTL / max-size (unchanged, from `application*.properties`)

Values are identical to before — this PR does not change any property. Per profile:

| Cache | Profile | maxSize | eternal | TTI (idle) s | TTL (live) s |
|---|---|---|---|---|---|
| consultingTypeCache | default | 100 | false | 0 (none) | 86400 |
| tenantCache | default | 100 | false | 0 (none) | 86400 |
| topicsCache | default | 100 | false | 0 (none) | 60 |
| applicationSettingsCache | default | 100 | false | 0 (none) | 60 |
| consultingTypeCache | dev/prod/staging | 1000 | false | 300 | 600 |
| tenantCache | dev/prod/staging | 1000 | false | 300 | 600 |
| topicsCache | dev/prod/staging | 1000 | false | 300 | 600 |
| applicationSettingsCache | dev/prod/staging | 100 | false | 300 | 600 |

### Dependency change

- **Removed** the dead `net.sf.ehcache:ehcache` dependency and its `ehcache.version` property. `grep` confirmed `net.sf.ehcache` was used **only** in `CacheManagerConfig.java`; `dependency:list` confirms it is now off the classpath.
- **Added** `com.github.ben-manes.caffeine:caffeine` (no explicit version — BOM-managed).

## Test that would have caught it

The pre-existing `*CacheTest` classes each supply their **own** `ConcurrentMapCacheManager` in a nested `@Configuration`, so they never exercised the production `CacheManagerConfig` — which is exactly why this shipped with no red test.

New `config/CacheManagerConfigIT` boots the **real** `CacheManagerConfig` and asserts:
1. a Spring `CacheManager` SPI bean exists and resolves **every** named cache;
2. a real `@Cacheable` method (`TenantService.getRestrictedTenantDataForSingleTenant`) is served from cache on the second call (collaborator hit once).

**Red → green evidence** (JDK 21):

- **RED** against the old ehcache2 config: context fails to load — `NoSuchBeanDefinitionException: No qualifying bean of type 'org.springframework.cache.CacheManager'` (both tests error).
- **GREEN** against Caffeine: `Tests run: 2, Failures: 0, Errors: 0`. Full caching-test set (new IT + 2 pre-existing) `Tests run: 4, Failures: 0, Errors: 0` with **0 Checkstyle violations** (`google_checks_light.xml`), `BUILD SUCCESS`.

## Cross-check of the other SB4 backends

Grepped each `CacheManagerConfig`. **AgencyService was the only broken one** — it was missed when UserService got its SB4 caching fix:

| Backend | Spring Boot | Caching | Verdict |
|---|---|---|---|
| **UserService** | 4.0.1 | ehcache2 via a **hand-rolled** `EhCache2CacheManager extends AbstractCacheManager` + `EhCache2Cache` adapter (NOT the removed bridge) | OK — already fixed with a different idiom |
| **TenantService** | 4.0.1 | ehcache3 / JCache (`spring.cache.jcache.config=classpath:ehcache.xml`) | OK |
| **ConsultingTypeService** | 2.7.14 | classic `EhCacheCacheManager` + ehcache2 | OK **on 2.7.x** — the bridge still exists in Spring 5.x. **Would break the moment it is bumped to SB3/SB4.** |

No follow-up needed now; flag ConsultingTypeService's caching for its eventual SB4 bump. None of the backends use Caffeine, so there was no existing Caffeine idiom to mirror — introduced fresh here. (UserService's `EhCache2CacheManager` adapter was the alternative; Caffeine is cleaner.)

## Scope / overlap notes

- Touches only `CacheManagerConfig` + its test + `pom.xml`.
- **Overlaps with #94**: this PR also migrates the two pre-existing cache tests from the removed `@MockBean` (`org.springframework.boot.test.mock.mockito`) to `@MockitoBean` — the identical two-line change #94 makes — because the test tree does not compile on `dev` without it, and the new IT needs a compiling tree to prove red→green. If #94 merges first, these are identical/trivially-resolved.
- Did **not** touch `.github/` (owned by a sibling CI agent, #89).
- Unrelated pre-existing local test failures (`AgencyTopicDepartmentConstraintRepositoryTest` / `AgencyRepositoryTenantAwareIT` — `DATA_PROTECTION_OFFICER_CONTACT` NOT NULL and `AgencyDatabase.sql` H2 drift from #90's ADR-003 work, plus IT `Connection refused`) were verified to fail identically on clean `origin/dev` with the original ehcache2 config — they are not caused by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
