### PR TITLE
Fix AgencyService startup without encryption key

### DIFF
--- a/src/main/java/de/caritas/cob/agencyservice/api/service/matrix/AgencyMatrixPasswordCipher.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/service/matrix/AgencyMatrixPasswordCipher.java
@@ -36,6 +36,7 @@ public class AgencyMatrixPasswordCipher {
     if (StringUtils.isBlank(plaintext) || plaintext.startsWith(ENCRYPTED_PREFIX)) {
       return plaintext;
     }
+    requireApplicationKey();
     try {
       Cipher cipher = Cipher.getInstance(CIPHER_TRANSFORMATION);
       cipher.init(Cipher.ENCRYPT_MODE, secretKeySpec());
@@ -50,6 +51,7 @@ public class AgencyMatrixPasswordCipher {
     if (StringUtils.isBlank(storedValue) || !storedValue.startsWith(ENCRYPTED_PREFIX)) {
       return storedValue;
     }
+    requireApplicationKey();
     String ciphertext = storedValue.substring(ENCRYPTED_PREFIX.length());
     try {
       Cipher cipher = Cipher.getInstance(CIPHER_TRANSFORMATION);
@@ -58,6 +60,13 @@ public class AgencyMatrixPasswordCipher {
       return new String(decrypted, StandardCharsets.UTF_8);
     } catch (Exception ex) {
       throw new InternalServerErrorException("Unable to decrypt agency Matrix password", ex);
+    }
+  }
+
+  private void requireApplicationKey() {
+    if (StringUtils.isBlank(applicationKey)) {
+      throw new InternalServerErrorException(
+          "Agency Matrix password encryption key is not configured");
     }
   }
 

--- a/src/main/java/de/caritas/cob/agencyservice/config/ConfigurationValidator.java
+++ b/src/main/java/de/caritas/cob/agencyservice/config/ConfigurationValidator.java
@@ -51,9 +51,6 @@ public class ConfigurationValidator {
   @Value("${matrix.admin-password:}")
   private String matrixAdminPassword;
 
-  @Value("${service.encryption.appkey:}")
-  private String serviceEncryptionAppkey;
-
   @Value("${consulting.type.service.api.url:}")
   private String consultingTypeServiceApiUrl;
 
@@ -102,9 +99,6 @@ public class ConfigurationValidator {
     }
     if (isEmpty(matrixAdminPassword)) {
       missingConfigs.add("matrix.admin-password (MATRIX_ADMIN_PASSWORD)");
-    }
-    if (isEmpty(serviceEncryptionAppkey)) {
-      missingConfigs.add("service.encryption.appkey (SERVICE_ENCRYPTION_APPKEY)");
     }
     if (isEmpty(consultingTypeServiceApiUrl)) {
       missingConfigs.add("consulting.type.service.api.url (CONSULTING_TYPE_SERVICE_API_URL)");

--- a/src/test/java/de/caritas/cob/agencyservice/api/service/matrix/AgencyMatrixPasswordCipherTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/service/matrix/AgencyMatrixPasswordCipherTest.java
@@ -1,7 +1,9 @@
 package de.caritas.cob.agencyservice.api.service.matrix;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import de.caritas.cob.agencyservice.api.exception.httpresponses.InternalServerErrorException;
 import org.junit.jupiter.api.Test;
 
 class AgencyMatrixPasswordCipherTest {
@@ -25,5 +27,14 @@ class AgencyMatrixPasswordCipherTest {
   void encryptShouldBeIdempotentForAlreadyEncryptedValues() {
     var encrypted = cipher.encrypt("matrix-secret-password");
     assertThat(cipher.encrypt(encrypted)).isEqualTo(encrypted);
+  }
+
+  @Test
+  void encryptShouldFailClearlyWhenApplicationKeyIsMissing() {
+    var cipherWithoutKey = new AgencyMatrixPasswordCipher("");
+
+    assertThatThrownBy(() -> cipherWithoutKey.encrypt("matrix-secret-password"))
+        .isInstanceOf(InternalServerErrorException.class)
+        .hasMessage("Agency Matrix password encryption key is not configured");
   }
 }

--- a/src/test/java/de/caritas/cob/agencyservice/config/ConfigurationValidatorTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/config/ConfigurationValidatorTest.java
@@ -28,7 +28,6 @@ class ConfigurationValidatorTest {
     setField(validator, "matrixServerName");
     setField(validator, "matrixAdminUsername");
     setField(validator, "matrixAdminPassword");
-    setField(validator, "serviceEncryptionAppkey");
     setField(validator, "consultingTypeServiceApiUrl");
     setField(validator, "tenantServiceApiUrl");
     setField(validator, "userAdminServiceApiUrl");


### PR DESCRIPTION
## Summary
- stop requiring SERVICE_ENCRYPTION_APPKEY during AgencyService startup validation
- keep Matrix password encryption/decryption protected by failing clearly when the key is missing and the cipher is actually used
- update focused validator/cipher tests

## Root cause
Pre-dev deployment failed during configurationValidator startup because the environment did not provide SERVICE_ENCRYPTION_APPKEY. That made the whole service crash before any agency Matrix password encryption/decryption path was exercised.

## Validation
- ./mvnw -Dtest=ConfigurationValidatorTest,AgencyMatrixPasswordCipherTest test