### PR TITLE
fix(liquibase): make demo-baseline changeset (0025) MariaDB-safe and restart-safe

### DIFF
--- a/src/main/resources/db/changelog/changeset/0025_demo_baseline/0025_changeSet.xml
+++ b/src/main/resources/db/changelog/changeset/0025_demo_baseline/0025_changeSet.xml
@@ -2,7 +2,11 @@
 <databaseChangeLog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd">
-    <changeSet author="oriso" id="syncDemoBaselineAgencyVisibility">
+    <!-- runOnChange: the demo baseline is fully idempotent (WHERE NOT EXISTS / ON DUPLICATE KEY
+         UPDATE / SETVAL never lowers), so it is safe to re-apply. Marking it runOnChange means
+         editing this changeset re-runs it and refreshes the stored checksum instead of aborting
+         startup with a "checksum changed" validation error on the next restart. -->
+    <changeSet author="oriso" id="syncDemoBaselineAgencyVisibility" runOnChange="true">
         <sqlFile path="db/changelog/changeset/0025_demo_baseline/syncDemoBaselineAgencyVisibility.sql" stripComments="true"/>
         <rollback>
             <sqlFile path="db/changelog/changeset/0025_demo_baseline/syncDemoBaselineAgencyVisibility-rollback.sql" stripComments="true"/>

--- a/src/main/resources/db/changelog/changeset/0025_demo_baseline/syncDemoBaselineAgencyVisibility.sql
+++ b/src/main/resources/db/changelog/changeset/0025_demo_baseline/syncDemoBaselineAgencyVisibility.sql
@@ -133,8 +133,11 @@ ON DUPLICATE KEY UPDATE
     `publication_status` = COALESCE(`publication_status`, 'DRAFT'),
     `publication_status_imprint` = COALESCE(`publication_status_imprint`, 'DRAFT');
 
--- MariaDB requires SETVAL's next_value argument to be an integer literal.
--- SETVAL never lowers a sequence, so these reserved baseline IDs are safe even
--- when an environment has already advanced beyond them.
-DO SETVAL(`agencyservice`.`sequence_agency_postcode_range`, 900000001, 0);
-DO SETVAL(`agencyservice`.`sequence_agency_topic`, 900000010, 0);
+-- MariaDB requires SETVAL's next_value argument to be an integer literal (a user
+-- variable or subquery raises ERROR 1064). We pass the baseline row IDs as the
+-- last-USED value (is_used = 1), so the next NEXTVAL returns id + increment and
+-- skips past the reserved IDs -- otherwise the following app INSERT would collide
+-- with the demo rows (ERROR 1062 Duplicate entry). SETVAL never lowers a sequence,
+-- so this is a no-op on environments that already advanced beyond these IDs.
+DO SETVAL(`agencyservice`.`sequence_agency_postcode_range`, 900000001, 1);
+DO SETVAL(`agencyservice`.`sequence_agency_topic`, 900000010, 1);

--- a/src/test/java/de/caritas/cob/agencyservice/api/repository/DemoBaselineChangesetIT.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/repository/DemoBaselineChangesetIT.java
@@ -1,0 +1,128 @@
+package de.caritas.cob.agencyservice.api.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import de.caritas.cob.agencyservice.AgencyServiceApplication;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+
+/**
+ * Regression guard for the opt-in demo baseline changeset
+ * ({@code db/changelog/changeset/0025_demo_baseline}, Liquibase context {@code demo-baseline}).
+ *
+ * <p>The consolidated {@link LiquibaseChangelogDriftIT} only runs the {@code seed} context, so the
+ * {@code demo-baseline} changeset was never exercised by any test. Two real MariaDB-only defects
+ * slipped through as a result:
+ *
+ * <ol>
+ *   <li><b>Invalid MariaDB syntax</b> — the original changeset ended with
+ *       {@code DO SETVAL(seq, @variable, 0)}. MariaDB's {@code SETVAL} rejects a user variable as
+ *       its {@code next_value} argument with {@code ERROR 1064}, so AgencyService crashed on the
+ *       first restart that actually applied the changeset. H2 (the {@code testing} profile) never
+ *       runs Liquibase, so unit tests stayed green.</li>
+ *   <li><b>Sequence collision</b> — after switching to a literal, {@code SETVAL(seq, id, 0)}
+ *       (is_used = 0) makes the next {@code NEXTVAL} return the <em>reserved</em> baseline id, so
+ *       the following application insert failed with {@code ERROR 1062 Duplicate entry}. The fix
+ *       passes {@code is_used = 1} so {@code NEXTVAL} skips past the reserved ids.</li>
+ * </ol>
+ *
+ * <p>This test boots the app against a <em>fresh, empty</em> MariaDB with the
+ * {@code seed,demo-baseline} contexts (so the base schema and the demo baseline are both built by
+ * Liquibase), then asserts the baseline landed and that a sequence-driven insert does not collide.
+ *
+ * <p>Like {@link LiquibaseChangelogDriftIT} the test is gated on {@code LIQUIBASE_IT_DB_URL} and is
+ * skipped on the normal H2-based {@code testing} build. Provide a fresh MariaDB, e.g.:
+ *
+ * <pre>
+ *   docker run -d --name demo-baseline-mariadb -p 3313:3306 \
+ *     -e MARIADB_ROOT_PASSWORD=root -e MARIADB_DATABASE=agencyservice mariadb:10.11
+ *
+ *   LIQUIBASE_IT_DB_URL="jdbc:mariadb://127.0.0.1:3313/agencyservice" \
+ *   LIQUIBASE_IT_DB_USERNAME=root \
+ *   LIQUIBASE_IT_DB_PASSWORD=root \
+ *   ./mvnw -Dtest=DemoBaselineChangesetIT -DfailIfNoTests=false test
+ * </pre>
+ */
+@SpringBootTest(classes = AgencyServiceApplication.class)
+@ActiveProfiles("dev")
+@EnabledIfEnvironmentVariable(named = "LIQUIBASE_IT_DB_URL", matches = ".+")
+@TestPropertySource(
+    properties = {
+      "spring.datasource.url=${LIQUIBASE_IT_DB_URL}",
+      "spring.datasource.username=${LIQUIBASE_IT_DB_USERNAME:root}",
+      "spring.datasource.password=${LIQUIBASE_IT_DB_PASSWORD:root}",
+      "spring.datasource.driver-class-name=org.mariadb.jdbc.Driver",
+      "spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MariaDBDialect",
+      // Liquibase owns the schema; build the base schema (seed) AND the opt-in demo baseline.
+      "spring.liquibase.enabled=true",
+      "spring.liquibase.change-log=classpath:db/changelog/agencyservice-master.xml",
+      "spring.liquibase.contexts=seed,demo-baseline",
+      // Hibernate schema validation is the drift IT's job; here we only care that Liquibase runs.
+      "spring.jpa.hibernate.ddl-auto=none",
+      "multitenancy.enabled=false",
+      // The dev profile activates ConfigurationValidator (@Profile("!testing")); placeholders only.
+      "keycloak.auth-server-url=http://localhost:8080",
+      "keycloak.realm=test",
+      "spring.security.oauth2.resourceserver.jwt.issuer-uri=http://localhost:8080/realms/test",
+      "spring.security.oauth2.resourceserver.jwt.jwk-set-uri=http://localhost:8080/realms/test/protocol/openid-connect/certs",
+      "matrix.api-url=http://localhost:8008",
+      "matrix.registration-shared-secret=test-secret",
+      "matrix.server-name=localhost",
+      "matrix.admin-username=admin",
+      "matrix.admin-password=admin",
+      "consulting.type.service.api.url=http://localhost:8083",
+      "tenant.service.api.url=http://localhost:8089",
+      "user.admin.service.api.url=http://localhost:8082"
+    })
+class DemoBaselineChangesetIT {
+
+  /** The demo agency id reserved by the baseline changeset (0025). */
+  private static final long DEMO_AGENCY_ID = 246L;
+
+  @Autowired private DataSource dataSource;
+
+  /**
+   * Reaching this test means the {@code demo-baseline} changeset applied without an
+   * {@code ERROR 1064} (invalid SETVAL syntax). We then assert the reserved agency exists and that
+   * an application-style insert driven by the AgencyService sequence does not collide with the
+   * reserved baseline id ({@code ERROR 1062}), which would happen with {@code SETVAL(..., 0)}.
+   */
+  @Test
+  void demoBaseline_applies_andSequenceDoesNotCollideWithReservedIds() throws Exception {
+    try (Connection connection = dataSource.getConnection();
+        Statement statement = connection.createStatement()) {
+
+      long demoAgencyCount = queryCount(statement, "SELECT COUNT(*) FROM agency WHERE id = " + DEMO_AGENCY_ID);
+      assertThat(demoAgencyCount)
+          .as("demo baseline agency (0025) must be present after the demo-baseline context ran")
+          .isEqualTo(1L);
+
+      // The is_used=1 fix: the next value from the sequence must skip past the reserved baseline
+      // id, so this insert must NOT raise "Duplicate entry" on the primary key.
+      assertThatCode(() ->
+              statement.executeUpdate(
+                  "INSERT INTO agency_postcode_range (id, agency_id, postcode_from, postcode_to) "
+                      + "VALUES (NEXTVAL(sequence_agency_postcode_range), "
+                      + DEMO_AGENCY_ID
+                      + ", '10000', '20000')"))
+          .as("a sequence-driven insert must not collide with the reserved demo baseline id")
+          .doesNotThrowAnyException();
+    }
+  }
+
+  private static long queryCount(Statement statement, String sql) throws Exception {
+    try (ResultSet resultSet = statement.executeQuery(sql)) {
+      resultSet.next();
+      return resultSet.getLong(1);
+    }
+  }
+}

--- a/src/test/java/de/caritas/cob/agencyservice/api/repository/DemoBaselineLiquibaseSqlTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/repository/DemoBaselineLiquibaseSqlTest.java
@@ -15,10 +15,14 @@ class DemoBaselineLiquibaseSqlTest {
         "db/changelog/changeset/0025_demo_baseline/syncDemoBaselineAgencyVisibility.sql");
     var sql = migration.getContentAsString(StandardCharsets.UTF_8);
 
+    // next_value must be an integer literal (a user variable raises MariaDB ERROR 1064), and
+    // is_used must be 1 so the next NEXTVAL skips past the reserved baseline ids instead of
+    // returning them and colliding with the demo rows (ERROR 1062). See DemoBaselineChangesetIT
+    // for the behavioural guard against a real MariaDB.
     assertThat(sql)
         .doesNotContain("SETVAL(`agencyservice`.`sequence_agency_postcode_range`, @")
         .doesNotContain("SETVAL(`agencyservice`.`sequence_agency_topic`, @")
-        .contains("SETVAL(`agencyservice`.`sequence_agency_postcode_range`, 900000001, 0)")
-        .contains("SETVAL(`agencyservice`.`sequence_agency_topic`, 900000010, 0)");
+        .contains("SETVAL(`agencyservice`.`sequence_agency_postcode_range`, 900000001, 1)")
+        .contains("SETVAL(`agencyservice`.`sequence_agency_topic`, 900000010, 1)");
   }
 }


### PR DESCRIPTION
## Why

AgencyService crashes on restart because of the opt-in demo-baseline Liquibase changeset (`0025_demo_baseline`, context `demo-baseline`). The invalid `SETVAL(seq, @variable, 0)` syntax (`ERROR 1064`) was already fixed to a literal in #123, but two problems remained — and neither is caught by the H2-based unit tests (the `testing` profile doesn't run Liquibase, and `LiquibaseChangelogDriftIT` only runs the `seed` context).

## What

1. **Sequence collision → `ERROR 1062 Duplicate entry`.** `SETVAL(seq, id, 0)` (`is_used=0`) makes the next `NEXTVAL` return the *reserved* baseline id, so the next application insert collides on the PK. Fixed by `is_used=1` so `NEXTVAL` skips past the reserved ids.
2. **Checksum crash on restart.** As a plain changeset, editing `0025` changes its checksum and aborts startup with `Validation Failed: checksum changed`. The baseline SQL is fully idempotent (`WHERE NOT EXISTS` / `ON DUPLICATE KEY UPDATE` / `SETVAL` never lowers), so it is now `runOnChange="true"` — it re-runs and refreshes the checksum instead of crashing.
3. **Regression test** `DemoBaselineChangesetIT`: boots against a fresh MariaDB with the `seed,demo-baseline` contexts, asserts the baseline applied and a sequence-driven insert does not collide. Env-gated on `LIQUIBASE_IT_DB_URL` like the existing drift IT, so it is skipped on the H2 `testing` build and in CI.

## Verification (real MariaDB 10.11.18)

- Reproduced the original `ERROR 1064` (`SETVAL(@variable)`) and the `ERROR 1062` collision (`is_used=0`).
- `DemoBaselineChangesetIT`: **RED** against `is_used=0` (`Duplicate entry '900000001'`) → **GREEN** after `is_used=1`.
- **Real pre-dev upgrade path:** applied the old `0025` (no `runOnChange`, `is_used=0`), then this version on restart → `0025` re-runs cleanly (no checksum failure) and a subsequent sequence insert succeeds.

## Affected repos

- ORISO-AgencyService only. (The out-of-band `ORISO-Helm/demo-baseline/demo-baseline-sync.sql` is a separate mechanism — flagged separately if it shares the pattern.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)