### PR TITLE
test(AS-TEST-07): strengthen TopicService coverage + cover topics-auth business logic (closes #75, supersedes #104)

### DIFF
--- a/src/main/java/de/caritas/cob/agencyservice/config/SecurityConfig.java
+++ b/src/main/java/de/caritas/cob/agencyservice/config/SecurityConfig.java
@@ -99,6 +99,10 @@ public class SecurityConfig {
             .hasAuthority(AuthorityValue.GET_ALL_AGENCIES)
             .requestMatchers("/agencyadmin", "/agencyadmin/", "/agencyadmin/**")
             .hasAnyAuthority(AuthorityValue.AGENCY_ADMIN, AuthorityValue.RESTRICTED_AGENCY_ADMIN)
+            // /agencies/topics enriches via an authenticated ConsultingTypeService call and is
+            // only used by logged-in clients; anonymous access must 401 here instead of NPE-500ing
+            // in the request-scoped AuthenticatedUser bean.
+            .requestMatchers("/agencies/topics", "/agencies/topics/").authenticated()
             .requestMatchers("/agencies/**").permitAll()
             .requestMatchers("/internal/agencies/**").permitAll()
             .anyRequest().denyAll())

--- a/src/test/java/de/caritas/cob/agencyservice/api/controller/AgencyControllerAuthorizationIT.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/controller/AgencyControllerAuthorizationIT.java
@@ -5,7 +5,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -63,8 +63,8 @@ public class AgencyControllerAuthorizationIT {
         .header(CSRF_HEADER, CSRF_VALUE))
         .andExpect(status().isUnauthorized());
 
-    verifyNoMoreInteractions(this.agencyService);
-    verifyNoMoreInteractions(this.topicEnrichmentService);
+    verifyNoInteractions(this.agencyService);
+    verifyNoInteractions(this.topicEnrichmentService);
   }
 
   @Test
@@ -82,6 +82,7 @@ public class AgencyControllerAuthorizationIT {
         .andExpect(status().isNoContent());
 
     verify(this.agencyService, times(1)).getAgenciesTopics();
+    verify(this.topicEnrichmentService, times(1)).enrichTopicIdsWithTopicData(any());
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/agencyservice/api/controller/AgencyControllerAuthorizationIT.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/controller/AgencyControllerAuthorizationIT.java
@@ -8,12 +8,15 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import de.caritas.cob.agencyservice.api.model.AgencyTopicsDTO;
 import de.caritas.cob.agencyservice.api.service.AgencyService;
 import de.caritas.cob.agencyservice.api.service.TopicEnrichmentService;
 import jakarta.servlet.http.Cookie;
 import java.util.Collections;
+import java.util.List;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -79,6 +82,29 @@ public class AgencyControllerAuthorizationIT {
         .andExpect(status().isNoContent());
 
     verify(this.agencyService, times(1)).getAgenciesTopics();
+  }
+
+  @Test
+  public void getAgenciesTopics_Should_ReturnOkWithEnrichedTopics_When_authenticatedAndTopicsExist()
+      throws Exception {
+
+    when(agencyService.getAgenciesTopics()).thenReturn(List.of(1, 2));
+    when(topicEnrichmentService.enrichTopicIdsWithTopicData(any()))
+        .thenReturn(List.of(
+            new AgencyTopicsDTO().id(1L).name("addiction"),
+            new AgencyTopicsDTO().id(2L).name("debt")));
+
+    mvc.perform(get(PATH_GET_LIST_OF_AGENCIES_TOPICS)
+        .with(SecurityMockMvcRequestPostProcessors.jwt())
+        .cookie(CSRF_COOKIE)
+        .header(CSRF_HEADER, CSRF_VALUE))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$", org.hamcrest.Matchers.hasSize(2)))
+        .andExpect(jsonPath("$[0].id").value(1))
+        .andExpect(jsonPath("$[0].name").value("addiction"));
+
+    verify(this.agencyService, times(1)).getAgenciesTopics();
+    verify(this.topicEnrichmentService, times(1)).enrichTopicIdsWithTopicData(any());
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/agencyservice/api/controller/AgencyControllerAuthorizationIT.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/controller/AgencyControllerAuthorizationIT.java
@@ -1,0 +1,99 @@
+package de.caritas.cob.agencyservice.api.controller;
+
+import static de.caritas.cob.agencyservice.testHelper.PathConstants.PATH_GET_LIST_OF_AGENCIES_TOPICS;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import de.caritas.cob.agencyservice.api.service.AgencyService;
+import de.caritas.cob.agencyservice.api.service.TopicEnrichmentService;
+import jakarta.servlet.http.Cookie;
+import java.util.Collections;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase.Replace;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+
+@RunWith(SpringRunner.class)
+@TestPropertySource(properties = {
+    "spring.profiles.active=testing",
+    "csrf.header.property=csrfHeader",
+    "csrf.cookie.property=csrfCookie"
+})
+@SpringBootTest
+@AutoConfigureMockMvc
+@AutoConfigureTestDatabase(replace = Replace.ANY)
+public class AgencyControllerAuthorizationIT {
+
+  private static final String CSRF_HEADER = "csrfHeader";
+  private static final String CSRF_VALUE = "test";
+  private static final Cookie CSRF_COOKIE = new Cookie("csrfCookie", CSRF_VALUE);
+
+  @Autowired
+  private MockMvc mvc;
+
+  @MockitoBean
+  private AgencyService agencyService;
+
+  @MockitoBean
+  private TopicEnrichmentService topicEnrichmentService;
+
+  @Test
+  public void getAgenciesTopics_Should_ReturnUnauthorizedAndCallNoMethods_When_noKeycloakAuthorizationIsPresent()
+      throws Exception {
+
+    mvc.perform(get(PATH_GET_LIST_OF_AGENCIES_TOPICS)
+        .cookie(CSRF_COOKIE)
+        .header(CSRF_HEADER, CSRF_VALUE))
+        .andExpect(status().isUnauthorized());
+
+    verifyNoMoreInteractions(this.agencyService);
+    verifyNoMoreInteractions(this.topicEnrichmentService);
+  }
+
+  @Test
+  public void getAgenciesTopics_Should_ReturnNoContentAndCallAgencyService_When_authenticated()
+      throws Exception {
+
+    when(agencyService.getAgenciesTopics()).thenReturn(Collections.emptyList());
+    when(topicEnrichmentService.enrichTopicIdsWithTopicData(any()))
+        .thenReturn(Collections.emptyList());
+
+    mvc.perform(get(PATH_GET_LIST_OF_AGENCIES_TOPICS)
+        .with(SecurityMockMvcRequestPostProcessors.jwt())
+        .cookie(CSRF_COOKIE)
+        .header(CSRF_HEADER, CSRF_VALUE))
+        .andExpect(status().isNoContent());
+
+    verify(this.agencyService, times(1)).getAgenciesTopics();
+  }
+
+  @Test
+  public void getAgencies_Should_RemainPubliclyAccessible_When_noKeycloakAuthorizationIsPresent()
+      throws Exception {
+
+    when(agencyService.getAgencies(any(), anyInt(), any(), any(), any(), any()))
+        .thenReturn(Collections.emptyList());
+
+    mvc.perform(get("/agencies?consultingType=1&postcode=10115")
+        .cookie(CSRF_COOKIE)
+        .header(CSRF_HEADER, CSRF_VALUE))
+        .andExpect(status().isOk());
+
+    verify(this.agencyService, times(1))
+        .getAgencies(any(), anyInt(), any(), any(), any(), any());
+  }
+}

--- a/src/test/java/de/caritas/cob/agencyservice/api/service/TopicServiceTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/service/TopicServiceTest.java
@@ -1,7 +1,8 @@
 package de.caritas.cob.agencyservice.api.service;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import de.caritas.cob.agencyservice.api.service.securityheader.SecurityHeaderSupplier;
@@ -13,6 +14,7 @@ import de.caritas.cob.agencyservice.topicservice.generated.web.TopicControllerAp
 import de.caritas.cob.agencyservice.topicservice.generated.web.model.TopicDTO;
 import java.util.List;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -22,8 +24,27 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpHeaders;
 import org.springframework.test.util.ReflectionTestUtils;
 
+/**
+ * Unit tests for {@link TopicService}.
+ *
+ * <p>{@link TopicService} wraps the generated {@link TopicControllerApi} and is the single point
+ * where the outgoing call to the (consulting-)topic service is decorated with the Keycloak bearer
+ * token and — when multitenancy is on — the {@code tenantId} header. These tests pin down that
+ * header-propagation contract with a real {@link TenantHeaderSupplier} and a real
+ * {@link ApiClient} (both {@code @Spy}) so the actual propagation logic runs; only the factory,
+ * the generated controller and the auth source are mocked.
+ *
+ * <p>The endpoint-level auth behaviour (anonymous {@code GET /agencies/topics} must not reach this
+ * service and gets a 401 rather than NPE-ing into a 500) is covered by
+ * {@link de.caritas.cob.agencyservice.api.controller.AgencyControllerAuthorizationIT}.
+ *
+ * <p>The {@code @Cacheable} annotation on {@link TopicService#getAllTopics()} is intentionally not
+ * asserted here — it is inert without a Spring proxy and belongs to a context-level test.
+ */
 @ExtendWith(MockitoExtension.class)
 class TopicServiceTest {
+
+  private static final String ACCESS_TOKEN = "test-bearer-token";
 
   @InjectMocks
   TopicService topicService;
@@ -46,67 +67,88 @@ class TopicServiceTest {
   @Spy
   ApiClient apiClient;
 
+  @BeforeEach
+  void wireControllerApi() {
+    when(topicServiceApiControllerFactory.createControllerApi()).thenReturn(topicControllerApi);
+    when(topicControllerApi.getApiClient()).thenReturn(apiClient);
+    when(authenticatedUser.getAccessToken()).thenReturn(ACCESS_TOKEN);
+  }
+
   @AfterEach
   void tearDown() {
     TenantContext.clear();
   }
 
   @Test
-  void getAllTopics_Should_ReturnTopicsFromApi() {
-    when(topicServiceApiControllerFactory.createControllerApi()).thenReturn(topicControllerApi);
-    when(topicControllerApi.getApiClient()).thenReturn(apiClient);
-    when(authenticatedUser.getAccessToken()).thenReturn("test-token");
-    when(topicControllerApi.getAllTopics()).thenReturn(List.of(new TopicDTO()));
+  void getAllTopics_Should_ReturnTopicListFromDownstreamApiUnchanged() {
+    var downstreamTopics = List.of(new TopicDTO().id(1L).name("addiction"),
+        new TopicDTO().id(2L).name("debt"));
+    when(topicControllerApi.getAllTopics()).thenReturn(downstreamTopics);
 
     var result = topicService.getAllTopics();
 
-    assertEquals(1, result.size());
+    assertThat(result).isEqualTo(downstreamTopics);
+    verify(topicControllerApi).getAllTopics();
   }
 
   @Test
-  void getAllTopics_Should_AddAuthorizationHeader() {
-    when(authenticatedUser.getAccessToken()).thenReturn("test-bearer-token");
-    when(topicServiceApiControllerFactory.createControllerApi()).thenReturn(topicControllerApi);
-    when(topicControllerApi.getApiClient()).thenReturn(apiClient);
+  void getAllTopics_Should_ReturnEmptyList_When_DownstreamReturnsEmpty() {
+    when(topicControllerApi.getAllTopics()).thenReturn(List.of());
+
+    var result = topicService.getAllTopics();
+
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void getAllTopics_Should_AddKeycloakBearerToken_ToApiClientDefaultHeaders() {
     when(topicControllerApi.getAllTopics()).thenReturn(List.of());
 
     topicService.getAllTopics();
 
-    HttpHeaders apiClientHeaders = (HttpHeaders) ReflectionTestUtils
-        .getField(apiClient, "defaultHeaders");
-    assertEquals("Bearer test-bearer-token", apiClientHeaders.get("Authorization").get(0));
+    assertThat(defaultHeaders().get(HttpHeaders.AUTHORIZATION))
+        .containsExactly("Bearer " + ACCESS_TOKEN);
   }
 
   @Test
   void getAllTopics_Should_AddTenantHeader_When_MultitenancyEnabled() {
     TenantContext.setCurrentTenant(1L);
     ReflectionTestUtils.setField(tenantHeaderSupplier, "multitenancy", true);
-    when(authenticatedUser.getAccessToken()).thenReturn("token");
-    when(topicServiceApiControllerFactory.createControllerApi()).thenReturn(topicControllerApi);
-    when(topicControllerApi.getApiClient()).thenReturn(apiClient);
     when(topicControllerApi.getAllTopics()).thenReturn(List.of());
 
     topicService.getAllTopics();
 
-    HttpHeaders apiClientHeaders = (HttpHeaders) ReflectionTestUtils
-        .getField(apiClient, "defaultHeaders");
-    assertEquals("1", apiClientHeaders.get("tenantId").get(0));
+    assertThat(defaultHeaders().get("tenantId")).containsExactly("1");
   }
 
   @Test
   void getAllTopics_Should_NotAddTenantHeader_When_MultitenancyDisabled() {
     TenantContext.setCurrentTenant(1L);
     ReflectionTestUtils.setField(tenantHeaderSupplier, "multitenancy", false);
-    when(authenticatedUser.getAccessToken()).thenReturn("token");
-    when(topicServiceApiControllerFactory.createControllerApi()).thenReturn(topicControllerApi);
-    when(topicControllerApi.getApiClient()).thenReturn(apiClient);
     when(topicControllerApi.getAllTopics()).thenReturn(List.of());
 
     topicService.getAllTopics();
 
-    HttpHeaders apiClientHeaders = (HttpHeaders) ReflectionTestUtils
-        .getField(apiClient, "defaultHeaders");
-    assertNull(apiClientHeaders.get("tenantId"));
+    assertThat(defaultHeaders().get("tenantId")).isNull();
   }
 
+  /**
+   * {@link SecurityHeaderSupplier} is injected into {@link TopicService} but never used in
+   * {@code addDefaultHeaders()} — this call uses the Keycloak bearer token directly, not the CSRF
+   * header set. This test documents that the dependency is dead so a future cleanup that removes it
+   * has a guard proving no behaviour change. See the cleanup note on issue #75.
+   */
+  @Test
+  void getAllTopics_Should_NotUseSecurityHeaderSupplier() {
+    when(topicControllerApi.getAllTopics()).thenReturn(List.of());
+
+    topicService.getAllTopics();
+
+    verifyNoInteractions(securityHeaderSupplier);
+  }
+
+  @SuppressWarnings("unchecked")
+  private HttpHeaders defaultHeaders() {
+    return (HttpHeaders) ReflectionTestUtils.getField(apiClient, "defaultHeaders");
+  }
 }


### PR DESCRIPTION
Closes #75 — reopened by QA (external) because the original coverage (merged via #85) only exercised header plumbing via reflection and never touched the actual runtime behaviour of the topics endpoint, which was NPE-500ing for anonymous callers on Pre-Dev.

This PR **incorporates #104** (the topics-auth fix) so the new business logic ships together with the tests that prove it. #104 can be closed as superseded.

## What changed

### Production (inherited from #104)
- `SecurityConfig`: `/agencies/topics` now requires authentication, placed before the `/agencies/**` permitAll. Public agency search (`/agencies`) untouched. Anonymous callers get **401 up front** instead of NPE-ing into a 500 inside the request-scoped `AuthenticatedUser` bean.

### Tests — `TopicServiceTest` (rewritten)
- Pure **JUnit 5 + AssertJ** (drops the JUnit 4 `Assert` mix the original inherited from the sibling `ConsultingTypeServiceTest`).
- Existing contract kept: delegation, Keycloak bearer propagation, tenant header on/off.
- **New edge cases**: downstream list returned unchanged, empty-downstream, and a guard (`verifyNoInteractions`) documenting that the injected `SecurityHeaderSupplier` is a **dead dependency** — so a future cleanup removing it has a regression net.

### Tests — `AgencyControllerAuthorizationIT` (extended from #104)
- Kept: anonymous → **401** with no service interaction; authenticated → reaches controller (204 empty); public `/agencies` search still **200**.
- **Added**: authenticated request with enriched topics → **200 + JSON body**, proving the OK branch of `getAgenciesTopics()` (controller → enrichment → response) actually returns topics — the branch the 204 case never touched.

## Validation (local, Temurin, `release 21`)
- `TopicServiceTest` → **6/6 green**
- `AgencyControllerAuthorizationIT` → **4/4 green**

Re #75 · supersedes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted the topics list endpoint so unauthenticated requests now return **401 Unauthorized** instead of triggering an application error.
  * Kept the general agencies endpoint publicly accessible as expected.
  * Improved handling of empty topic results, returning **204 No Content** when no topics are available.

* **Tests**
  * Added coverage for authenticated and unauthenticated access to agencies and topics endpoints.
  * Expanded test validation for topic retrieval and response enrichment behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->