### PR TITLE
ci: report-only jobs finish green with warnings instead of red (detox PR status)

### DIFF
--- a/.github/workflows/ci-pull-request.yml
+++ b/.github/workflows/ci-pull-request.yml
@@ -82,4 +82,7 @@ jobs:
             echo "Skipping $spec (new on this branch, nothing to diff against)"
           fi
         done
-        exit $status
+        if [ "$status" -ne 0 ]; then
+          echo "::warning::oasdiff found (formally) breaking API spec changes - report-only; see the log groups above. Flip to a hard failure once the breaking-change process is agreed."
+          echo "### api-contract-diff: breaking changes detected (report-only)" >> "$GITHUB_STEP_SUMMARY"
+        fi


### PR DESCRIPTION
## Problem
Every open PR shows a red ✗ even though all blocking checks are green — the cause is the deliberately non-required jobs (IT burn-in, `api-contract-diff`): `continue-on-error` keeps them from gating, but the check run itself still concludes FAILURE and paints the PR status red.

## Fix
Both jobs now finish **green with a `::warning::` annotation** (oasdiff additionally writes a step summary) instead of red. One exception stays hard: the zero-report guard in the burn-in (silently skipped tests are an infrastructure failure, not burn-in noise).

## Verification
YAML validated; behavior identical except for exit code + annotation. After merging, the false-red ✗ disappears from all open PRs (re-run required).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
