### PR TITLE
chore(coderabbit): add config and enable auto review on dev

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,75 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+
+language: en-US
+
+tone_instructions: "Be a strict, practical ORISO reviewer for this Spring Boot service. Keep comments concise, concrete, and focused on correctness, mergeability, privacy, security, tests, and maintainability."
+
+reviews:
+  profile: assertive
+  request_changes_workflow: true
+  high_level_summary: true
+  review_status: true
+  review_details: true
+  poem: false
+
+  auto_review:
+    enabled: true
+    description_keyword: "coderabbit: review"
+    auto_incremental_review: false
+    drafts: false
+    labels:
+      - "coderabbit"
+    base_branches:
+      - "dev"
+
+  path_filters:
+    - "!target/**"
+    - "!**/generated/**"
+    - "src/**"
+    - "pom.xml"
+    - ".github/**"
+    - "*.md"
+
+  path_instructions:
+    - path: "src/main/**/*.java"
+      instructions: |
+        Check behavior against the surrounding ORISO flow, not only types. Flag
+        missing transaction boundaries, swallowed exceptions, N+1 queries, and
+        privacy regressions around Matrix identifiers, chat content and user data.
+        Configuration must stay environment-driven — never hardcode hosts, IPs or
+        credentials (see ADR-005 / finding DB-M04).
+    - path: "src/main/resources/db/**"
+      instructions: |
+        Liquibase changesets are append-only. Flag edits to already-applied
+        changesets, missing rollback, and changes that are not idempotent.
+    - path: "src/test/**/*.java"
+      instructions: |
+        Tests must be able to fail. Flag over-mocking that hides the defect,
+        assertions that cannot break, and missing edge cases.
+
+  pre_merge_checks:
+    title:
+      mode: warning
+      requirements: "Use a concise conventional title that names the affected ORISO area."
+    description:
+      mode: warning
+    custom_checks:
+      - name: "Validation evidence"
+        mode: error
+        instructions: |
+          Pass for docs/config-only PRs. For behavior-affecting product code,
+          pass only if the PR includes relevant automated tests or clearly lists
+          the exact validation command and result. Fail if product behavior
+          changed with no test/validation evidence and no explicit rationale.
+
+knowledge_base:
+  code_guidelines:
+    enabled: true
+    filePatterns:
+      - "README.md"
+      - ".understand-anything/README.md"
+      - ".understand-anything/ARCHITECTURE.md"
+      - ".understand-anything/ORISO-ECOSYSTEM.md"
+
+chat:
+  auto_reply: true


### PR DESCRIPTION
Add a `.coderabbit.yaml` (this repo had none), modelled on `ORISO-Frontend/.coderabbit.yaml` — `profile: assertive`, `request_changes_workflow: true`, repo-appropriate `path_filters` and `path_instructions`.

## Why

CodeRabbit is treated as a merge-blocking review gate for ORISO, but it has been **auto-reviewing nothing, silently**. Discovered on ORISO-UserService PR #370, where the check reported:

```
CodeRabbit / Review — skipping
"Auto reviews are disabled on base/target branches other than the default branch."
```

State before this change:

| repo | `.coderabbit.yaml` | effect |
|---|---|---|
| ORISO-Frontend, ORISO-Admin | present, but `auto_review.enabled: false` | never auto-reviews |
| ORISO-UserService, ORISO-AgencyService, ORISO-TenantService, ORISO-Helm | **absent** | CodeRabbit defaults → only auto-reviews PRs targeting the GitHub default branch, which is `main` — and nothing targets `main` |

Net effect: **no PR in any repo received an automatic CodeRabbit review.**

## What changes

`reviews.auto_review.enabled: true`, with `base_branches: ["dev"]`. A review gate that never runs protects nothing.

## Scope decision

`dev` only, deliberately. PRs targeting `pre-dev` still get no automatic review — the gate sits at `dev`. If feature PRs into `pre-dev` should also be reviewed, add `"pre-dev"` to `base_branches`.

## Base branch

This PR targets **`dev`**, not `pre-dev`: CodeRabbit reads `.coderabbit.yaml` from the base branch of the PR it reviews, so with `base_branches: ["dev"]` the config has to exist on `dev` to have any effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
