### PR TITLE
Fix MariaDB demo baseline sequence migration

### DIFF
--- a/src/main/resources/db/changelog/changeset/0025_demo_baseline/syncDemoBaselineAgencyVisibility.sql
+++ b/src/main/resources/db/changelog/changeset/0025_demo_baseline/syncDemoBaselineAgencyVisibility.sql
@@ -133,14 +133,8 @@ ON DUPLICATE KEY UPDATE
     `publication_status` = COALESCE(`publication_status`, 'DRAFT'),
     `publication_status_imprint` = COALESCE(`publication_status_imprint`, 'DRAFT');
 
-SET @demo_sequence_postcode_value := (
-    SELECT GREATEST(COALESCE(MAX(`id`), 0), 900000001)
-    FROM `agencyservice`.`agency_postcode_range`
-);
-DO SETVAL(`agencyservice`.`sequence_agency_postcode_range`, @demo_sequence_postcode_value, 0);
-
-SET @demo_sequence_agency_topic_value := (
-    SELECT GREATEST(COALESCE(MAX(`id`), 0), 900000010)
-    FROM `agencyservice`.`agency_topic`
-);
-DO SETVAL(`agencyservice`.`sequence_agency_topic`, @demo_sequence_agency_topic_value, 0);
+-- MariaDB requires SETVAL's next_value argument to be an integer literal.
+-- SETVAL never lowers a sequence, so these reserved baseline IDs are safe even
+-- when an environment has already advanced beyond them.
+DO SETVAL(`agencyservice`.`sequence_agency_postcode_range`, 900000001, 0);
+DO SETVAL(`agencyservice`.`sequence_agency_topic`, 900000010, 0);

--- a/src/test/java/de/caritas/cob/agencyservice/api/repository/DemoBaselineLiquibaseSqlTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/repository/DemoBaselineLiquibaseSqlTest.java
@@ -1,0 +1,24 @@
+package de.caritas.cob.agencyservice.api.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.io.ClassPathResource;
+
+class DemoBaselineLiquibaseSqlTest {
+
+  @Test
+  void sequenceSetvalCallsUseIntegerLiteralsRequiredByMariaDb() throws IOException {
+    var migration = new ClassPathResource(
+        "db/changelog/changeset/0025_demo_baseline/syncDemoBaselineAgencyVisibility.sql");
+    var sql = migration.getContentAsString(StandardCharsets.UTF_8);
+
+    assertThat(sql)
+        .doesNotContain("SETVAL(`agencyservice`.`sequence_agency_postcode_range`, @")
+        .doesNotContain("SETVAL(`agencyservice`.`sequence_agency_topic`, @")
+        .contains("SETVAL(`agencyservice`.`sequence_agency_postcode_range`, 900000001, 0)")
+        .contains("SETVAL(`agencyservice`.`sequence_agency_topic`, 900000010, 0)");
+  }
+}


### PR DESCRIPTION
## Summary
- replace variable-based MariaDB `SETVAL` calls with integer literals required by MariaDB
- keep sequence advancement safe because `SETVAL` never lowers an already higher sequence
- add a regression test that guards the production Liquibase SQL syntax

## Runtime evidence
- PreDev AgencyService crashed in changeset `0025_demo_baseline` with MariaDB error 1064 at `@demo_sequence_postcode_value` when Liquibase was enabled

## Validation
- RED: `./mvnw -Dtest=DemoBaselineLiquibaseSqlTest test`
- GREEN: same targeted test
- `./mvnw test` — 452 tests, 0 failures/errors
- `git diff --check`
- `xmllint --noout` for the master and changeset XML

Refs #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)
