### PR TITLE
fix(api): replace invalid OpenAPI scalar 'type: long' with integer/int64

### DIFF
--- a/api/agencyadminservice.yaml
+++ b/api/agencyadminservice.yaml
@@ -659,7 +659,8 @@ components:
       type: object
       properties:
         id:
-          type: long
+          type: integer
+          format: int64
           example: 12132
         name:
           type: string
@@ -899,7 +900,8 @@ components:
         topicIds:
           type: array
           items:
-            type: long
+            type: integer
+            format: int64
         demographics:
           $ref: '#/components/schemas/DemographicsDTO'
         tenantId:
@@ -997,7 +999,8 @@ components:
         topicIds:
           type: array
           items:
-            type: long
+            type: integer
+            format: int64
         demographics:
           $ref: '#/components/schemas/DemographicsDTO'
         counsellingRelations:

--- a/services/appointmentService.yaml
+++ b/services/appointmentService.yaml
@@ -375,7 +375,8 @@ components:
       type: object
       properties:
         id:
-          type: long
+          type: integer
+          format: int64
           example: 1
         userId:
           type: integer
@@ -712,7 +713,8 @@ components:
                 user:
                   type: string
                 bookingId:
-                  type: long
+                  type: integer
+                  format: int64
                 isInitialAppointment:
                   type: boolean
 
@@ -758,11 +760,13 @@ components:
         agencies:
           type: array
           items:
-            type: long
+            type: integer
+            format: int64
     AgencyMasterDataSyncRequestDTO:
       type: object
       properties:
         id:
-          type: long
+          type: integer
+          format: int64
         name:
           type: string

--- a/services/tenantservice.yaml
+++ b/services/tenantservice.yaml
@@ -246,7 +246,8 @@ paths:
           description: Tenant Id
           required: false
           schema:
-            type: long
+            type: integer
+            format: int64
       responses:
         200:
           description: Successful operation
@@ -274,7 +275,8 @@ paths:
           description: Tenant ID
           required: true
           schema:
-            type: long
+            type: integer
+            format: int64
       responses:
         200:
           description: Successful operation
@@ -360,7 +362,8 @@ components:
         - subdomain
       properties:
         id:
-          type: long
+          type: integer
+          format: int64
           example: 12132
         name:
           type: string
@@ -392,7 +395,8 @@ components:
             - name
           properties:
             id:
-              type: long
+              type: integer
+              format: int64
               example: 12132
             name:
               type: string
@@ -430,7 +434,8 @@ components:
         - subdomain
       properties:
         id:
-          type: long
+          type: integer
+          format: int64
           example: 12132
         name:
           type: string
@@ -453,7 +458,8 @@ components:
         - name
       properties:
         id:
-          type: long
+          type: integer
+          format: int64
           example: 12132
         name:
           type: string
@@ -644,7 +650,8 @@ components:
         - subdomain
       properties:
         id:
-          type: long
+          type: integer
+          format: int64
           example: 12132
         name:
           type: string

--- a/services/topicservice.yaml
+++ b/services/topicservice.yaml
@@ -123,7 +123,8 @@ components:
         - description
       properties:
         id:
-          type: long
+          type: integer
+          format: int64
           example: 12132
         name:
           type: string


### PR DESCRIPTION
## What
Replaces all 15 occurrences of the invalid OpenAPI scalar `type: long` with `type: integer` + `format: int64`: `api/agencyadminservice.yaml` (3), `services/tenantservice.yaml` (7), `services/appointmentService.yaml` (4), `services/topicservice.yaml` (1).

## Why
`long` is not a valid OpenAPI data type. Downstream type generators break on it — ORISO-Frontend's `dtsgen.ts` needed a normalization workaround because of this (see OpenResilienceInitiative/ORISO-Frontend#384). Sibling PRs: TS#68, CTS#52, US#329.

## Verification
`./mvnw -B compile` green; `integer/int64` still maps to `Long`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
