### PR TITLE
ci: add release branch image workflow

### DIFF
--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -1,0 +1,105 @@
+name: Release AgencyService Image
+
+on:
+  push:
+    branches:
+      - "release/agencyservice-*"
+
+env:
+  REGISTRY: ghcr.io
+  ORG: openresilienceinitiative
+  IMAGE_NAME: oriso-agencyservice
+  RELEASE_PREFIX: release/agencyservice-
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  release:
+    name: validate, tag and publish release image
+    if: ${{ github.event.deleted == false }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout release branch
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Validate release branch
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          BRANCH="${GITHUB_REF_NAME}"
+          VERSION="${BRANCH#${RELEASE_PREFIX}}"
+
+          if [[ "${BRANCH}" == "${VERSION}" ]]; then
+            echo "::error::Release branch must match ${RELEASE_PREFIX}<version>, for example ${RELEASE_PREFIX}2.0.1"
+            exit 1
+          fi
+
+          if [[ ! "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Release version must be semantic version format, for example 2.0.1"
+            exit 1
+          fi
+
+          if git ls-remote --exit-code --tags origin "refs/tags/v${VERSION}" >/dev/null 2>&1; then
+            echo "::error::Tag v${VERSION} already exists. Choose a new version."
+            exit 1
+          fi
+
+          echo "VERSION=${VERSION}" >> "${GITHUB_ENV}"
+          echo "IMAGE=${REGISTRY}/${ORG}/${IMAGE_NAME}:${VERSION}" >> "${GITHUB_ENV}"
+
+      - name: Run AgencyService tests and build
+        uses: ./.github/actions/maven-build
+        with:
+          java_version: "21"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Login to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push release image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          push: true
+          tags: ${{ env.IMAGE }}
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=${{ env.VERSION }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Create and push release tag
+        shell: bash
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "v${VERSION}" -m "Release AgencyService v${VERSION}"
+          git push origin "v${VERSION}"
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ env.VERSION }}
+          target_commitish: ${{ github.sha }}
+          name: AgencyService v${{ env.VERSION }}
+          generate_release_notes: true
+          body: |
+            Docker image:
+            `${{ env.IMAGE }}`
+
+            Source branch:
+            `${{ github.ref_name }}`
+


### PR DESCRIPTION
Adds the service release workflow for the agreed release management process.

What it does:
- Runs only when a release branch is pushed.
- Validates the release branch version.
- Builds and publishes fixed GHCR image tag(s).
- Creates the matching Git tag.
- Creates a GitHub Release with generated release notes.

This workflow does not run for normal feature branches, PR branches, dev, or main.