### PR TITLE
OBS-P5: Remove dormant Sentry SDK

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,6 @@
     <maven.compiler.target>21</maven.compiler.target>
     <hibernate.search.version>6.1.1.Final</hibernate.search.version>
     <springfox.boot.starter.version>3.0.0</springfox.boot.starter.version>
-    <sentry.version>8.46.0</sentry.version>
     <owasp.java.html.sanitizer>20211018.1</owasp.java.html.sanitizer>
   </properties>
 
@@ -107,16 +106,6 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-freemarker</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.sentry</groupId>
-      <artifactId>sentry-spring-boot-4-starter</artifactId>
-      <version>${sentry.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>io.sentry</groupId>
-      <artifactId>sentry-logback</artifactId>
-      <version>${sentry.version}</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,15 +8,6 @@ spring.data.jpa.repositories.bootstrap-mode=default
 spring.main.banner-mode=off
 spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.mongo.MongoAutoConfiguration,org.springframework.boot.autoconfigure.data.mongo.MongoDataAutoConfiguration
 
-# ---------------- Sentry ----------------
-sentry.dsn=${SENTRY_DSN:}
-sentry.environment=${SENTRY_ENVIRONMENT:dev}
-sentry.release=${SENTRY_RELEASE:oriso-agencyservice@local}
-sentry.traces-sample-rate=${SENTRY_TRACES_SAMPLE_RATE:0.0}
-sentry.send-default-pii=${SENTRY_SEND_DEFAULT_PII:false}
-sentry.logging.minimum-event-level=${SENTRY_LOGGING_MINIMUM_EVENT_LEVEL:warn}
-sentry.logging.minimum-breadcrumb-level=${SENTRY_LOGGING_MINIMUM_BREADCRUMB_LEVEL:info}
-
 # ---------------- Server ----------------
 server.port=8084
 server.host=http://localhost


### PR DESCRIPTION
## Summary
- Part of the observability rollout tracked in OpenResilienceInitiative/ORISO-Helm#62 (OBS-P5). SigNoz now has full traces/metrics/logs/RUM/error-intake parity (OBS-P1 through P4/P6/P8/P9), and this service's Sentry project has had zero events since 2026-06-22, so the dormant Sentry SDK is being removed rather than left in place.
- Removed `io.sentry:sentry-spring-boot-4-starter`, `io.sentry:sentry-logback`, and the `sentry.version` property from `pom.xml`.
- Removed the `sentry.*` block (`sentry.dsn`, `sentry.environment`, `sentry.release`, `sentry.traces-sample-rate`, `sentry.send-default-pii`, `sentry.logging.*`) from `application.properties`.
- No explicit `Sentry.*` API usage existed anywhere in `src/main`, and no Sentry-related test setup existed in `src/test`, so no source code changes were needed beyond the dependency/config removal.

Note: this repo's own Sentry issue (Zipkin `localhost:9411` connection-refused spam) was already fixed as a side effect of the OBS-P2 OTLP migration (PR #120) — this PR is purely the final SDK removal.

**Helm note for a human to follow up on separately (not touched here):** `application.properties` read a `SENTRY_DSN` env var (along with `SENTRY_ENVIRONMENT`, `SENTRY_RELEASE`, `SENTRY_TRACES_SAMPLE_RATE`, `SENTRY_SEND_DEFAULT_PII`, `SENTRY_LOGGING_MINIMUM_EVENT_LEVEL`, `SENTRY_LOGGING_MINIMUM_BREADCRUMB_LEVEL`) — someone should clean up the corresponding entries in ORISO-Helm's config for this service once this PR merges.

## Test plan
- [x] `mvn clean verify` run locally: unit tests pass 455/455 (`mvn test` alone is green).
- [x] The 47 integration-test failures (`Tests run: 197, Failures: 14, Errors: 33, Skipped: 2`) surfaced by `mvn clean verify` are **pre-existing on pre-dev** — verified by stashing this change, running the identical `mvn clean verify` against the unmodified baseline, and confirming the exact same failure count and the exact same failing test classes. This change introduces zero new failures.
- [x] Confirmed no remaining `io.sentry` or `sentry.*` references anywhere in the repo (pom.xml, all `application*.properties`, Dockerfile, src/main, src/test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)