### PR TITLE
fix: honor explicit tenant header before fallback

### DIFF
--- a/src/main/java/de/caritas/cob/agencyservice/api/tenant/TenantResolverService.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/tenant/TenantResolverService.java
@@ -41,7 +41,7 @@ public class TenantResolverService {
   private boolean multitenancyWithSingleDomain;
 
   private List<TenantResolver> nonAuthenticatedTenantResolvers() {
-    return newArrayList(multitenancyWithSingleDomainTenantResolver, customHeaderTenantResolver,
+    return newArrayList(customHeaderTenantResolver, multitenancyWithSingleDomainTenantResolver,
         subdomainTenantResolver);
   }
 

--- a/src/test/java/de/caritas/cob/agencyservice/api/tenant/TenantResolverServiceTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/tenant/TenantResolverServiceTest.java
@@ -2,6 +2,7 @@ package de.caritas.cob.agencyservice.api.tenant;
 
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -163,8 +164,6 @@ class TenantResolverServiceTest {
   @Test
   void resolve_Should_ResolveTenantId_FromHeader() {
     // given
-    when(multitenancyWithSingleDomainTenantResolver.resolve(authenticatedRequest))
-        .thenReturn(Optional.empty());
     when(customHeaderTenantResolver.resolve(authenticatedRequest)).thenReturn(Optional.of(2L));
 
     // when
@@ -173,6 +172,19 @@ class TenantResolverServiceTest {
     // then
     assertThat(resolved).isEqualTo(2L);
     verify(subdomainTenantResolver, never()).resolve(authenticatedRequest);
+  }
+
+  @Test
+  void resolve_Should_PreferExplicitHeaderOverSingleDomainTenant_ForNonAuthenticatedRequest() {
+    when(customHeaderTenantResolver.resolve(nonAuthenticatedRequest)).thenReturn(Optional.of(83L));
+    lenient().when(multitenancyWithSingleDomainTenantResolver.resolve(nonAuthenticatedRequest))
+        .thenReturn(Optional.of(1L));
+
+    Long resolved = tenantResolverService.resolve(nonAuthenticatedRequest);
+
+    assertThat(resolved).isEqualTo(83L);
+    verify(multitenancyWithSingleDomainTenantResolver, never()).resolve(nonAuthenticatedRequest);
+    verify(subdomainTenantResolver, never()).resolve(nonAuthenticatedRequest);
   }
 
   @Test


### PR DESCRIPTION
## Summary

- prefer an explicit tenant header over single-domain inference for unauthenticated requests
- retain single-domain and subdomain resolution as fallbacks
- add a regression test for the tenant-83 header versus tenant-1 fallback case

## Why

PreDev Live Chat propagates the invite link tenant from UserService to AgencyService. AgencyService previously resolved the main single-domain tenant first and ignored that explicit tenant context, returning a tenant-1 agency for a tenant-83 request. The hardened UserService correctly rejects that result, but the end-to-end flow cannot proceed until the downstream resolver honors the caller's explicit tenant.

## TDD evidence

- RED: regression test expected tenant 83 but the previous order returned tenant 1
- GREEN: `TenantResolverServiceTest` — 9 tests, 0 failures
- Full gate: 451 tests, 0 failures/errors/skips; Checkstyle and package build green
- Local CodeRabbit CLI: 0 findings across both changed files

## Risk and rollback

The change affects only unauthenticated tenant-resolution precedence. Authenticated access-token resolution is unchanged. Requests without a resolvable explicit header continue to use the existing single-domain and subdomain fallbacks. Rollback is the single commit in this PR.

## PreDev verification after merge

- deploy the immutable AgencyService PreDev image
- prove the live pod digest, start time, health, and Liquibase status
- verify `tenantId: 83` no longer returns a tenant-1 agency
- rerun the real-browser External Inbound Live Chat gate

Closes #121
Related: OpenResilienceInitiative/ORISO-UserService#413

PreDev only. No merge or deployment to `dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
