### PR TITLE
fix(security): 401 instead of 500 for anonymous GET /agencies/topics

### DIFF
--- a/src/main/java/de/caritas/cob/agencyservice/config/SecurityConfig.java
+++ b/src/main/java/de/caritas/cob/agencyservice/config/SecurityConfig.java
@@ -99,6 +99,10 @@ public class SecurityConfig {
             .hasAuthority(AuthorityValue.GET_ALL_AGENCIES)
             .requestMatchers("/agencyadmin", "/agencyadmin/", "/agencyadmin/**")
             .hasAnyAuthority(AuthorityValue.AGENCY_ADMIN, AuthorityValue.RESTRICTED_AGENCY_ADMIN)
+            // /agencies/topics enriches via an authenticated ConsultingTypeService call and is
+            // only used by logged-in clients; anonymous access must 401 here instead of NPE-500ing
+            // in the request-scoped AuthenticatedUser bean.
+            .requestMatchers("/agencies/topics", "/agencies/topics/").authenticated()
             .requestMatchers("/agencies/**").permitAll()
             .requestMatchers("/internal/agencies/**").permitAll()
             .anyRequest().denyAll())

--- a/src/test/java/de/caritas/cob/agencyservice/api/controller/AgencyControllerAuthorizationIT.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/controller/AgencyControllerAuthorizationIT.java
@@ -1,0 +1,99 @@
+package de.caritas.cob.agencyservice.api.controller;
+
+import static de.caritas.cob.agencyservice.testHelper.PathConstants.PATH_GET_LIST_OF_AGENCIES_TOPICS;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import de.caritas.cob.agencyservice.api.service.AgencyService;
+import de.caritas.cob.agencyservice.api.service.TopicEnrichmentService;
+import jakarta.servlet.http.Cookie;
+import java.util.Collections;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase.Replace;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+
+@RunWith(SpringRunner.class)
+@TestPropertySource(properties = {
+    "spring.profiles.active=testing",
+    "csrf.header.property=csrfHeader",
+    "csrf.cookie.property=csrfCookie"
+})
+@SpringBootTest
+@AutoConfigureMockMvc
+@AutoConfigureTestDatabase(replace = Replace.ANY)
+public class AgencyControllerAuthorizationIT {
+
+  private static final String CSRF_HEADER = "csrfHeader";
+  private static final String CSRF_VALUE = "test";
+  private static final Cookie CSRF_COOKIE = new Cookie("csrfCookie", CSRF_VALUE);
+
+  @Autowired
+  private MockMvc mvc;
+
+  @MockitoBean
+  private AgencyService agencyService;
+
+  @MockitoBean
+  private TopicEnrichmentService topicEnrichmentService;
+
+  @Test
+  public void getAgenciesTopics_Should_ReturnUnauthorizedAndCallNoMethods_When_noKeycloakAuthorizationIsPresent()
+      throws Exception {
+
+    mvc.perform(get(PATH_GET_LIST_OF_AGENCIES_TOPICS)
+        .cookie(CSRF_COOKIE)
+        .header(CSRF_HEADER, CSRF_VALUE))
+        .andExpect(status().isUnauthorized());
+
+    verifyNoMoreInteractions(this.agencyService);
+    verifyNoMoreInteractions(this.topicEnrichmentService);
+  }
+
+  @Test
+  public void getAgenciesTopics_Should_ReturnNoContentAndCallAgencyService_When_authenticated()
+      throws Exception {
+
+    when(agencyService.getAgenciesTopics()).thenReturn(Collections.emptyList());
+    when(topicEnrichmentService.enrichTopicIdsWithTopicData(any()))
+        .thenReturn(Collections.emptyList());
+
+    mvc.perform(get(PATH_GET_LIST_OF_AGENCIES_TOPICS)
+        .with(SecurityMockMvcRequestPostProcessors.jwt())
+        .cookie(CSRF_COOKIE)
+        .header(CSRF_HEADER, CSRF_VALUE))
+        .andExpect(status().isNoContent());
+
+    verify(this.agencyService, times(1)).getAgenciesTopics();
+  }
+
+  @Test
+  public void getAgencies_Should_RemainPubliclyAccessible_When_noKeycloakAuthorizationIsPresent()
+      throws Exception {
+
+    when(agencyService.getAgencies(any(), anyInt(), any(), any(), any(), any()))
+        .thenReturn(Collections.emptyList());
+
+    mvc.perform(get("/agencies?consultingType=1&postcode=10115")
+        .cookie(CSRF_COOKIE)
+        .header(CSRF_HEADER, CSRF_VALUE))
+        .andExpect(status().isOk());
+
+    verify(this.agencyService, times(1))
+        .getAgencies(any(), anyInt(), any(), any(), any(), any());
+  }
+}


### PR DESCRIPTION
## Problem
Anonymous `GET /service/agencies/topics` on Pre-Dev returns **500**: `/agencies/**` is `permitAll`, but the handler chain (AgencyController → TopicEnrichmentService → TopicService) instantiates the request-scoped `AuthenticatedUser` bean for the authenticated CTS call — `AuthenticatedUserConfig.getAuthenticatedUser()` (line 45) casts a null principal to `JwtAuthenticationToken` and NPEs. Diagnosed live from Pre-Dev pod logs (2026-07-07).

## Why route-level authenticated() (and not an anonymous-safe bean)
The endpoint is only used by logged-in clients (frontend `AdditionalEnquiry`); no anonymous consumer exists (checked FE/Admin/US on dev). Even with an anonymous-safe bean the downstream CTS call would just fail later with `Bearer null`. Rejecting at the route is the honest contract: **401 up front**.

## Change
- `SecurityConfig`: `/agencies/topics` now requires authentication, placed before the `/agencies/**` permitAll. Public agency search (`/agencies`) untouched.
- New `AgencyControllerAuthorizationIT` (pattern of `AgencyAdminControllerAuthorizationIT`):
  1. anonymous topics request → 401, no service interaction
  2. authenticated request (`jwt()` post-processor) → reaches controller (204 with empty enrichment)
  3. anonymous `/agencies?consultingType=1&postcode=10115` → still 200 (public search regression guard)

Note: the test uses `SecurityMockMvcRequestPostProcessors.jwt()` instead of `@WithMockUser` — with the SB4 resource-server chain `@WithMockUser` does not authenticate the request (the Bearer entry point fires); this likely affects existing `*IT` classes in the red burn-in job too.

## Validation
`mvn test -Dtest=AgencyControllerAuthorizationIT` → 3/3 green (Maven container, Temurin 21).

🤖 Generated with [Claude Code](https://claude.com/claude-code)