### PR TITLE
feat(agency-controls): enforcedPermissionToggles for agency admin controls (P1b of Admin#291)

### DIFF
--- a/api/components/agency-settings.yaml
+++ b/api/components/agency-settings.yaml
@@ -97,6 +97,11 @@ components:
           example: true
         allowedPermissionToggles:
           $ref: '#/components/schemas/AgencyAdminAllowedPermissionToggles'
+        # enforcedPermissionToggles: per-feature flags an upper role locks ON for lower roles
+        # (Traeger -> Beratungsstelle). true = enforced-on; absent/false = not enforced. Same shape
+        # as allowedPermissionToggles. See ADR-013.
+        enforcedPermissionToggles:
+          $ref: '#/components/schemas/AgencyAdminAllowedPermissionToggles'
 
     Settings:
       type: object

--- a/src/main/java/de/caritas/cob/agencyservice/api/admin/service/agencyadmincontrol/AgencyAdminControlsConverter.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/admin/service/agencyadmincontrol/AgencyAdminControlsConverter.java
@@ -13,7 +13,9 @@ public class AgencyAdminControlsConverter {
     }
     return new AgencyAdminControls()
         .permissionsPageEnabled(settings.getPermissionsPageEnabled())
-        .allowedPermissionToggles(toAllowedPermissionToggles(settings.getAllowedPermissionToggles()));
+        .allowedPermissionToggles(toAllowedPermissionToggles(settings.getAllowedPermissionToggles()))
+        .enforcedPermissionToggles(
+            toAllowedPermissionToggles(settings.getEnforcedPermissionToggles()));
   }
 
   public AgencyAdminControlsSettings toAgencyAdminControlsSettings(AgencyAdminControls controls) {
@@ -24,6 +26,8 @@ public class AgencyAdminControlsConverter {
         .permissionsPageEnabled(nullAsTrue(controls.getPermissionsPageEnabled()))
         .allowedPermissionToggles(
             toAllowedPermissionTogglesSettings(controls.getAllowedPermissionToggles()))
+        .enforcedPermissionToggles(
+            toEnforcedPermissionTogglesSettings(controls.getEnforcedPermissionToggles()))
         .build();
   }
 
@@ -33,6 +37,10 @@ public class AgencyAdminControlsConverter {
 
   private Boolean nullAsTrue(Boolean value) {
     return value != null ? value : Boolean.TRUE;
+  }
+
+  private Boolean nullAsFalse(Boolean value) {
+    return value != null ? value : Boolean.FALSE;
   }
 
   private AgencyAdminAllowedPermissionToggles toAllowedPermissionToggles(
@@ -103,6 +111,42 @@ public class AgencyAdminControlsConverter {
         .voiceMessagesOneOnOneChats(nullAsTrue(toggles.getVoiceMessagesOneOnOneChats()))
         .voiceMessagesGroupChats(nullAsTrue(toggles.getVoiceMessagesGroupChats()))
         .voiceMessagesSupervisionChats(nullAsTrue(toggles.getVoiceMessagesSupervisionChats()))
+        .build();
+  }
+
+  private AgencyAdminAllowedPermissionTogglesSettings toEnforcedPermissionTogglesSettings(
+      AgencyAdminAllowedPermissionToggles toggles) {
+    if (toggles == null) {
+      return null;
+    }
+    return AgencyAdminAllowedPermissionTogglesSettings.builder()
+        .appearance(nullAsFalse(toggles.getAppearance()))
+        .anonymousChat(nullAsFalse(toggles.getAnonymousChat()))
+        .calls(nullAsFalse(toggles.getCalls()))
+        .groupChat(nullAsFalse(toggles.getGroupChat()))
+        .supervision(nullAsFalse(toggles.getSupervision()))
+        .supervisionAnonymousChats(nullAsFalse(toggles.getSupervisionAnonymousChats()))
+        .supervisionOneOnOneChats(nullAsFalse(toggles.getSupervisionOneOnOneChats()))
+        .audioCalls(nullAsFalse(toggles.getAudioCalls()))
+        .audioCallsAnonymousChats(nullAsFalse(toggles.getAudioCallsAnonymousChats()))
+        .audioCallsOneOnOneChats(nullAsFalse(toggles.getAudioCallsOneOnOneChats()))
+        .audioCallsGroupChats(nullAsFalse(toggles.getAudioCallsGroupChats()))
+        .audioCallsSupervisionChats(nullAsFalse(toggles.getAudioCallsSupervisionChats()))
+        .videoCalls(nullAsFalse(toggles.getVideoCalls()))
+        .videoCallsAnonymousChats(nullAsFalse(toggles.getVideoCallsAnonymousChats()))
+        .videoCallsOneOnOneChats(nullAsFalse(toggles.getVideoCallsOneOnOneChats()))
+        .videoCallsGroupChats(nullAsFalse(toggles.getVideoCallsGroupChats()))
+        .videoCallsSupervisionChats(nullAsFalse(toggles.getVideoCallsSupervisionChats()))
+        .threads(nullAsFalse(toggles.getThreads()))
+        .threadsAnonymousChats(nullAsFalse(toggles.getThreadsAnonymousChats()))
+        .threadsOneOnOneChats(nullAsFalse(toggles.getThreadsOneOnOneChats()))
+        .threadsGroupChats(nullAsFalse(toggles.getThreadsGroupChats()))
+        .threadsSupervisionChats(nullAsFalse(toggles.getThreadsSupervisionChats()))
+        .voiceMessages(nullAsFalse(toggles.getVoiceMessages()))
+        .voiceMessagesAnonymousChats(nullAsFalse(toggles.getVoiceMessagesAnonymousChats()))
+        .voiceMessagesOneOnOneChats(nullAsFalse(toggles.getVoiceMessagesOneOnOneChats()))
+        .voiceMessagesGroupChats(nullAsFalse(toggles.getVoiceMessagesGroupChats()))
+        .voiceMessagesSupervisionChats(nullAsFalse(toggles.getVoiceMessagesSupervisionChats()))
         .build();
   }
 }

--- a/src/main/java/de/caritas/cob/agencyservice/api/admin/service/agencyadmincontrol/AgencyAdminControlsSettings.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/admin/service/agencyadmincontrol/AgencyAdminControlsSettings.java
@@ -13,4 +13,11 @@ public class AgencyAdminControlsSettings {
 
   private Boolean permissionsPageEnabled;
   private AgencyAdminAllowedPermissionTogglesSettings allowedPermissionToggles;
+
+  /**
+   * Per-feature flags an upper role locks on for lower roles (Träger -> Beratungsstelle). {@code
+   * true} = enforced-on; absent/{@code false} = not enforced. Same shape as {@link
+   * #allowedPermissionToggles}. See ADR-013. Null on legacy rows (backward compatible).
+   */
+  private AgencyAdminAllowedPermissionTogglesSettings enforcedPermissionToggles;
 }

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/service/agencyadmincontrol/AgencyAdminControlsConverterTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/service/agencyadmincontrol/AgencyAdminControlsConverterTest.java
@@ -1,0 +1,45 @@
+package de.caritas.cob.agencyservice.api.admin.service.agencyadmincontrol;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import de.caritas.cob.agencyservice.api.model.AgencyAdminAllowedPermissionToggles;
+import de.caritas.cob.agencyservice.api.model.AgencyAdminControls;
+import org.junit.jupiter.api.Test;
+
+class AgencyAdminControlsConverterTest {
+
+  private final AgencyAdminControlsConverter converter = new AgencyAdminControlsConverter();
+
+  @Test
+  void toAgencyAdminControls_should_preserveEnforcedToggle() {
+    var controls =
+        new AgencyAdminControls()
+            .enforcedPermissionToggles(new AgencyAdminAllowedPermissionToggles().videoCalls(true));
+
+    var settings = converter.toAgencyAdminControlsSettings(controls);
+    var back = converter.toAgencyAdminControls(settings);
+
+    assertThat(back.getEnforcedPermissionToggles().getVideoCalls()).isTrue();
+  }
+
+  @Test
+  void toAgencyAdminControlsSettings_should_defaultMissingEnforcedToggleToFalse() {
+    // unlike allowed (defaults true), an unset enforced flag means "not enforced" = false
+    var controls =
+        new AgencyAdminControls().enforcedPermissionToggles(new AgencyAdminAllowedPermissionToggles());
+
+    var settings = converter.toAgencyAdminControlsSettings(controls);
+
+    assertThat(settings.getEnforcedPermissionToggles().getVideoCalls()).isFalse();
+  }
+
+  @Test
+  void toAgencyAdminControlsSettings_should_keepEnforcedNullWhenAbsent() {
+    var controls =
+        new AgencyAdminControls().allowedPermissionToggles(new AgencyAdminAllowedPermissionToggles());
+
+    var settings = converter.toAgencyAdminControlsSettings(controls);
+
+    assertThat(settings.getEnforcedPermissionToggles()).isNull();
+  }
+}


### PR DESCRIPTION
Agency-level backbone (P1b) for the three-level permission cascade — see OpenResilienceInitiative/ORISO-Admin#291 / ADR-013.

**Problem:** Agency admin controls could only *force a feature off*; there was no way for a Träger to lock a feature **on** for its Beratungsstellen. Per microservice data-ownership, agency-scoped controls belong here (AgencyService owns Beratungsstellen).

**What changed**
- api: `enforcedPermissionToggles` added to `AgencyAdminControls` (same shape as `allowedPermissionToggles`) in `components/agency-settings.yaml`.
- model: `AgencyAdminControlsSettings` carries it — `null` on legacy rows, backward compatible.
- converter: round-trips with `nullAsFalse` (default = *not* enforced, unlike `allowed` which defaults `true`) and preserves `null` when absent.
- test: `AgencyAdminControlsConverterTest` (preserve `true`, default-missing-to-`false`, keep `null` when absent).

**Verification:** `mvnw -Dtest=AgencyAdminControlsConverterTest test` → 3/3 green; `checkstyle:check` clean.

Mirror of ORISO-TenantService#75 (platform/Träger level). Inert until a caller sets enforced flags (wired in later steps of #291).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
