### PR TITLE
fix: fix spring boot 4 test applicationcontext failures

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -342,12 +342,12 @@
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-jdbc-test</artifactId>
+      <artifactId>spring-boot-starter-jdbc-test</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-data-jpa-test</artifactId>
+      <artifactId>spring-boot-starter-data-jpa-test</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -690,6 +690,12 @@
         <configuration>
           <source>21</source>
           <target>21</target>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>org.projectlombok</groupId>
+              <artifactId>lombok</artifactId>
+            </path>
+          </annotationProcessorPaths>
         </configuration>
       </plugin>
       <plugin>

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/controller/AgencyAdminControllerTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/controller/AgencyAdminControllerTest.java
@@ -58,6 +58,9 @@ import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.hateoas.client.LinkDiscoverers;
 import org.springframework.http.MediaType;
@@ -70,7 +73,10 @@ import org.springframework.test.web.servlet.MockMvc;
 @RunWith(SpringRunner.class)
 @SpringBootTest(
     webEnvironment = SpringBootTest.WebEnvironment.MOCK,
-    classes = AgencyServiceApplication.class)
+    classes = {
+      AgencyServiceApplication.class,
+      AgencyAdminControllerTest.UserAdminApiClientTestConfiguration.class
+    })
 @AutoConfigureMockMvc(addFilters = false)
 @TestPropertySource(
     locations = "classpath:application-testing.properties")
@@ -106,9 +112,6 @@ public class AgencyAdminControllerTest {
   private JwtAuthConverterProperties jwtAuthConverterProperties;
 
   @MockitoBean
-  private UserAdminServiceApiControllerFactory adminServiceApiControllerFactory;
-
-  @MockitoBean
   private SecurityHeaderSupplier securityHeaderSupplier;
 
   @MockitoBean
@@ -121,6 +124,19 @@ public class AgencyAdminControllerTest {
   @MockitoBean
   private AgencyRepository agencyRepository;
 
+  /**
+   * Mockito inline cannot instrument {@link UserAdminServiceApiControllerFactory} because it
+   * references OpenAPI-generated client types; provide a plain mock bean instead.
+   */
+  @TestConfiguration
+  static class UserAdminApiClientTestConfiguration {
+
+    @Bean
+    @Primary
+    UserAdminServiceApiControllerFactory userAdminServiceApiControllerFactory() {
+      return Mockito.mock(UserAdminServiceApiControllerFactory.class);
+    }
+  }
 
   @Test
   public void searchAgencies_Should_returnBadRequest_When_requiredPaginationParamsAreMissing()

--- a/src/test/java/de/caritas/cob/agencyservice/api/controller/AgencyControllerTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/controller/AgencyControllerTest.java
@@ -47,15 +47,20 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.security.oauth2.server.resource.autoconfigure.servlet.OAuth2ResourceServerAutoConfiguration;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.hateoas.client.LinkDiscoverers;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
-@WebMvcTest(AgencyController.class)
+@WebMvcTest(
+    controllers = AgencyController.class,
+    excludeAutoConfiguration = OAuth2ResourceServerAutoConfiguration.class)
 @AutoConfigureMockMvc(addFilters = false)
+@ActiveProfiles("testing")
 class AgencyControllerTest {
 
   static final String PATH_GET_AGENCIES_BY_CONSULTINGTYPE = "/agencies/consultingtype/1";

--- a/src/test/java/de/caritas/cob/agencyservice/api/repository/agency/AgencyAddressRepositoryTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/repository/agency/AgencyAddressRepositoryTest.java
@@ -9,23 +9,19 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
 import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
 import org.springframework.boot.jpa.test.autoconfigure.TestEntityManager;
+import org.springframework.boot.liquibase.autoconfigure.LiquibaseAutoConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 /**
  * Self-contained persistence test for the Beratungszentrum (agency centre) address/contact fields
- * that the admin create/edit forms need. Overrides the dialect to H2 so Hibernate builds the schema
- * from the entities and the test is runnable in a bare local build.
+ * that the admin create/edit forms need. Uses the {@code testing} profile (see
+ * {@code application-testing.properties}) so Hibernate builds the schema from the entities on H2.
  */
-@TestPropertySource(
-    properties = {
-      "spring.profiles.active=testing",
-      "spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect",
-      "spring.jpa.hibernate.ddl-auto=create-drop"
-    })
+@TestPropertySource(properties = {"spring.profiles.active=testing"})
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.ANY)
 @ExtendWith(SpringExtension.class)
-@DataJpaTest
+@DataJpaTest(excludeAutoConfiguration = LiquibaseAutoConfiguration.class)
 class AgencyAddressRepositoryTest {
 
   @Autowired private TestEntityManager em;

--- a/src/test/java/de/caritas/cob/agencyservice/api/repository/agencytopic/AgencyTopicDepartmentConstraintRepositoryTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/repository/agencytopic/AgencyTopicDepartmentConstraintRepositoryTest.java
@@ -15,26 +15,21 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
 import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
 import org.springframework.boot.jpa.test.autoconfigure.TestEntityManager;
+import org.springframework.boot.liquibase.autoconfigure.LiquibaseAutoConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 /**
  * Self-contained persistence test for ADR-003's "department = unique (agency × topic)" rule: the
  * {@code agency_topic} table carries {@code UNIQUE(agency_id, topic_id)} plus the department's own
- * imprint ({@code content_imprint} / {@code publication_status_imprint}). Mirrors the H2 setup of
- * {@link AgencyTopicLegalRepositoryTest}: dialect overridden to H2 with schema generated from the
- * entities, so the {@code @UniqueConstraint} on {@link AgencyTopic} is materialised and provable in
- * a bare local build.
+ * imprint ({@code content_imprint} / {@code publication_status_imprint}). Uses the {@code testing}
+ * profile (see {@code application-testing.properties}) so Hibernate builds the schema from the
+ * entities on H2.
  */
-@TestPropertySource(
-    properties = {
-      "spring.profiles.active=testing",
-      "spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect",
-      "spring.jpa.hibernate.ddl-auto=create-drop"
-    })
+@TestPropertySource(properties = {"spring.profiles.active=testing"})
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.ANY)
 @ExtendWith(SpringExtension.class)
-@DataJpaTest
+@DataJpaTest(excludeAutoConfiguration = LiquibaseAutoConfiguration.class)
 class AgencyTopicDepartmentConstraintRepositoryTest {
 
   @Autowired private TestEntityManager em;
@@ -46,6 +41,9 @@ class AgencyTopicDepartmentConstraintRepositoryTest {
             .name(name)
             .consultingTypeId(1)
             .dataProtectionResponsibleEntity(DataProtectionResponsibleEntity.AGENCY_RESPONSIBLE)
+            .dataProtectionOfficerContactData("officer")
+            .dataProtectionAlternativeContactData("alternative")
+            .dataProtectionAgencyResponsibleContactData("agency")
             .createDate(now)
             .updateDate(now)
             .build());

--- a/src/test/java/de/caritas/cob/agencyservice/api/repository/agencytopic/AgencyTopicLegalRepositoryTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/repository/agencytopic/AgencyTopicLegalRepositoryTest.java
@@ -11,25 +11,20 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
 import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
 import org.springframework.boot.jpa.test.autoconfigure.TestEntityManager;
+import org.springframework.boot.liquibase.autoconfigure.LiquibaseAutoConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 /**
  * Self-contained persistence test for the per-Fachbereich (department = agency × topic) legal model:
  * each {@code agency_topic} carries its own data privacy policy ({@code content_dpp}) and a
- * publication status. The module's other {@code @DataJpaTest} tests assume an externally provisioned
- * schema (MariaDB dialect), so this test overrides the dialect to H2 and lets Hibernate build the
- * schema from the entities — runnable and meaningful in a bare local build.
+ * publication status. Uses the {@code testing} profile (see {@code application-testing.properties})
+ * so Hibernate builds the schema from the entities on H2.
  */
-@TestPropertySource(
-    properties = {
-      "spring.profiles.active=testing",
-      "spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect",
-      "spring.jpa.hibernate.ddl-auto=create-drop"
-    })
+@TestPropertySource(properties = {"spring.profiles.active=testing"})
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.ANY)
 @ExtendWith(SpringExtension.class)
-@DataJpaTest
+@DataJpaTest(excludeAutoConfiguration = LiquibaseAutoConfiguration.class)
 class AgencyTopicLegalRepositoryTest {
 
   @Autowired private TestEntityManager em;


### PR DESCRIPTION
## What
Fix failing unit tests after the Spring Boot 4 upgrade where 57 tests could not load the Spring ApplicationContext.
## Why
Spring Boot 4 changed test slice auto-configuration and Mockito behavior. Several test classes were starting incomplete or incompatible contexts:
- `@DataJpaTest` slices were missing JPA test setup and conflicted with Liquibase auto-config
- `@WebMvcTest` tried to wire OAuth2 Resource Server security without a full security context
- `@MockitoBean` on `UserAdminServiceApiControllerFactory` failed because Mockito inline could not instrument OpenAPI-generated client types
## Summary
Restore a green test suite by aligning repository, controller, and admin controller tests with Spring Boot 4 slice testing patterns. Repository tests now reuse the shared `testing` profile from `application-testing.properties` instead of duplicating H2 settings in each test class.
## Changes Made
- **pom.xml**: Switch to `spring-boot-starter-jdbc-test` and `spring-boot-starter-data-jpa-test`; add Lombok to `annotationProcessorPaths`
- **AgencyAddressRepositoryTest**, **AgencyTopicLegalRepositoryTest**, **AgencyTopicDepartmentConstraintRepositoryTest**:
  - Use `spring.profiles.active=testing` instead of hardcoded H2 properties
  - Exclude `LiquibaseAutoConfiguration` from `@DataJpaTest`
  - Keep `@AutoConfigureTestDatabase(replace = ANY)`
- **AgencyControllerTest**:
  - Exclude `OAuth2ResourceServerAutoConfiguration` from `@WebMvcTest`
  - Activate `testing` profile
- **AgencyAdminControllerTest**:
  - Replace `@MockitoBean` on `UserAdminServiceApiControllerFactory` with a `@TestConfiguration` that provides a manual `@Primary` mock bean
## Tests
- [ ] `mvn test "-Dcheckstyle.skip=true"`
- [ ] `AgencyAddressRepositoryTest` — 1 test
- [ ] `AgencyTopicLegalRepositoryTest` — 4 tests
- [ ] `AgencyTopicDepartmentConstraintRepositoryTest` — 5 tests
- [ ] `AgencyControllerTest` — all controller slice tests pass
- [ ] `AgencyAdminControllerTest` — all admin controller tests pass
- [ ] Full suite: 438 tests, 0 failures