### PR TITLE
Close agency admin CSRF logout regression (#50).

### DIFF
--- a/src/main/java/de/caritas/cob/agencyservice/filter/StatelessCsrfFilter.java
+++ b/src/main/java/de/caritas/cob/agencyservice/filter/StatelessCsrfFilter.java
@@ -60,6 +60,10 @@ public class StatelessCsrfFilter extends OncePerRequestFilter {
     filterChain.doFilter(request, response);
   }
 
+  /**
+   * Admin UI calls the API host with a bearer token while the CSRF cookie stays on the admin host.
+   * Cross-host mutations must not be rejected by the cookie/header CSRF check.
+   */
   private boolean isBearerAuthenticatedRequest(HttpServletRequest request) {
     String authorizationHeader = request.getHeader("Authorization");
     return authorizationHeader != null

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/controller/AgencyAdminControllerAuthorizationIT.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/controller/AgencyAdminControllerAuthorizationIT.java
@@ -14,10 +14,11 @@ import static de.caritas.cob.agencyservice.testHelper.TestConstants.VALID_POSTCO
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -34,7 +35,10 @@ import de.caritas.cob.agencyservice.api.model.AgencyTypeRequestDTO;
 import de.caritas.cob.agencyservice.api.model.PostcodeRangeDTO;
 import de.caritas.cob.agencyservice.api.model.UpdateAgencyDTO;
 import jakarta.servlet.http.Cookie;
+import java.util.List;
+import java.util.Map;
 import org.jeasy.random.EasyRandom;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
@@ -43,12 +47,16 @@ import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabas
 import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase.Replace;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.http.MediaType;
-import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
 
 @RunWith(SpringRunner.class)
 @TestPropertySource(properties = {
@@ -64,9 +72,13 @@ public class AgencyAdminControllerAuthorizationIT {
   private static final String CSRF_HEADER = "csrfHeader";
   private static final String CSRF_VALUE = "test";
   private static final Cookie CSRF_COOKIE = new Cookie("csrfCookie", CSRF_VALUE);
+  private static final String BEARER_AUTHORIZATION = "Bearer test-token";
 
   @Autowired
   private MockMvc mvc;
+
+  @MockitoBean
+  private JwtDecoder jwtDecoder;
 
   @MockitoBean
   private AgencyAdminSearchService agencyAdminFullResponseDTO;
@@ -79,6 +91,17 @@ public class AgencyAdminControllerAuthorizationIT {
 
   @MockitoBean
   private AgencyValidator agencyValidator;
+
+  @Before
+  public void setUpJwtDecoder() {
+    Jwt agencyAdminJwt =
+        Jwt.withTokenValue("test-token")
+            .header("alg", "none")
+            .claim("sub", "agency-admin")
+            .claim("realm_access", Map.of("roles", List.of("agency-admin")))
+            .build();
+    when(jwtDecoder.decode(any(String.class))).thenReturn(agencyAdminJwt);
+  }
 
   @Test
   public void searchAgencies_Should_ReturnUnauthorizedAndCallNoMethods_When_noKeycloakAuthorizationIsPresent()
@@ -93,15 +116,13 @@ public class AgencyAdminControllerAuthorizationIT {
   }
 
   @Test
-  @WithMockUser(authorities = {"AUTHORIZATION_AGENCY_ADMIN"})
   public void searchAgencies_Should_ReturnOkAndCallAgencyAdminSearchService_When_agencyAdminAuthority()
       throws Exception {
 
     mvc.perform(get(AGENCY_SEARCH_PATH)
         .param(PAGE_PARAM, "0")
         .param(PER_PAGE_PARAM, "1")
-        .cookie(CSRF_COOKIE)
-        .header(CSRF_HEADER, CSRF_VALUE))
+        .header("Authorization", BEARER_AUTHORIZATION))
         .andExpect(status().isOk());
 
     verify(this.agencyAdminFullResponseDTO, times(1)).searchAgencies(any(), anyInt(), any(), any());
@@ -120,13 +141,10 @@ public class AgencyAdminControllerAuthorizationIT {
   }
 
   @Test
-  @WithMockUser(authorities = {"AUTHORIZATION_AGENCY_ADMIN"})
   public void getAgencyPostCodeRanges_Should_ReturnOkAndCallAgencyPostCodeRangeAdminService_When_agencyAdminAuthority()
       throws Exception {
 
-    mvc.perform(get(AGENCY_POSTCODE_RANGE_PATH)
-        .cookie(CSRF_COOKIE)
-        .header(CSRF_HEADER, CSRF_VALUE))
+    mvc.perform(get(AGENCY_POSTCODE_RANGE_PATH).header("Authorization", BEARER_AUTHORIZATION))
         .andExpect(status().isOk());
 
     verify(this.agencyPostCodeRangeAdminService, times(1)).findPostcodeRangesForAgency(anyLong());
@@ -147,13 +165,13 @@ public class AgencyAdminControllerAuthorizationIT {
   }
 
   @Test
-  @WithMockUser(authorities = {"AUTHORIZATION_AGENCY_ADMIN"})
-  public void createAgency_Should_ReturnForbiddenAndCallNoMethods_When_csrfTokenIsMissing()
+  public void createAgency_Should_ReturnForbiddenAndCallNoMethods_When_csrfTokenIsMissingAndNoBearerHeader()
       throws Exception {
 
     mvc.perform(post(CREATE_AGENCY_PATH)
         .contentType(MediaType.APPLICATION_JSON)
-        .content(VALID_AGENCY_DTO))
+        .content(VALID_AGENCY_DTO)
+        .with(agencyAdminCookieAuth()))
         .andExpect(status().isForbidden());
 
     verifyNoMoreInteractions(this.agencyAdminService);
@@ -161,13 +179,27 @@ public class AgencyAdminControllerAuthorizationIT {
   }
 
   @Test
-  @WithMockUser(authorities = {"AUTHORIZATION_AGENCY_ADMIN"})
+  public void createAgency_Should_ReturnCreatedAndCallAgencyAdminServiceAndAgencyValidator_When_bearerPresentWithoutCsrf()
+      throws Exception {
+
+    mvc.perform(post(CREATE_AGENCY_PATH)
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(VALID_AGENCY_DTO)
+        .header("Authorization", BEARER_AUTHORIZATION))
+        .andExpect(status().isCreated());
+
+    verify(this.agencyValidator, times(1)).validate(Mockito.any(AgencyDTO.class));
+    verify(this.agencyAdminService, times(1)).createAgency(Mockito.any());
+  }
+
+  @Test
   public void createAgency_Should_ReturnCreatedAndCallAgencyAdminServiceAndAgencyValidator_When_agencyAdminAuthority()
       throws Exception {
 
     mvc.perform(post(CREATE_AGENCY_PATH)
         .contentType(MediaType.APPLICATION_JSON)
         .content(VALID_AGENCY_DTO)
+        .with(agencyAdminCookieAuth())
         .cookie(CSRF_COOKIE)
         .header(CSRF_HEADER, CSRF_VALUE))
         .andExpect(status().isCreated());
@@ -191,13 +223,28 @@ public class AgencyAdminControllerAuthorizationIT {
   }
 
   @Test
-  @WithMockUser(authorities = {"AUTHORIZATION_AGENCY_ADMIN"})
+  public void updateAgency_Should_ReturnOkAndCallAgencyAdminServiceAndAgencyValidator_When_bearerPresentWithoutCsrf()
+      throws Exception {
+
+    mvc.perform(put(UPDATE_DELETE_AGENCY_PATH)
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(VALID_AGENCY_UPDATE_DTO)
+        .header("Authorization", BEARER_AUTHORIZATION))
+        .andExpect(status().isOk());
+
+    verify(this.agencyValidator, times(1))
+        .validate(Mockito.anyLong(), Mockito.any(UpdateAgencyDTO.class));
+    verify(this.agencyAdminService, times(1)).updateAgency(Mockito.anyLong(), Mockito.any());
+  }
+
+  @Test
   public void updateAgency_Should_ReturnOkAndCallAgencyAdminServiceAndAgencyValidator_When_agencyAdminAuthority()
       throws Exception {
 
     mvc.perform(put(UPDATE_DELETE_AGENCY_PATH)
         .contentType(MediaType.APPLICATION_JSON)
         .content(VALID_AGENCY_UPDATE_DTO)
+        .with(agencyAdminCookieAuth())
         .cookie(CSRF_COOKIE)
         .header(CSRF_HEADER, CSRF_VALUE))
         .andExpect(status().isOk());
@@ -221,12 +268,12 @@ public class AgencyAdminControllerAuthorizationIT {
   }
 
   @Test
-  @WithMockUser(authorities = {"AUTHORIZATION_AGENCY_ADMIN"})
   public void deletePostcodeRange_Should_ReturnOKAndCallAgencyAdminServiceAndAgencyValidator_When_agencyAdminAuthority()
       throws Exception {
 
     mvc.perform(delete(AGENCY_POSTCODE_RANGE_PATH + "1")
         .contentType(MediaType.APPLICATION_JSON)
+        .with(agencyAdminCookieAuth())
         .cookie(CSRF_COOKIE)
         .header(CSRF_HEADER, CSRF_VALUE))
         .andExpect(status().isOk());
@@ -248,13 +295,13 @@ public class AgencyAdminControllerAuthorizationIT {
   }
 
   @Test
-  @WithMockUser(authorities = {"AUTHORIZATION_AGENCY_ADMIN"})
   public void createAgencyPostcodeRange_Should_ReturnCreatedAndCallAgencyPostCodeRangeAdminService_When_agencyAdminAuthority()
       throws Exception {
 
     mvc.perform(post(AGENCY_POSTCODE_RANGE_PATH)
         .contentType(MediaType.APPLICATION_JSON)
         .content(VALID_POSTCODE_RANGE_DTO)
+        .with(agencyAdminCookieAuth())
         .cookie(CSRF_COOKIE)
         .header(CSRF_HEADER, CSRF_VALUE))
         .andExpect(status().isCreated());
@@ -277,13 +324,13 @@ public class AgencyAdminControllerAuthorizationIT {
   }
 
   @Test
-  @WithMockUser(authorities = {"AUTHORIZATION_AGENCY_ADMIN"})
   public void updateAgencyPostcodeRange_Should_ReturnOkAndCallAgencyPostCodeRangeAdminService_When_agencyAdminAuthority()
       throws Exception {
 
     mvc.perform(put(AGENCY_POSTCODE_RANGE_PATH)
         .contentType(MediaType.APPLICATION_JSON)
         .content(VALID_POSTCODE_RANGE_DTO)
+        .with(agencyAdminCookieAuth())
         .cookie(CSRF_COOKIE)
         .header(CSRF_HEADER, CSRF_VALUE))
         .andExpect(status().isOk());
@@ -306,7 +353,6 @@ public class AgencyAdminControllerAuthorizationIT {
   }
 
   @Test
-  @WithMockUser(authorities = {"AUTHORIZATION_AGENCY_ADMIN"})
   public void changeAgencyType_Should_ReturnOkAndCallAgencyAdminService_When_agencyAdminAuthority()
       throws Exception {
     AgencyTypeRequestDTO requestDTO =
@@ -315,6 +361,7 @@ public class AgencyAdminControllerAuthorizationIT {
     mvc.perform(post(CHANGE_AGENCY_TYPE_PATH)
         .contentType(MediaType.APPLICATION_JSON)
         .content(new ObjectMapper().writeValueAsString(requestDTO))
+        .with(agencyAdminCookieAuth())
         .cookie(CSRF_COOKIE)
         .header(CSRF_HEADER, CSRF_VALUE))
         .andExpect(status().isOk());
@@ -336,12 +383,12 @@ public class AgencyAdminControllerAuthorizationIT {
   }
 
   @Test
-  @WithMockUser(authorities = {"AUTHORIZATION_AGENCY_ADMIN"})
   public void deleteAgency_Should_ReturnOkAndCallAgencyAdminService_When_agencyAdminAuthority()
       throws Exception {
 
     mvc.perform(delete(UPDATE_DELETE_AGENCY_PATH)
         .contentType(MediaType.APPLICATION_JSON)
+        .with(agencyAdminCookieAuth())
         .cookie(CSRF_COOKIE)
         .header(CSRF_HEADER, CSRF_VALUE))
         .andExpect(status().isOk());
@@ -363,16 +410,22 @@ public class AgencyAdminControllerAuthorizationIT {
   }
 
   @Test
-  @WithMockUser(authorities = {"AUTHORIZATION_AGENCY_ADMIN"})
   public void getAgency_Should_ReturnOkAndCallAgencyAdminService_When_agencyAdminAuthority()
       throws Exception {
 
     mvc.perform(get(GET_AGENCY_PATH + "/1")
         .contentType(MediaType.APPLICATION_JSON)
-        .cookie(CSRF_COOKIE)
-        .header(CSRF_HEADER, CSRF_VALUE))
+        .header("Authorization", BEARER_AUTHORIZATION))
         .andExpect(status().isOk());
 
     verify(this.agencyAdminService, times(1)).findAgency(anyLong());
+  }
+
+  private static RequestPostProcessor agencyAdminCookieAuth() {
+    return authentication(
+        new UsernamePasswordAuthenticationToken(
+            "agency-admin",
+            "n/a",
+            List.of(new SimpleGrantedAuthority("AUTHORIZATION_AGENCY_ADMIN"))));
   }
 }


### PR DESCRIPTION
## Summary
Closes #50 validation gap.

The bearer bypass in `StatelessCsrfFilter` is already on `dev` (skip cookie/header CSRF when `Authorization: Bearer …` is present). This PR adds regression coverage for the real admin scenario: cross-host bearer mutations without a matching CSRF cookie.

Also fixes `AgencyAdminControllerAuthorizationIT` for OAuth2 resource server (replaces broken `@WithMockUser` with `JwtDecoder` mock + Bearer header).

## Why
Admin UI posts to `/service/agencyadmin/agencies` with a bearer token, but the CSRF cookie lives on the admin host. Without the bypass, the API returns 403 and the frontend treats it as logout.

## Test plan
- [x] `StatelessCsrfFilterTest`
- [x] `AgencyAdminControllerAuthorizationIT` (incl. create/update with bearer, no CSRF)
- [ ] After deploy: agency creation on Pre-Dev / dev (`oriso.org`)