### PR TITLE
fix: return 200 with empty list for bulk agency lookup with no matches

### DIFF
--- a/src/main/java/de/caritas/cob/agencyservice/api/controller/AgencyController.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/controller/AgencyController.java
@@ -103,8 +103,7 @@ public class AgencyController implements AgenciesApi {
 
     var agencies = agencyService.getAgencies(agencyIds);
 
-    return agencies.isEmpty() ? new ResponseEntity<>(HttpStatus.NOT_FOUND)
-        : new ResponseEntity<>(agencies, HttpStatus.OK);
+    return new ResponseEntity<>(agencies, HttpStatus.OK);
   }
 
   /**

--- a/src/test/java/de/caritas/cob/agencyservice/api/controller/AgencyControllerTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/controller/AgencyControllerTest.java
@@ -166,13 +166,15 @@ class AgencyControllerTest {
   }
 
   @Test
-  void getAgencies_With_Ids_Should_ReturnNoContent_When_ServiceReturnsNoAgency()
+  void getAgencies_With_Ids_Should_ReturnOkAndEmptyList_When_ServiceReturnsNoAgency()
       throws Exception {
 
     when(agencyService.getAgencies(anyList())).thenReturn(Collections.emptyList());
 
     mvc.perform(get(PATH_GET_AGENCIES_WITH_IDS + AGENCY_ID).accept(MediaType.APPLICATION_JSON))
-        .andExpect(status().isNotFound());
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$").isArray())
+        .andExpect(jsonPath("$").isEmpty());
   }
 
   @Test


### PR DESCRIPTION
## Summary
- `GET /agencies/{ids}` returns **200 + `[]`** when no agencies match (was 404)
- `AgencyControllerTest` updated

## Why
Empty bulk lookup is a valid result; 404 broke generated clients and caused 500s downstream.

## Test plan
- [x] `AgencyControllerTest#getAgencies_With_Ids*` passes locally
- [x] Manual: `curl http://localhost:8084/agencies/999999999` → `[]`
- [ ] 
<img width="569" height="44" alt="image" src="https://github.com/user-attachments/assets/3564283a-a8b3-495d-8792-3c1834480c90" />


Closes #4