### PR TITLE
feat: allow server-side sort by id and createDate in agency admin search

### DIFF
--- a/api/agencyadminservice.yaml
+++ b/api/agencyadminservice.yaml
@@ -1123,14 +1123,16 @@ components:
       properties:
         field:
           type: string
-          example: 'name|description|postcode|city|teamAgency|offline'
+          example: 'id|name|description|postcode|city|teamAgency|offline|createDate'
           enum:
+            - 'id'
             - 'name'
             - 'description'
             - 'postCode'
             - 'city'
             - 'teamAgency'
             - 'offline'
+            - 'createDate'
         order:
           type: string
           example: 'ASC|DESC'

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/service/agency/AgencyAdminSearchServiceIT.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/service/agency/AgencyAdminSearchServiceIT.java
@@ -141,6 +141,60 @@ class AgencyAdminSearchServiceIT {
   }
 
   @Test
+  void searchAgency_Should_SortByIdAscending() {
+    // given, when
+    var agencySearchResult = agencyAdminSearchService.searchAgencies("", 1, 20,
+        new Sort().field(FieldEnum.ID).order(Sort.OrderEnum.ASC));
+
+    // then
+    assertThat(agencySearchResult.getEmbedded()).hasSize(20);
+    List<Long> collect = agencySearchResult.getEmbedded().stream()
+        .map(p -> p.getEmbedded().getId()).collect(Collectors.toList());
+    assertThat(collect).isSorted();
+  }
+
+  @Test
+  void searchAgency_Should_SortByIdDescending() {
+    // given, when
+    var agencySearchResult = agencyAdminSearchService.searchAgencies("", 1, 20,
+        new Sort().field(FieldEnum.ID).order(Sort.OrderEnum.DESC));
+
+    // then
+    assertThat(agencySearchResult.getEmbedded()).hasSize(20);
+    List<Long> collect = agencySearchResult.getEmbedded().stream()
+        .map(p -> p.getEmbedded().getId()).collect(Collectors.toList());
+    assertThat(collect).isSortedAccordingTo(Comparator.reverseOrder());
+  }
+
+  @Test
+  void searchAgency_Should_SortByCreateDateAscending() {
+    // given, when
+    var agencySearchResult = agencyAdminSearchService.searchAgencies("", 1, 20,
+        new Sort().field(FieldEnum.CREATE_DATE).order(Sort.OrderEnum.ASC));
+
+    // then
+    assertThat(agencySearchResult.getEmbedded()).hasSize(20);
+    List<String> collect = agencySearchResult.getEmbedded().stream()
+        .filter(result -> result.getEmbedded().getCreateDate() != null)
+        .map(p -> p.getEmbedded().getCreateDate()).collect(Collectors.toList());
+    assertThat(collect).isSorted();
+  }
+
+  @Test
+  void searchAgency_Should_SortByCreateDateDescending() {
+    // given, when
+    var agencySearchResult = agencyAdminSearchService.searchAgencies("", 1, 20,
+        new Sort().field(FieldEnum.CREATE_DATE).order(Sort.OrderEnum.DESC));
+
+    // then
+    assertThat(agencySearchResult.getEmbedded()).hasSize(20);
+    List<String> collect = agencySearchResult.getEmbedded().stream()
+        .filter(result -> result.getEmbedded().getCreateDate() != null)
+        .map(p -> p.getEmbedded().getCreateDate()).collect(Collectors.toList());
+    assertThat(collect).isSortedAccordingTo(Comparator.reverseOrder());
+  }
+
+  @Test
   void searchAgency_Should_NotFindAnyAgencies_WhenUserIsAgencyAdminButDoesntManageAnyAgencies() {
     // given
     when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(true);


### PR DESCRIPTION
## Problem

The admin agency list (`GET /agencyadmin/agencies`) cannot sort by `id` or `createDate` — the `Sort.field` enum whitelist rejects them, so ORISO-Admin falls back to broken per-page client sorting (parent: OpenResilienceInitiative/ORISO-Admin#306).

## Changes

- Extend `Sort.field` enum in `api/agencyadminservice.yaml` with `id` and `createDate` (entity property names; `applySortingAndPagination` uses `root.get(sortField)` and `addOrderBy` already handles non-string types — no service change needed).
- Add 4 integration tests to `AgencyAdminSearchServiceIT`: sort by id ASC/DESC and createDate ASC/DESC.

## Verification

- `mvn verify -DskipITs=false`: `AgencyAdminSearchServiceIT` 10/10 green (was 6, +4 new).
- Baseline check on unmodified `pre-dev`: the suite-wide 14 failures / 33 errors are pre-existing and unchanged by this PR (identical counts before/after; failing classes are unrelated, e.g. `AgencyServiceIT`, `ResponseEntityExceptionHandlerIT`).

Closes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)
