### PR TITLE
ci: hardened test gate, non-blocking IT burn-in + oasdiff contract diff; run the orphan search IT

### DIFF
--- a/.github/actions/maven-build/action.yml
+++ b/.github/actions/maven-build/action.yml
@@ -14,9 +14,45 @@ runs:
       distribution: 'temurin'
       cache: maven
 
+  # Blocking unit-test gate (Test Quality Audit 2026-07-04, item 3).
+  # Runs the surefire `unit-tests` execution (test phase, **/*Test) and fails the
+  # build if any report shows failures/errors — or if NO reports were produced at
+  # all (a green build with zero reports means tests were silently skipped).
   - name: Run Maven tests
     shell: bash
-    run: ./mvnw -B test
+    run: |
+      ./mvnw -B test
+      python3 - <<'PY'
+      from pathlib import Path
+      import sys
+      import xml.etree.ElementTree as ET
+
+      reports = sorted(Path("target/surefire-reports").glob("TEST-*.xml"))
+      if not reports:
+          print("::error::Zero surefire reports found — tests were silently skipped or never ran.")
+          sys.exit(1)
+
+      total_tests = 0
+      failing_reports = []
+      for report in reports:
+          root = ET.parse(report).getroot()
+          total_tests += int(root.attrib.get("tests", 0))
+          failures = int(root.attrib.get("failures", 0))
+          errors = int(root.attrib.get("errors", 0))
+          if failures or errors:
+              failing_reports.append((report, failures, errors))
+
+      print(f"Parsed {len(reports)} surefire report(s), {total_tests} tests.")
+      if total_tests == 0:
+          print("::error::Surefire reports contain zero executed tests.")
+          sys.exit(1)
+
+      if failing_reports:
+          print("Maven reported test failures/errors:")
+          for report, failures, errors in failing_reports:
+              print(f"- {report}: failures={failures}, errors={errors}")
+          sys.exit(1)
+      PY
 
   - name: Package Java application
     shell: bash

--- a/.github/actions/maven-verify-burnin/action.yml
+++ b/.github/actions/maven-verify-burnin/action.yml
@@ -1,0 +1,94 @@
+name: Reusable Maven integration-test burn-in
+
+# Burn-in action (Test Quality Audit 2026-07-04, item 3 + CI Roadmap Part 1).
+# Runs the full `verify` lifecycle so the surefire `integration-tests` execution
+# (bound to the integration-test phase, includes **/*IT.*) actually runs. These
+# integration tests have never run in CI before (local burn-in 2026-07-07:
+# 23 IT classes, 7 green / 16 red — mostly context-load errors), so this action
+# is wired into a NON-BLOCKING (continue-on-error) job. It must NOT be a
+# required check until the ITs are green. `mvnw` is run with `-fae` so IT
+# failures are visible in the job summary and reports without aborting the
+# report-collection step below.
+
+inputs:
+  java_version:
+    required: true
+
+runs:
+  using: 'composite'
+  steps:
+  - name: Set up JDK and Maven
+    uses: actions/setup-java@v5
+    with:
+      java-version: ${{ inputs.java_version }}
+      distribution: 'temurin'
+      cache: maven
+
+  - name: Run Maven verify (unit + integration tests, burn-in)
+    shell: bash
+    # -fae (fail-at-end) lets every module/execution run so the report set is
+    # complete; the actual pass/fail signal comes from the report gate below,
+    # which this burn-in job tolerates (continue-on-error at the job level).
+    run: ./mvnw -B -fae verify
+
+  - name: Assert test reports were produced (zero-report guard)
+    if: ${{ always() }}
+    shell: bash
+    # Guards against a future silent-skip: a green build that produced ZERO test
+    # reports must be treated as a failure, not a pass. Surefire writes both the
+    # unit (**/*Test) and integration (**/*IT) executions into surefire-reports;
+    # failsafe-reports is globbed too in case a module adopts failsafe later.
+    run: |
+      shopt -s nullglob globstar
+      reports=( **/target/surefire-reports/TEST-*.xml **/target/failsafe-reports/TEST-*.xml )
+      count=${#reports[@]}
+      echo "Found ${count} test report file(s)."
+      if [ "${count}" -eq 0 ]; then
+        echo "::error::Zero test reports were produced — tests were silently skipped or never ran."
+        exit 1
+      fi
+
+  - name: Summarise integration-test results (burn-in)
+    if: ${{ always() }}
+    shell: bash
+    run: |
+      python3 - <<'PY'
+      from pathlib import Path
+      import xml.etree.ElementTree as ET
+
+      total_tests = total_failures = total_errors = total_skipped = 0
+      failing = []
+      for report in Path(".").glob("**/target/surefire-reports/TEST-*.xml"):
+          try:
+              root = ET.parse(report).getroot()
+          except ET.ParseError:
+              continue
+          tests = int(root.attrib.get("tests", 0))
+          failures = int(root.attrib.get("failures", 0))
+          errors = int(root.attrib.get("errors", 0))
+          skipped = int(root.attrib.get("skipped", 0))
+          total_tests += tests
+          total_failures += failures
+          total_errors += errors
+          total_skipped += skipped
+          if failures or errors:
+              failing.append((report, failures, errors))
+
+      print(f"Integration-test burn-in: tests={total_tests} "
+            f"failures={total_failures} errors={total_errors} skipped={total_skipped}")
+      if failing:
+          print("Reports with failures/errors (expected during burn-in):")
+          for report, failures, errors in sorted(failing):
+              print(f"- {report}: failures={failures}, errors={errors}")
+      PY
+
+  - name: Upload test reports
+    if: ${{ always() }}
+    uses: actions/upload-artifact@v4
+    with:
+      name: integration-test-reports-${{ inputs.java_version }}
+      path: |
+        **/target/surefire-reports/*.xml
+        **/target/failsafe-reports/*.xml
+      if-no-files-found: warn
+      retention-days: 7

--- a/.github/workflows/ci-feature-branch.yml
+++ b/.github/workflows/ci-feature-branch.yml
@@ -19,3 +19,20 @@ jobs:
       uses: ./.github/actions/maven-build
       with:
         java_version: '21'
+
+  # Non-blocking burn-in (Test Quality Audit 2026-07-04, item 3 + CI Roadmap Part 1).
+  # Runs `mvnw -B verify` so the integration-test phase (24 *IT classes) runs on
+  # feature branches too. continue-on-error keeps it non-blocking during burn-in.
+  integration-tests:
+    name: integration-tests (non-blocking, burn-in)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v6
+
+    - name: Run integration tests (verify)
+      uses: ./.github/actions/maven-verify-burnin
+      with:
+        java_version: '21'

--- a/.github/workflows/ci-pull-request.yml
+++ b/.github/workflows/ci-pull-request.yml
@@ -27,3 +27,59 @@ jobs:
         push_to_ghcr: false
         image_name: oriso-agencyservice
         github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  # Non-blocking burn-in (Test Quality Audit 2026-07-04, item 3 + CI Roadmap Part 1).
+  # Runs `mvnw -B verify`, which reaches the surefire `integration-tests` execution
+  # (integration-test phase, **/*IT.*) — 24 IT classes that have never run in CI
+  # (local burn-in 2026-07-07: 7 green / 16 red, mostly context-load errors).
+  # continue-on-error keeps this OFF the required-checks path until the ITs are
+  # green; flip to a required check once burn-in is consistently passing.
+  integration-tests:
+    name: integration-tests (non-blocking, burn-in)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v6
+
+    - name: Run integration tests (verify)
+      uses: ./.github/actions/maven-verify-burnin
+      with:
+        java_version: '21'
+
+  # Non-blocking OpenAPI contract diff: flags breaking changes to this service's
+  # own vendored specs (api/*.yaml) between the PR base and head. Informational
+  # during burn-in; flip to blocking once the process around intentional breaking
+  # changes (version bump / consumer sign-off) is agreed.
+  api-contract-diff:
+    name: api-contract-diff (non-blocking)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+
+    steps:
+    - name: Checkout PR head
+      uses: actions/checkout@v6
+
+    - name: Checkout base branch
+      uses: actions/checkout@v6
+      with:
+        ref: ${{ github.base_ref }}
+        path: .base
+
+    - name: Diff own OpenAPI specs against base (oasdiff breaking)
+      shell: bash
+      run: |
+        shopt -s nullglob
+        status=0
+        for spec in api/*.yaml api/*.yml; do
+          if [ -f ".base/$spec" ]; then
+            echo "::group::oasdiff breaking $spec"
+            docker run --rm -v "$PWD:/work:ro" ghcr.io/oasdiff/oasdiff:latest \
+              breaking "/work/.base/$spec" "/work/$spec" --fail-on WARN || status=1
+            echo "::endgroup::"
+          else
+            echo "Skipping $spec (new on this branch, nothing to diff against)"
+          fi
+        done
+        exit $status

--- a/.github/workflows/ci-pull-request.yml
+++ b/.github/workflows/ci-pull-request.yml
@@ -75,7 +75,7 @@ jobs:
         for spec in api/*.yaml api/*.yml; do
           if [ -f ".base/$spec" ]; then
             echo "::group::oasdiff breaking $spec"
-            docker run --rm -v "$PWD:/work:ro" ghcr.io/oasdiff/oasdiff:latest \
+            docker run --rm -v "$PWD:/work:ro" tufin/oasdiff:latest \
               breaking "/work/.base/$spec" "/work/$spec" --fail-on WARN || status=1
             echo "::endgroup::"
           else

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/service/agency/AgencyAdminSearchServiceSearchIT.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/service/agency/AgencyAdminSearchServiceSearchIT.java
@@ -21,10 +21,9 @@ import de.caritas.cob.agencyservice.api.model.Sort.OrderEnum;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
@@ -34,16 +33,14 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.transaction.annotation.Transactional;
 
-@RunWith(SpringRunner.class)
 @SpringBootTest(classes = AgencyServiceApplication.class)
 @TestPropertySource(properties = "spring.profiles.active=testing")
 @AutoConfigureTestDatabase(replace = Replace.ANY)
 @DirtiesContext(classMode = ClassMode.BEFORE_CLASS)
 @Transactional
-public class AgencyAdminSearchServiceIntegrationTests {
+class AgencyAdminSearchServiceSearchIT {
 
   @Autowired
   private AgencyAdminSearchService agencyAdminSearchService;


### PR DESCRIPTION
## Why

The Test Quality Audit (2026-07-04, reconciled 07-07) found AgencyService was the only backend without the hardened surefire report gate and without an integration-test burn-in job — no CI anywhere runs the `integration-tests` surefire execution (`**/*IT.*`, bound to the `integration-test` phase). It also found one orphan test class that matched neither surefire include pattern and therefore never ran at all.

Note: the audit-era `-Dmaven.test.skip=true` is already gone (removed in #89); the current `maven-build` action runs `./mvnw -B test`. This PR adds the missing hardening on top.

## What

**Hardened unit-test gate** (`.github/actions/maven-build`): after `./mvnw -B test`, parse `target/surefire-reports` and fail on any failures/errors — and also on *zero report files* or *zero executed tests*, so a future silent-skip regression cannot pass as green. Same pattern as UserService/TenantService/CTS.

**Non-blocking IT burn-in** (`.github/actions/maven-verify-burnin`, copied from UserService): `./mvnw -B -fae verify` runs the `**/*IT.*` execution for the first time in CI; zero-report guard, per-report summary, artifact upload. Wired into `ci-pull-request.yml` and `ci-feature-branch.yml` as `integration-tests` with `continue-on-error: true` — **must not become a required check yet**:

Local burn-in on this branch (JDK 21, 2026-07-07): 24 IT classes, 161 IT tests → **16 failures / 107 errors**. Red classes (mostly context-load errors): ResponseEntityExceptionHandlerIT, AgencyAdminControllerAuthorizationIT, AgencyAdminServiceIT, AgencyAdminServiceTenantAwareIT, AgencyAdminSearchServiceIT, AgencyPostcodeRangeAdminServiceIT, AgencyValidatorIT, AgencyAdminControllerIT (+WithDemographics/WithTopics), AgencyControllerWithDemographicsIT, AgencyControllerWithSingleDomainMultitenancyIT, AgencyRepositoryIT, AgencyRepositoryTenantAwareIT, AgencyServiceIT, AgencyServiceTenantAwareIT. Green: ActuatorControllerIT, AgencyControllerIT, ConsultingTypeManagerIT, LiquibaseChangelogDriftIT, AgencyPostcodeRangeAdminServiceTenantAwareIT, CacheManagerConfigIT, RestTemplateConfigIT.

**Orphan test now runs**: `AgencyAdminSearchServiceIntegrationTests` (19 tests) matched neither `**/*Test.java` nor `**/*IT.*` and mixed JUnit 4 + 5 annotations. Renamed to `AgencyAdminSearchServiceSearchIT` and migrated to pure JUnit 5; it now executes in the integration-test phase (currently red on seed-data expectations — part of the burn-in set above).

**Non-blocking `api-contract-diff` job** (`ci-pull-request.yml`): runs the `oasdiff` docker image (`breaking`) over the service's own vendored specs (`api/agencyservice.yaml`, `api/agencyadminservice.yaml`) comparing PR base vs head, `continue-on-error: true`.

## Verification

- `./mvnw -B test`: **440 tests, 0 failures, 0 errors, 0 skipped — BUILD SUCCESS** (unchanged before/after the rename, since the orphan never ran in the test phase).
- `./mvnw -B -fae verify`: IT numbers above (burn-in job is non-blocking by design).
- Gate script exercised locally against the green report set (72 reports parsed, exit 0) and fails correctly on a synthetic failing report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)