### PR TITLE
fix(liquibase): wire ADR-003 changeset 0023 into the master changelog

### DIFF
--- a/src/main/resources/db/changelog/agencyservice-master.xml
+++ b/src/main/resources/db/changelog/agencyservice-master.xml
@@ -60,6 +60,7 @@
   <include file="db/changelog/changeset/0020_agency_settings/0020_changeSet.xml"/>
   <include file="db/changelog/changeset/0021_agency_topic_legal/0021_changeSet.xml"/>
   <include file="db/changelog/changeset/0022_agency_address_contact/0022_changeSet.xml"/>
+  <include file="db/changelog/changeset/0023_agency_topic_department/0023_changeSet.xml"/>
 
   <!--
     L1 gap detection (2026-07-04): the consolidated changelog was run against a fresh MariaDB


### PR DESCRIPTION
## Problem

The L1 consolidated master `agencyservice-master.xml` includes structural changesets only up to `0022_agency_address_contact`. The ADR-003 department slice `changeset/0023_agency_topic_department/0023_changeSet.xml` (shipped with the ADR-003 work in #90) was **never wired into the master via an `<include>`** — confirmed: `grep 0023 agencyservice-master.xml` was empty.

So its three changesets never run through Liquibase on dev/staging/prod:
- dedup duplicate `(agency_id, topic_id)` rows
- add `UNIQUE(agency_id, topic_id)` `uq_agency_topic`
- add `content_imprint` / `publication_status_imprint` columns

The ADR-003 unique constraint + department imprint columns therefore exist **only in the JPA entity and the H2 create-drop test schema, never in a real database**. The env-gated `LiquibaseChangelogDriftIT` would have caught this, but it doesn't run in CI — which is exactly why it went unnoticed.

## Change

One line: add `<include file="db/changelog/changeset/0023_agency_topic_department/0023_changeSet.xml"/>` after `0022`.

## Verification

Against a fresh MariaDB 11 via dockerized `liquibase:4.23.2`:
- Full master applies cleanly — **26 changesets run, all three `0023` ones executed**, `Update has been successful`.
- `content_imprint`, `publication_status_imprint` columns and the `uq_agency_topic` constraint confirmed present afterward.
- **Idempotent**: a second `update` is `Run: 0` — safe against the current dev DB (the unique-constraint changeset has an `onFail=MARK_RAN` precondition; the dedup is a no-op self-join DELETE; imprint uses `ADD COLUMN IF NOT EXISTS`).
- `./mvnw -B test` (JDK 21): the **only** failures are the 5 pre-existing `AgencyTopicDepartmentConstraintRepositoryTest` errors that **#96** fixes — orthogonal to this XML-only change (433 other tests green).

## Notes

- **Complements #96** (ADR-003 DPO-contact dev mode). Both edit the master near `0022`; intended final order is `0022 → 0023 → 0024`. If #96 lands first, this needs a trivial rebase to place `0023` before `0024` (the changesets are independent, so execution order among them is not functionally significant).
- **Follow-on:** the pre-seed schema mirror `charts/mariadb/sql-schemas/agencyservice-schema.sql` (ORISO-Helm) should be regenerated once this lands, so the ADR-003 columns/constraint reach fresh installs while Liquibase stays off cluster-side (my mirror-sync #14 reported agency "in sync" precisely because 0023 wasn't in the master yet).

ADR-003. 

🤖 Generated with [Claude Code](https://claude.com/claude-code)