### PR TITLE
fix(adr-003): dev mode for DPO contact so AgencyService tests can run

### DIFF
--- a/src/main/java/de/caritas/cob/agencyservice/api/admin/validation/validators/AgencyDataProtectionValidationService.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/admin/validation/validators/AgencyDataProtectionValidationService.java
@@ -11,11 +11,23 @@ import de.caritas.cob.agencyservice.api.exception.httpresponses.InvalidOfflineSt
 import de.caritas.cob.agencyservice.api.model.DataProtectionContactDTO;
 import de.caritas.cob.agencyservice.api.repository.agency.DataProtectionPlaceHolderType;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 @Component
 @Slf4j
 public class AgencyDataProtectionValidationService {
+
+  /**
+   * ADR-003 "dev mode" switch. The data protection officer contact is a legal imprint/DPP
+   * requirement (ADR-003) and stays MANDATORY in production, so this defaults to {@code true}. It
+   * is set to {@code false} in the {@code testing} (and local/dev) profiles so tests and dev flows
+   * can create an agency without a fully populated DPO contact — the DB column itself is nullable
+   * (changeset 0016/0024). Decided in #oriso-codereview: "brauchen einen dev modus, sonst koennen
+   * wir nichts testen".
+   */
+  @Value("${agency.department.require-dpo-contact:true}")
+  private boolean requireDataProtectionOfficerContact;
 
   public void validate(ValidateAgencyDTO validateAgencyDto) {
     validateThatDataProtectionDtoExists(validateAgencyDto);
@@ -35,6 +47,11 @@ public class AgencyDataProtectionValidationService {
   }
 
   private void validateIfDataProtectionOfficer(ValidateAgencyDTO validateAgencyDto) {
+    if (!requireDataProtectionOfficerContact) {
+      // ADR-003 dev mode: requirement relaxed (testing/dev profiles) so agencies can be created
+      // without a complete DPO contact. Production keeps requireDataProtectionOfficerContact=true.
+      return;
+    }
     if (DATA_PROTECTION_OFFICER.equals(
         validateAgencyDto.getDataProtectionDTO().getDataProtectionResponsibleEntity())
         && areFieldsEmpty(

--- a/src/main/java/de/caritas/cob/agencyservice/api/repository/agency/Agency.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/repository/agency/Agency.java
@@ -155,7 +155,13 @@ public class Agency implements TenantAware {
   @Enumerated(EnumType.STRING)
   private DataProtectionResponsibleEntity dataProtectionResponsibleEntity;
 
-  @Column(name = "data_protection_officer_contact", columnDefinition = "longtext", nullable = false)
+  // ADR-003 dev mode: the DB column is nullable (changeset 0016 declares it NULL, made explicit
+  // in 0024). "Required" is enforced at the application layer, gated by the
+  // agency.department.require-dpo-contact flag (default true in prod, false in testing/dev), so
+  // dev/test flows and the @DataJpaTest persistence tests can insert an Agency without it while
+  // production still rejects a missing DPO contact. Keeping nullable=false here would re-impose a
+  // hard NOT NULL on the create-drop test schema and block testing — see #oriso-codereview thread.
+  @Column(name = "data_protection_officer_contact", columnDefinition = "longtext")
   @JdbcTypeCode(Types.LONGVARCHAR)
   private String dataProtectionOfficerContactData;
 

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -105,3 +105,9 @@ cache.applicationsettings.configuration.eternal=false
 cache.applicationsettings.configuration.timeToIdleSeconds=300
 cache.applicationsettings.configuration.timeToLiveSeconds=600
 keycloak.ssl-required=none
+
+# ---------------- ADR-003 department / DPO contact (dev mode) ----------------
+# Relaxed on the dev environment so agencies can be created without a complete DPO contact
+# while building/testing. Production (application-prod.properties) keeps the base default (true).
+# See ADR-003 and the #oriso-codereview thread.
+agency.department.require-dpo-contact=false

--- a/src/main/resources/application-testing.properties
+++ b/src/main/resources/application-testing.properties
@@ -104,3 +104,9 @@ cache.applicationsettings.configuration.eternal=false
 cache.applicationsettings.configuration.timeToIdleSeconds=300
 cache.applicationsettings.configuration.timeToLiveSeconds=600
 keycloak.ssl-required=none
+
+# ---------------- ADR-003 department / DPO contact (dev mode) ----------------
+# Relaxed in the testing profile so @DataJpaTest / service tests and dev flows can create an
+# agency without a complete DPO contact. Production keeps the base default (true). See ADR-003
+# and the #oriso-codereview thread.
+agency.department.require-dpo-contact=false

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -143,6 +143,13 @@ feature.appointment.enabled=false
 feature.multitenancy.with.single.domain.enabled=${FEATURE_MULTITENANCY_WITH_SINGLE_DOMAIN_ENABLED:false}
 multitenancy.enabled=${MULTITENANCY_ENABLED:false}
 
+# ---------------- ADR-003 department / DPO contact ----------------
+# The data protection officer contact is a legal imprint/DPP requirement (ADR-003) and is
+# MANDATORY in production (this default). The testing/local/dev profiles override it to false
+# ("dev mode", decided in #oriso-codereview) so tests and dev flows can create agencies without
+# a fully populated DPO contact. Enforcement is application-layer; the DB column is nullable.
+agency.department.require-dpo-contact=${AGENCY_DEPARTMENT_REQUIRE_DPO_CONTACT:true}
+
 
 # ---------------- Actuator ----------------
 management.endpoint.health.enabled=true

--- a/src/main/resources/db/changelog/agencyservice-master.xml
+++ b/src/main/resources/db/changelog/agencyservice-master.xml
@@ -61,6 +61,10 @@
   <include file="db/changelog/changeset/0021_agency_topic_legal/0021_changeSet.xml"/>
   <include file="db/changelog/changeset/0022_agency_address_contact/0022_changeSet.xml"/>
   <include file="db/changelog/changeset/0023_agency_topic_department/0023_changeSet.xml"/>
+  <!-- ADR-003 dev mode: make agency.data_protection_officer_contact explicitly nullable so
+       testing/dev can create agencies without it; required stays enforced at the app layer in
+       prod (agency.department.require-dpo-contact). Additive, preconditioned (MARK_RAN). -->
+  <include file="db/changelog/changeset/0024_agency_dpo_contact_nullable/0024_changeSet.xml"/>
 
   <!--
     L1 gap detection (2026-07-04): the consolidated changelog was run against a fresh MariaDB

--- a/src/main/resources/db/changelog/agencyservice-master.xml
+++ b/src/main/resources/db/changelog/agencyservice-master.xml
@@ -60,6 +60,7 @@
   <include file="db/changelog/changeset/0020_agency_settings/0020_changeSet.xml"/>
   <include file="db/changelog/changeset/0021_agency_topic_legal/0021_changeSet.xml"/>
   <include file="db/changelog/changeset/0022_agency_address_contact/0022_changeSet.xml"/>
+  <include file="db/changelog/changeset/0023_agency_topic_department/0023_changeSet.xml"/>
 
   <!--
     L1 gap detection (2026-07-04): the consolidated changelog was run against a fresh MariaDB

--- a/src/main/resources/db/changelog/changeset/0024_agency_dpo_contact_nullable/0024_changeSet.xml
+++ b/src/main/resources/db/changelog/changeset/0024_agency_dpo_contact_nullable/0024_changeSet.xml
@@ -1,0 +1,19 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd">
+    <!-- ADR-003 dev mode: make agency.data_protection_officer_contact explicitly NULLABLE so
+         testing/dev can create agencies without a DPO contact. "Required" is enforced at the
+         application layer (agency.department.require-dpo-contact, default true in prod). The
+         precondition MARK_RANs on any database where the column is missing, so the changeset is
+         safe on partially-migrated schemas. Additive and idempotent. -->
+    <changeSet author="oriso" id="makeDataProtectionOfficerContactNullable">
+        <preConditions onFail="MARK_RAN">
+            <columnExists tableName="agency" columnName="data_protection_officer_contact"/>
+        </preConditions>
+        <sqlFile path="db/changelog/changeset/0024_agency_dpo_contact_nullable/makeDataProtectionOfficerContactNullable.sql" stripComments="true"/>
+        <rollback>
+            <sqlFile path="db/changelog/changeset/0024_agency_dpo_contact_nullable/makeDataProtectionOfficerContactNullable-rollback.sql" stripComments="true"/>
+        </rollback>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changeset/0024_agency_dpo_contact_nullable/makeDataProtectionOfficerContactNullable-rollback.sql
+++ b/src/main/resources/db/changelog/changeset/0024_agency_dpo_contact_nullable/makeDataProtectionOfficerContactNullable-rollback.sql
@@ -1,0 +1,5 @@
+-- Rollback: restore the NOT NULL constraint on the data protection officer contact column.
+-- Only safe when every existing agency row has a non-null value; otherwise this fails, which is
+-- the intended guard (ADR-003 production requirement).
+ALTER TABLE `agencyservice`.`agency`
+MODIFY COLUMN data_protection_officer_contact longtext NOT NULL;

--- a/src/main/resources/db/changelog/changeset/0024_agency_dpo_contact_nullable/makeDataProtectionOfficerContactNullable.sql
+++ b/src/main/resources/db/changelog/changeset/0024_agency_dpo_contact_nullable/makeDataProtectionOfficerContactNullable.sql
@@ -1,0 +1,9 @@
+-- ADR-003 dev mode (#oriso-codereview): make the data protection officer contact column
+-- explicitly NULLABLE at the DB level. It was already created NULL in changeset 0016, but the
+-- JPA entity previously declared nullable=false, re-imposing a hard NOT NULL on the H2
+-- create-drop test schema and blocking testing/dev. "Required" is now enforced at the
+-- application layer, gated by agency.department.require-dpo-contact (true in prod, false in
+-- testing/dev). This changeset locks the nullable contract so the two layers cannot drift.
+-- Idempotent: re-modifying an already-nullable column is a safe no-op.
+ALTER TABLE `agencyservice`.`agency`
+MODIFY COLUMN data_protection_officer_contact longtext NULL;

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/validation/validators/AgencyDataProtectionValidationServiceTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/validation/validators/AgencyDataProtectionValidationServiceTest.java
@@ -11,16 +11,27 @@ import de.caritas.cob.agencyservice.api.model.DataProtectionDTO.DataProtectionRe
 import de.caritas.cob.agencyservice.tenantservice.generated.web.model.Content;
 import de.caritas.cob.agencyservice.tenantservice.generated.web.model.RestrictedTenantDTO;
 import org.assertj.core.api.Fail;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 class AgencyDataProtectionValidationServiceTest {
 
   @InjectMocks
   AgencyDataProtectionValidationService agencyDataProtectionValidator;
+
+  @BeforeEach
+  void enforceProductionRequirement() {
+    // Default to the production behaviour (ADR-003 requirement ON) so the existing officer/
+    // responsible checks are exercised. Mockito's @InjectMocks leaves the @Value boolean at its
+    // JVM default (false); set it explicitly. The dev-mode relaxation is covered separately.
+    ReflectionTestUtils.setField(
+        agencyDataProtectionValidator, "requireDataProtectionOfficerContact", true);
+  }
 
   @Test
   void validate_Should_NotValidate_When_DataProtectionOfficerIsNotSet() {
@@ -128,6 +139,40 @@ class AgencyDataProtectionValidationServiceTest {
     } catch (Exception e) {
       // then
       Fail.fail("Should not throw exception");
+    }
+  }
+
+  @Test
+  void validate_Should_RejectMissingOfficerContact_When_RequirementEnforced() {
+    // given: ADR-003 production behaviour — requirement ON (set in @BeforeEach)
+    ValidateAgencyDTO agencyToValidate = ValidateAgencyDTO.builder()
+        .dataProtectionDTO(new DataProtectionDTO().dataProtectionResponsibleEntity(
+            DataProtectionResponsibleEntityEnum.DATA_PROTECTION_OFFICER)).build();
+
+    // when / then: a missing DPO contact is rejected in production
+    try {
+      agencyDataProtectionValidator.validate(agencyToValidate);
+      Fail.fail("Should throw when the DPO contact requirement is enforced");
+    } catch (InvalidOfflineStatusException e) {
+      assertThat(e.getHttpStatusExceptionReason())
+          .isEqualTo(HttpStatusExceptionReason.DATA_PROTECTION_OFFICER_IS_EMPTY);
+    }
+  }
+
+  @Test
+  void validate_Should_AllowMissingOfficerContact_When_DevModeRelaxesRequirement() {
+    // given: ADR-003 dev mode — requirement OFF (testing/dev profiles)
+    ReflectionTestUtils.setField(
+        agencyDataProtectionValidator, "requireDataProtectionOfficerContact", false);
+    ValidateAgencyDTO agencyToValidate = ValidateAgencyDTO.builder()
+        .dataProtectionDTO(new DataProtectionDTO().dataProtectionResponsibleEntity(
+            DataProtectionResponsibleEntityEnum.DATA_PROTECTION_OFFICER)).build();
+
+    // when / then: no exception even though the DPO contact is missing
+    try {
+      agencyDataProtectionValidator.validate(agencyToValidate);
+    } catch (Exception e) {
+      Fail.fail("Dev mode should relax the DPO contact requirement");
     }
   }
 }


### PR DESCRIPTION
## The red test

`src/test/java/.../agencytopic/AgencyTopicDepartmentConstraintRepositoryTest` failed on all 5 cases with:

```
NULL not allowed for column "DATA_PROTECTION_OFFICER_CONTACT"
insert into agency (... data_protection_officer_contact ...) values (...)
```

thrown from the test's `persistAgency()` fixture — before the ADR-003 unique-constraint / imprint assertions could even run. This red test reached `dev` because CI currently skips test execution; it must go green so the CI test-execution flip (**#89**) can proceed.

## Root cause

The `agency.data_protection_officer_contact` DB column is already **nullable** (changeset `0016_add_data_protection_attributes` declares it `NULL`, and no later changeset changes that). But the `Agency` JPA entity declared:

```java
@Column(name = "data_protection_officer_contact", columnDefinition = "longtext", nullable = false)
```

Under `@DataJpaTest` with `ddl-auto=create-drop` on H2, the schema is generated from the **entity annotations**, so `nullable = false` became a hard `NOT NULL`. That was *stricter than both* the DB and the existing app-layer validation (`AgencyDataProtectionValidationService` only required the DPO contact conditionally, when the responsible entity is `DATA_PROTECTION_OFFICER`).

## Dev-mode design (Frank, #oriso-codereview thread)

The DPO contact is a legal imprint/DPP requirement per **ADR-003** and stays **MANDATORY in production**, but there must be a dev/test mode where it is relaxed ("brauchen einen dev modus, sonst können wir nichts testen").

**Toggle:** `agency.department.require-dpo-contact`
| Profile | Value | Where |
|---|---|---|
| base / prod / staging | `true` (env override `AGENCY_DEPARTMENT_REQUIRE_DPO_CONTACT`) | `application.properties` |
| `testing` | `false` | `application-testing.properties` |
| `dev` | `false` | `application-dev.properties` |

`AgencyDataProtectionValidationService` reads the flag via `@Value(...:true)` and returns early from the DPO-officer check when it is `false`. Production behaviour is unchanged (flag defaults to `true`).

## Nullable-column changelog

New changeset `0024_agency_dpo_contact_nullable` runs `MODIFY COLUMN data_protection_officer_contact longtext NULL` — additive, idempotent, guarded by a `columnExists` precondition with `onFail=MARK_RAN`, wired into the L1 consolidated master changelog after `0022`. This makes the nullable contract explicit so the DB and entity cannot drift back apart. (Next free changeset number on `dev`; `0023` was the existing ADR-003 department slice.)

## Entity change

Dropped `nullable = false` from the `@Column` on `dataProtectionOfficerContactData` so the entity matches the already-nullable DB.

## Test evidence (red → green)

- `AgencyTopicDepartmentConstraintRepositoryTest`: **5 errors → 5/5 pass**.
- `AgencyDataProtectionValidationServiceTest`: **6 → 8 pass**, with two new tests:
  - `validate_Should_RejectMissingOfficerContact_When_RequirementEnforced` — proves prod enforcement (flag `true`) still throws `DATA_PROTECTION_OFFICER_IS_EMPTY`.
  - `validate_Should_AllowMissingOfficerContact_When_DevModeRelaxesRequirement` — proves dev mode (flag `false`) allows it.
- Full unit suite: **440 tests, 0 failures, 0 errors** (438 baseline + 2 new), JDK 21.
- Checkstyle (`google_checks_light.xml`, the project gate): **0 violations**.

## Unblocks

The AgencyService CI test-execution flip (**#89** / Hassan) — with this red test green, test execution can be turned back on.

Ref: ADR-003 DPO-contact dev mode; #oriso-codereview thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)