### PR TITLE
feat(legal): shared legal-text objects for department DPP/imprint (ADR-014)

### DIFF
--- a/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/DepartmentDataProtectionService.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/DepartmentDataProtectionService.java
@@ -14,6 +14,7 @@ import de.caritas.cob.agencyservice.api.repository.agency.Agency;
 import de.caritas.cob.agencyservice.api.repository.agencytopic.AgencyTopic;
 import de.caritas.cob.agencyservice.api.repository.agencytopic.AgencyTopicRepository;
 import de.caritas.cob.agencyservice.api.repository.agencytopic.PublicationStatus;
+import de.caritas.cob.agencyservice.api.repository.legaltext.LegalText;
 import de.caritas.cob.agencyservice.api.tenant.TenantContext;
 import de.caritas.cob.agencyservice.api.util.AuthenticatedUser;
 import de.caritas.cob.agencyservice.api.validation.InputSanitizer;
@@ -79,13 +80,25 @@ public class DepartmentDataProtectionService {
 
     assertCallerTenantMatches(department.getAgency());
 
-    department.setContentDpp(toJson(sanitizeTranslations(content)));
-    department.setPublicationStatus(
-        publish ? PublicationStatus.PUBLISHED : PublicationStatus.DRAFT);
-    department.setUpdateDate(LocalDateTime.now());
+    var sanitizedJson = toJson(sanitizeTranslations(content));
+    var status = publish ? PublicationStatus.PUBLISHED : PublicationStatus.DRAFT;
+    var now = LocalDateTime.now();
+
+    LegalText referenced = department.getDpp();
+    if (referenced != null) {
+      // ADR-014: the referenced shared object is the truth — write through to it; the inline
+      // column stays untouched (the read path ignores it once a reference exists).
+      referenced.setContent(sanitizedJson);
+      referenced.setPublicationStatus(status);
+      referenced.setUpdateDate(now);
+    } else {
+      department.setContentDpp(sanitizedJson);
+      department.setPublicationStatus(status);
+    }
+    department.setUpdateDate(now);
     agencyTopicRepository.save(department);
 
-    return department.getPublicationStatus();
+    return status;
   }
 
   /**
@@ -104,6 +117,11 @@ public class DepartmentDataProtectionService {
 
     assertCallerTenantMatches(department.getAgency());
 
+    LegalText referenced = department.getDpp();
+    if (referenced != null) {
+      return new DepartmentDataProtectionView(
+          referenced.getContent(), referenced.getPublicationStatus());
+    }
     return new DepartmentDataProtectionView(
         department.getContentDpp(), department.getPublicationStatus());
   }

--- a/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/DepartmentImprintService.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/DepartmentImprintService.java
@@ -11,6 +11,7 @@ import de.caritas.cob.agencyservice.api.repository.agency.Agency;
 import de.caritas.cob.agencyservice.api.repository.agencytopic.AgencyTopic;
 import de.caritas.cob.agencyservice.api.repository.agencytopic.AgencyTopicRepository;
 import de.caritas.cob.agencyservice.api.repository.agencytopic.PublicationStatus;
+import de.caritas.cob.agencyservice.api.repository.legaltext.LegalText;
 import de.caritas.cob.agencyservice.api.tenant.TenantContext;
 import de.caritas.cob.agencyservice.api.util.AuthenticatedUser;
 import de.caritas.cob.agencyservice.api.validation.InputSanitizer;
@@ -71,13 +72,25 @@ public class DepartmentImprintService {
 
     assertCallerTenantMatches(department.getAgency());
 
-    department.setContentImprint(toJson(sanitizeTranslations(content)));
-    department.setPublicationStatusImprint(
-        publish ? PublicationStatus.PUBLISHED : PublicationStatus.DRAFT);
-    department.setUpdateDate(LocalDateTime.now());
+    var sanitizedJson = toJson(sanitizeTranslations(content));
+    var status = publish ? PublicationStatus.PUBLISHED : PublicationStatus.DRAFT;
+    var now = LocalDateTime.now();
+
+    LegalText referenced = department.getImprint();
+    if (referenced != null) {
+      // ADR-014: the referenced shared object is the truth — write through to it; the inline
+      // column stays untouched (the read path ignores it once a reference exists).
+      referenced.setContent(sanitizedJson);
+      referenced.setPublicationStatus(status);
+      referenced.setUpdateDate(now);
+    } else {
+      department.setContentImprint(sanitizedJson);
+      department.setPublicationStatusImprint(status);
+    }
+    department.setUpdateDate(now);
     agencyTopicRepository.save(department);
 
-    return department.getPublicationStatusImprint();
+    return status;
   }
 
   /**
@@ -96,6 +109,11 @@ public class DepartmentImprintService {
 
     assertCallerTenantMatches(department.getAgency());
 
+    LegalText referenced = department.getImprint();
+    if (referenced != null) {
+      return new DepartmentImprintView(
+          referenced.getContent(), referenced.getPublicationStatus());
+    }
     return new DepartmentImprintView(
         department.getContentImprint(), department.getPublicationStatusImprint());
   }

--- a/src/main/java/de/caritas/cob/agencyservice/api/repository/agency/AgencyRepository.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/repository/agency/AgencyRepository.java
@@ -95,10 +95,10 @@ public interface AgencyRepository extends JpaRepository<Agency, Long> {
 
   Optional<Agency> findByIdAndDeleteDateNull(Long agencyId);
 
-  @EntityGraph(attributePaths = {"agencyTopics"})
+  @EntityGraph(attributePaths = {"agencyTopics", "agencyTopics.dpp", "agencyTopics.imprint"})
   List<Agency> findByIdIn(List<Long> agencyIds);
 
-  @EntityGraph(attributePaths = {"agencyTopics"})
+  @EntityGraph(attributePaths = {"agencyTopics", "agencyTopics.dpp", "agencyTopics.imprint"})
   List<Agency> findByConsultingTypeId(int consultingTypeId);
 
   Optional<Agency> findById(Long agencyIds);

--- a/src/main/java/de/caritas/cob/agencyservice/api/repository/agency/AgencyTenantAwareRepository.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/repository/agency/AgencyTenantAwareRepository.java
@@ -63,10 +63,10 @@ public interface AgencyTenantAwareRepository extends JpaRepository<Agency, Long>
 
   Optional<Agency> findByIdAndDeleteDateNull(Long agencyId);
 
-  @EntityGraph(attributePaths = {"agencyTopics"})
+  @EntityGraph(attributePaths = {"agencyTopics", "agencyTopics.dpp", "agencyTopics.imprint"})
   List<Agency> findByIdIn(List<Long> agencyIds);
 
-  @EntityGraph(attributePaths = {"agencyTopics"})
+  @EntityGraph(attributePaths = {"agencyTopics", "agencyTopics.dpp", "agencyTopics.imprint"})
   List<Agency> findByConsultingTypeId(int consultingTypeId);
 
 }

--- a/src/main/java/de/caritas/cob/agencyservice/api/repository/agency/AgencyTenantUnawareRepository.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/repository/agency/AgencyTenantUnawareRepository.java
@@ -41,10 +41,10 @@ public interface AgencyTenantUnawareRepository extends JpaRepository<Agency, Lon
 
   Optional<Agency> findByIdAndDeleteDateNull(Long agencyId);
 
-  @EntityGraph(attributePaths = {"agencyTopics"})
+  @EntityGraph(attributePaths = {"agencyTopics", "agencyTopics.dpp", "agencyTopics.imprint"})
   List<Agency> findByIdIn(List<Long> agencyIds);
 
-  @EntityGraph(attributePaths = {"agencyTopics"})
+  @EntityGraph(attributePaths = {"agencyTopics", "agencyTopics.dpp", "agencyTopics.imprint"})
   List<Agency> findByConsultingTypeId(int consultingTypeId);
 
   List<Agency> findByTenantId(Long tenantId);

--- a/src/main/java/de/caritas/cob/agencyservice/api/repository/agencytopic/AgencyTopic.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/repository/agencytopic/AgencyTopic.java
@@ -2,6 +2,7 @@ package de.caritas.cob.agencyservice.api.repository.agencytopic;
 
 import de.caritas.cob.agencyservice.api.model.TopicDTO;
 import de.caritas.cob.agencyservice.api.repository.agency.Agency;
+import de.caritas.cob.agencyservice.api.repository.legaltext.LegalText;
 import java.time.LocalDateTime;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -74,6 +75,20 @@ public class AgencyTopic {
   @Enumerated(EnumType.STRING)
   @Column(name = "publication_status_imprint", nullable = false)
   private PublicationStatus publicationStatusImprint = PublicationStatus.DRAFT;
+
+  /**
+   * ADR-014: reference to the shared data privacy policy object. When set it wins over the inline
+   * {@link #contentDpp}; several departments may point at the same text. {@code null} = fall back
+   * to the inline column (pre-backfill rows) or, if that is empty too, to the tenant-level text.
+   */
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "dpp_id")
+  private LegalText dpp;
+
+  /** ADR-014: reference to the shared Impressum object, same semantics as {@link #dpp}. */
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "imprint_id")
+  private LegalText imprint;
 
   @Transient TopicDTO topicData = new TopicDTO();
 

--- a/src/main/java/de/caritas/cob/agencyservice/api/repository/agencytopic/AgencyTopic.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/repository/agencytopic/AgencyTopic.java
@@ -3,6 +3,7 @@ package de.caritas.cob.agencyservice.api.repository.agencytopic;
 import de.caritas.cob.agencyservice.api.model.TopicDTO;
 import de.caritas.cob.agencyservice.api.repository.agency.Agency;
 import de.caritas.cob.agencyservice.api.repository.legaltext.LegalText;
+import de.caritas.cob.agencyservice.api.repository.legaltext.LegalTextKind;
 import java.time.LocalDateTime;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -15,6 +16,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
 import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
@@ -103,6 +105,47 @@ public class AgencyTopic {
     }
     if (publicationStatusImprint == null) {
       publicationStatusImprint = PublicationStatus.DRAFT;
+    }
+    validateLegalTextReferences();
+  }
+
+  @PreUpdate
+  void validateOnUpdate() {
+    validateLegalTextReferences();
+  }
+
+  /**
+   * ADR-014 invariants, enforced at the persistence boundary so no future write path can slip a
+   * bad assignment past the service-level guards: the DPP slot only accepts {@code
+   * LegalTextKind.DPP} objects, the imprint slot only {@code IMPRINT}, and a department must never
+   * reference another Träger's document (checked only when both tenant ids are known —
+   * single-tenant mode carries nulls).
+   */
+  private void validateLegalTextReferences() {
+    assertReferenceKind(dpp, LegalTextKind.DPP, "dpp");
+    assertReferenceKind(imprint, LegalTextKind.IMPRINT, "imprint");
+    assertReferenceTenant(dpp, "dpp");
+    assertReferenceTenant(imprint, "imprint");
+  }
+
+  private void assertReferenceKind(
+      LegalText reference, LegalTextKind expectedKind, String slot) {
+    if (reference != null && reference.getKind() != expectedKind) {
+      throw new IllegalStateException(
+          String.format(
+              "agency_topic.%s_id must reference a legal text of kind %s but got %s",
+              slot, expectedKind, reference.getKind()));
+    }
+  }
+
+  private void assertReferenceTenant(LegalText reference, String slot) {
+    Long referenceTenant = reference == null ? null : reference.getTenantId();
+    Long agencyTenant = agency == null ? null : agency.getTenantId();
+    if (referenceTenant != null && agencyTenant != null && !referenceTenant.equals(agencyTenant)) {
+      throw new IllegalStateException(
+          String.format(
+              "agency_topic.%s_id references a legal text of tenant %d but the agency belongs to tenant %d",
+              slot, referenceTenant, agencyTenant));
     }
   }
 }

--- a/src/main/java/de/caritas/cob/agencyservice/api/repository/agencytopic/AgencyTopicRepository.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/repository/agencytopic/AgencyTopicRepository.java
@@ -19,4 +19,10 @@ public interface AgencyTopicRepository extends JpaRepository<AgencyTopic, Long> 
   /** Finds all department rows for a given agency. */
   @Query(value = "select * from agency_topic where agency_id = :agencyId", nativeQuery = true)
   List<AgencyTopic> findAllByAgencyId(@Param("agencyId") Long agencyId);
+
+  /** How many departments reference this shared DPP text ("used by N", ADR-014). */
+  long countByDpp_Id(Long legalTextId);
+
+  /** How many departments reference this shared Impressum text ("used by N", ADR-014). */
+  long countByImprint_Id(Long legalTextId);
 }

--- a/src/main/java/de/caritas/cob/agencyservice/api/repository/legaltext/LegalText.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/repository/legaltext/LegalText.java
@@ -1,0 +1,78 @@
+package de.caritas.cob.agencyservice.api.repository.legaltext;
+
+import de.caritas.cob.agencyservice.api.repository.agencytopic.PublicationStatus;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+
+/**
+ * A reusable legal text (data privacy policy or Impressum) owned by a Träger (tenant), per
+ * ADR-014: departments (Fachbereich = agency × topic) reference one text per kind, and several
+ * departments may share the same text — one maintained document instead of N inline copies.
+ *
+ * <p>{@code content} is a JSON language→HTML map, the same shape the inline
+ * {@code agency_topic.content_dpp}/{@code content_imprint} columns use, so the admin editor and the
+ * public read side keep working unchanged.
+ */
+@Entity
+@Table(name = "legal_text")
+@AllArgsConstructor
+@RequiredArgsConstructor
+@Getter
+@Setter
+@Builder
+public class LegalText {
+
+  @Id
+  @SequenceGenerator(name = "id_seq", allocationSize = 1, sequenceName = "sequence_legal_text")
+  @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "id_seq")
+  @Column(name = "id", updatable = false, nullable = false)
+  private Long id;
+
+  @Column(name = "tenant_id")
+  private Long tenantId;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "kind", nullable = false)
+  private LegalTextKind kind;
+
+  /** Admin-facing name, e.g. "Standard-DSE Träger" — shown in the legal-text library. */
+  @Column(name = "label", nullable = false)
+  private String label;
+
+  /** JSON language→HTML map, same shape as the former inline department columns. */
+  @Column(name = "content")
+  private String content;
+
+  @Builder.Default
+  @Enumerated(EnumType.STRING)
+  @Column(name = "publication_status", nullable = false)
+  private PublicationStatus publicationStatus = PublicationStatus.DRAFT;
+
+  @Column(name = "create_date")
+  private LocalDateTime createDate;
+
+  @Column(name = "update_date")
+  private LocalDateTime updateDate;
+
+  /** Mirrors {@code AgencyTopic#applyDefaults}: NOT NULL status survives non-builder paths. */
+  @PrePersist
+  void applyDefaults() {
+    if (publicationStatus == null) {
+      publicationStatus = PublicationStatus.DRAFT;
+    }
+  }
+}

--- a/src/main/java/de/caritas/cob/agencyservice/api/repository/legaltext/LegalText.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/repository/legaltext/LegalText.java
@@ -9,6 +9,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
 import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
@@ -68,11 +69,26 @@ public class LegalText {
   @Column(name = "update_date")
   private LocalDateTime updateDate;
 
-  /** Mirrors {@code AgencyTopic#applyDefaults}: NOT NULL status survives non-builder paths. */
+  /**
+   * Mirrors {@code AgencyTopic#applyDefaults}: the NOT NULL columns (status, dates) survive
+   * non-builder construction paths and repository saves where no caller set them explicitly.
+   */
   @PrePersist
   void applyDefaults() {
     if (publicationStatus == null) {
       publicationStatus = PublicationStatus.DRAFT;
     }
+    var now = LocalDateTime.now();
+    if (createDate == null) {
+      createDate = now;
+    }
+    if (updateDate == null) {
+      updateDate = now;
+    }
+  }
+
+  @PreUpdate
+  void refreshUpdateDate() {
+    updateDate = LocalDateTime.now();
   }
 }

--- a/src/main/java/de/caritas/cob/agencyservice/api/repository/legaltext/LegalTextKind.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/repository/legaltext/LegalTextKind.java
@@ -1,0 +1,7 @@
+package de.caritas.cob.agencyservice.api.repository.legaltext;
+
+/** The two kinds of department legal texts a Träger can author (ADR-014). */
+public enum LegalTextKind {
+  DPP,
+  IMPRINT
+}

--- a/src/main/java/de/caritas/cob/agencyservice/api/repository/legaltext/LegalTextRepository.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/repository/legaltext/LegalTextRepository.java
@@ -1,0 +1,9 @@
+package de.caritas.cob.agencyservice.api.repository.legaltext;
+
+import java.util.List;
+import org.springframework.data.repository.CrudRepository;
+
+public interface LegalTextRepository extends CrudRepository<LegalText, Long> {
+
+  List<LegalText> findByTenantIdAndKindOrderByLabelAsc(Long tenantId, LegalTextKind kind);
+}

--- a/src/main/java/de/caritas/cob/agencyservice/api/service/AgencyService.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/service/AgencyService.java
@@ -22,6 +22,7 @@ import de.caritas.cob.agencyservice.api.repository.agency.Agency;
 import de.caritas.cob.agencyservice.api.repository.agency.AgencyRepository;
 import de.caritas.cob.agencyservice.api.repository.agencytopic.AgencyTopic;
 import de.caritas.cob.agencyservice.api.repository.agencytopic.PublicationStatus;
+import de.caritas.cob.agencyservice.api.repository.legaltext.LegalText;
 import de.caritas.cob.agencyservice.api.tenant.TenantContext;
 import de.caritas.cob.agencyservice.consultingtypeservice.generated.web.model.ExtendedConsultingTypeResponseDTO;
 import de.caritas.cob.agencyservice.tenantservice.generated.web.model.RestrictedTenantDTO;
@@ -496,15 +497,33 @@ public class AgencyService {
    * plus whether its own legal texts (ADR-003) are published. Uses the already-loaded {@code
    * agencyTopics} association (the same one {@code topicIds} is built from), so no additional
    * query is issued per agency or topic.
+   *
+   * <p>ADR-014: like {@link DepartmentLegalService}, a referenced shared legal-text object fully
+   * replaces the inline column — the flags must follow the same resolution order, otherwise the
+   * registration search would report stale inline state after a write-through publish/draft-save.
    */
   private AgencyDepartmentDTO convertToAgencyDepartmentDTO(AgencyTopic agencyTopic) {
     return new AgencyDepartmentDTO()
         .topicId(agencyTopic.getTopicId())
-        .hasPublishedDpp(
-            hasPublishedContent(agencyTopic.getContentDpp(), agencyTopic.getPublicationStatus()))
-        .hasPublishedImprint(
-            hasPublishedContent(
-                agencyTopic.getContentImprint(), agencyTopic.getPublicationStatusImprint()));
+        .hasPublishedDpp(hasPublishedDpp(agencyTopic))
+        .hasPublishedImprint(hasPublishedImprint(agencyTopic));
+  }
+
+  private boolean hasPublishedDpp(AgencyTopic agencyTopic) {
+    LegalText referenced = agencyTopic.getDpp();
+    if (referenced != null) {
+      return hasPublishedContent(referenced.getContent(), referenced.getPublicationStatus());
+    }
+    return hasPublishedContent(agencyTopic.getContentDpp(), agencyTopic.getPublicationStatus());
+  }
+
+  private boolean hasPublishedImprint(AgencyTopic agencyTopic) {
+    LegalText referenced = agencyTopic.getImprint();
+    if (referenced != null) {
+      return hasPublishedContent(referenced.getContent(), referenced.getPublicationStatus());
+    }
+    return hasPublishedContent(
+        agencyTopic.getContentImprint(), agencyTopic.getPublicationStatusImprint());
   }
 
   private boolean hasPublishedContent(String content, PublicationStatus status) {

--- a/src/main/java/de/caritas/cob/agencyservice/api/service/DepartmentLegalService.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/service/DepartmentLegalService.java
@@ -5,6 +5,7 @@ import de.caritas.cob.agencyservice.api.repository.agency.Agency;
 import de.caritas.cob.agencyservice.api.repository.agencytopic.AgencyTopic;
 import de.caritas.cob.agencyservice.api.repository.agencytopic.AgencyTopicRepository;
 import de.caritas.cob.agencyservice.api.repository.agencytopic.PublicationStatus;
+import de.caritas.cob.agencyservice.api.repository.legaltext.LegalText;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -39,9 +40,30 @@ public class DepartmentLegalService {
     assertAgencyIsNotDeleted(department.getAgency());
 
     return new DepartmentLegalView(
-        publishedContentOrNull(department.getContentDpp(), department.getPublicationStatus()),
-        publishedContentOrNull(
-            department.getContentImprint(), department.getPublicationStatusImprint()));
+        resolveDpp(department), resolveImprint(department));
+  }
+
+  /**
+   * ADR-014 resolution order: a referenced shared legal-text object, once assigned, fully replaces
+   * the legacy inline column — including its DRAFT state. Only reference-less (pre-backfill) rows
+   * fall back to the inline content.
+   */
+  private String resolveDpp(AgencyTopic department) {
+    LegalText referenced = department.getDpp();
+    if (referenced != null) {
+      return publishedContentOrNull(referenced.getContent(), referenced.getPublicationStatus());
+    }
+    return publishedContentOrNull(
+        department.getContentDpp(), department.getPublicationStatus());
+  }
+
+  private String resolveImprint(AgencyTopic department) {
+    LegalText referenced = department.getImprint();
+    if (referenced != null) {
+      return publishedContentOrNull(referenced.getContent(), referenced.getPublicationStatus());
+    }
+    return publishedContentOrNull(
+        department.getContentImprint(), department.getPublicationStatusImprint());
   }
 
   private void assertAgencyIsNotDeleted(Agency agency) {

--- a/src/main/java/de/caritas/cob/agencyservice/api/service/DepartmentLegalService.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/service/DepartmentLegalService.java
@@ -45,8 +45,14 @@ public class DepartmentLegalService {
 
   /**
    * ADR-014 resolution order: a referenced shared legal-text object, once assigned, fully replaces
-   * the legacy inline column — including its DRAFT state. Only reference-less (pre-backfill) rows
-   * fall back to the inline content.
+   * the legacy inline column — including its DRAFT state. Only reference-less rows fall back to the
+   * inline content.
+   *
+   * <p><b>Unassign semantics (this release):</b> clearing {@code dpp_id}/{@code imprint_id} makes a
+   * department reference-less again, so it falls back to its own inline {@code content_dpp}/{@code
+   * content_imprint} — NOT to a tenant-level fallback document. The backfill deliberately keeps the
+   * inline columns for one release as this read-fallback and as the rollback anchor; they are not
+   * cleared on unassign. Tenant-level fallback is future work (see ADR-014 / #134).
    */
   private String resolveDpp(AgencyTopic department) {
     LegalText referenced = department.getDpp();

--- a/src/main/resources/db/changelog/agencyservice-master.xml
+++ b/src/main/resources/db/changelog/agencyservice-master.xml
@@ -68,6 +68,9 @@
   <!-- Demo/initial-delivery data is opt-in. Enable with Liquibase context
        "demo-baseline" for demo environments or before customer-facing demo runs. -->
   <include file="db/changelog/changeset/0025_demo_baseline/0025_changeSet.xml" contextFilter="demo-baseline"/>
+  <!-- ADR-014: shared legal-text objects (legal_text table + department references + backfill
+       that merges byte-identical inline texts into one shared row per tenant/kind/status). -->
+  <include file="db/changelog/changeset/0026_legal_text/0026_changeSet.xml"/>
 
   <!--
     L1 gap detection (2026-07-04): the consolidated changelog was run against a fresh MariaDB

--- a/src/main/resources/db/changelog/changeset/0026_legal_text/0026_changeSet.xml
+++ b/src/main/resources/db/changelog/changeset/0026_legal_text/0026_changeSet.xml
@@ -1,0 +1,37 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd">
+    <!-- ADR-014 step 1: legal texts become first-class shared objects owned by a Träger. -->
+    <changeSet author="oriso" id="createLegalTextTable">
+        <sqlFile path="db/changelog/changeset/0026_legal_text/createLegalText.sql" stripComments="true"/>
+        <rollback>
+            <sqlFile path="db/changelog/changeset/0026_legal_text/createLegalText-rollback.sql" stripComments="true"/>
+        </rollback>
+    </changeSet>
+
+    <!-- ADR-014 step 2: departments reference their legal texts (nullable = tenant fallback). -->
+    <changeSet author="oriso" id="addAgencyTopicLegalTextReferences">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">
+                SELECT COUNT(*) FROM information_schema.TABLE_CONSTRAINTS
+                WHERE TABLE_SCHEMA = 'agencyservice'
+                  AND TABLE_NAME = 'agency_topic'
+                  AND CONSTRAINT_NAME = 'fk_agency_topic_dpp'
+            </sqlCheck>
+        </preConditions>
+        <sqlFile path="db/changelog/changeset/0026_legal_text/addAgencyTopicLegalTextReferences.sql" stripComments="true"/>
+        <rollback>
+            <sqlFile path="db/changelog/changeset/0026_legal_text/addAgencyTopicLegalTextReferences-rollback.sql" stripComments="true"/>
+        </rollback>
+    </changeSet>
+
+    <!-- ADR-014 step 3: lift inline department texts into shared objects, merging byte-identical
+         (tenant, content, status) texts into one row. Inline columns stay as rollback anchor. -->
+    <changeSet author="oriso" id="backfillLegalTextFromInline">
+        <sqlFile path="db/changelog/changeset/0026_legal_text/backfillLegalTextFromInline.sql" stripComments="true"/>
+        <rollback>
+            <sqlFile path="db/changelog/changeset/0026_legal_text/backfillLegalTextFromInline-rollback.sql" stripComments="true"/>
+        </rollback>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changeset/0026_legal_text/addAgencyTopicLegalTextReferences-rollback.sql
+++ b/src/main/resources/db/changelog/changeset/0026_legal_text/addAgencyTopicLegalTextReferences-rollback.sql
@@ -1,0 +1,4 @@
+ALTER TABLE `agencyservice`.`agency_topic` DROP FOREIGN KEY IF EXISTS `fk_agency_topic_dpp`;
+ALTER TABLE `agencyservice`.`agency_topic` DROP FOREIGN KEY IF EXISTS `fk_agency_topic_imprint`;
+ALTER TABLE `agencyservice`.`agency_topic` DROP COLUMN IF EXISTS `dpp_id`;
+ALTER TABLE `agencyservice`.`agency_topic` DROP COLUMN IF EXISTS `imprint_id`;

--- a/src/main/resources/db/changelog/changeset/0026_legal_text/addAgencyTopicLegalTextReferences-rollback.sql
+++ b/src/main/resources/db/changelog/changeset/0026_legal_text/addAgencyTopicLegalTextReferences-rollback.sql
@@ -1,4 +1,6 @@
 ALTER TABLE `agencyservice`.`agency_topic` DROP FOREIGN KEY IF EXISTS `fk_agency_topic_dpp`;
 ALTER TABLE `agencyservice`.`agency_topic` DROP FOREIGN KEY IF EXISTS `fk_agency_topic_imprint`;
+ALTER TABLE `agencyservice`.`agency_topic` DROP INDEX IF EXISTS `idx_agency_topic_dpp_id`;
+ALTER TABLE `agencyservice`.`agency_topic` DROP INDEX IF EXISTS `idx_agency_topic_imprint_id`;
 ALTER TABLE `agencyservice`.`agency_topic` DROP COLUMN IF EXISTS `dpp_id`;
 ALTER TABLE `agencyservice`.`agency_topic` DROP COLUMN IF EXISTS `imprint_id`;

--- a/src/main/resources/db/changelog/changeset/0026_legal_text/addAgencyTopicLegalTextReferences.sql
+++ b/src/main/resources/db/changelog/changeset/0026_legal_text/addAgencyTopicLegalTextReferences.sql
@@ -1,0 +1,16 @@
+-- ADR-014: departments reference their legal texts instead of owning inline copies. The inline
+-- content_dpp / content_imprint columns stay for one release as a read-fallback and rollback
+-- anchor; the read path ignores them once a reference is set.
+ALTER TABLE `agencyservice`.`agency_topic`
+ADD COLUMN IF NOT EXISTS `dpp_id` bigint(21) NULL;
+
+ALTER TABLE `agencyservice`.`agency_topic`
+ADD COLUMN IF NOT EXISTS `imprint_id` bigint(21) NULL;
+
+ALTER TABLE `agencyservice`.`agency_topic`
+ADD CONSTRAINT `fk_agency_topic_dpp` FOREIGN KEY (`dpp_id`)
+REFERENCES `agencyservice`.`legal_text` (`id`) ON UPDATE CASCADE;
+
+ALTER TABLE `agencyservice`.`agency_topic`
+ADD CONSTRAINT `fk_agency_topic_imprint` FOREIGN KEY (`imprint_id`)
+REFERENCES `agencyservice`.`legal_text` (`id`) ON UPDATE CASCADE;

--- a/src/main/resources/db/changelog/changeset/0026_legal_text/addAgencyTopicLegalTextReferences.sql
+++ b/src/main/resources/db/changelog/changeset/0026_legal_text/addAgencyTopicLegalTextReferences.sql
@@ -7,6 +7,15 @@ ADD COLUMN IF NOT EXISTS `dpp_id` bigint(21) NULL;
 ALTER TABLE `agencyservice`.`agency_topic`
 ADD COLUMN IF NOT EXISTS `imprint_id` bigint(21) NULL;
 
+-- Explicit, predictably-named indexes created before the FK constraints so InnoDB reuses them
+-- instead of auto-generating one per FK. countByDpp_Id / countByImprint_Id and the assignment
+-- joins would otherwise table-scan agency_topic at scale.
+ALTER TABLE `agencyservice`.`agency_topic`
+ADD INDEX IF NOT EXISTS `idx_agency_topic_dpp_id` (`dpp_id`);
+
+ALTER TABLE `agencyservice`.`agency_topic`
+ADD INDEX IF NOT EXISTS `idx_agency_topic_imprint_id` (`imprint_id`);
+
 ALTER TABLE `agencyservice`.`agency_topic`
 ADD CONSTRAINT `fk_agency_topic_dpp` FOREIGN KEY (`dpp_id`)
 REFERENCES `agencyservice`.`legal_text` (`id`) ON UPDATE CASCADE;

--- a/src/main/resources/db/changelog/changeset/0026_legal_text/backfillLegalTextFromInline-rollback.sql
+++ b/src/main/resources/db/changelog/changeset/0026_legal_text/backfillLegalTextFromInline-rollback.sql
@@ -1,0 +1,4 @@
+-- Unlink and remove only the migrated objects; the inline columns still hold the original texts.
+UPDATE `agencyservice`.`agency_topic` SET `dpp_id` = NULL WHERE `dpp_id` IS NOT NULL;
+UPDATE `agencyservice`.`agency_topic` SET `imprint_id` = NULL WHERE `imprint_id` IS NOT NULL;
+DELETE FROM `agencyservice`.`legal_text` WHERE `label` LIKE 'Migrated %';

--- a/src/main/resources/db/changelog/changeset/0026_legal_text/backfillLegalTextFromInline.sql
+++ b/src/main/resources/db/changelog/changeset/0026_legal_text/backfillLegalTextFromInline.sql
@@ -1,0 +1,67 @@
+-- ADR-014 backfill: lift the inline per-department legal texts into shared legal_text objects.
+-- Byte-identical texts (same tenant, same content, same publication status) collapse into ONE
+-- shared row, so departments that legally share a document reference a single maintained object.
+-- Only reference-less rows with real content are lifted; re-running is a no-op because linked
+-- rows are excluded by the dpp_id/imprint_id IS NULL guards.
+
+-- 1) one legal_text per distinct (tenant, content, status) DPP
+INSERT INTO `agencyservice`.`legal_text`
+    (`id`, `tenant_id`, `kind`, `label`, `content`, `publication_status`, `create_date`, `update_date`)
+SELECT NEXT VALUE FOR `agencyservice`.`sequence_legal_text`,
+       src.`tenant_id`,
+       'DPP',
+       CONCAT('Migrated data privacy policy ', ROW_NUMBER() OVER (ORDER BY src.`tenant_id`)),
+       src.`content`,
+       src.`status`,
+       UTC_TIMESTAMP(),
+       UTC_TIMESTAMP()
+FROM (
+    SELECT DISTINCT a.`tenant_id` AS `tenant_id`,
+                    at.`content_dpp` AS `content`,
+                    at.`publication_status` AS `status`
+    FROM `agencyservice`.`agency_topic` at
+    JOIN `agencyservice`.`agency` a ON a.`id` = at.`agency_id`
+    WHERE at.`content_dpp` IS NOT NULL AND at.`content_dpp` <> '' AND at.`dpp_id` IS NULL
+) src;
+
+-- 2) link each department to its (possibly shared) DPP object
+UPDATE `agencyservice`.`agency_topic` at
+JOIN `agencyservice`.`agency` a ON a.`id` = at.`agency_id`
+JOIN `agencyservice`.`legal_text` lt
+    ON lt.`kind` = 'DPP'
+    AND (lt.`tenant_id` <=> a.`tenant_id`)
+    AND lt.`content` = at.`content_dpp`
+    AND lt.`publication_status` = at.`publication_status`
+SET at.`dpp_id` = lt.`id`
+WHERE at.`content_dpp` IS NOT NULL AND at.`content_dpp` <> '' AND at.`dpp_id` IS NULL;
+
+-- 3) one legal_text per distinct (tenant, content, status) imprint
+INSERT INTO `agencyservice`.`legal_text`
+    (`id`, `tenant_id`, `kind`, `label`, `content`, `publication_status`, `create_date`, `update_date`)
+SELECT NEXT VALUE FOR `agencyservice`.`sequence_legal_text`,
+       src.`tenant_id`,
+       'IMPRINT',
+       CONCAT('Migrated imprint ', ROW_NUMBER() OVER (ORDER BY src.`tenant_id`)),
+       src.`content`,
+       src.`status`,
+       UTC_TIMESTAMP(),
+       UTC_TIMESTAMP()
+FROM (
+    SELECT DISTINCT a.`tenant_id` AS `tenant_id`,
+                    at.`content_imprint` AS `content`,
+                    at.`publication_status_imprint` AS `status`
+    FROM `agencyservice`.`agency_topic` at
+    JOIN `agencyservice`.`agency` a ON a.`id` = at.`agency_id`
+    WHERE at.`content_imprint` IS NOT NULL AND at.`content_imprint` <> '' AND at.`imprint_id` IS NULL
+) src;
+
+-- 4) link each department to its (possibly shared) imprint object
+UPDATE `agencyservice`.`agency_topic` at
+JOIN `agencyservice`.`agency` a ON a.`id` = at.`agency_id`
+JOIN `agencyservice`.`legal_text` lt
+    ON lt.`kind` = 'IMPRINT'
+    AND (lt.`tenant_id` <=> a.`tenant_id`)
+    AND lt.`content` = at.`content_imprint`
+    AND lt.`publication_status` = at.`publication_status_imprint`
+SET at.`imprint_id` = lt.`id`
+WHERE at.`content_imprint` IS NOT NULL AND at.`content_imprint` <> '' AND at.`imprint_id` IS NULL;

--- a/src/main/resources/db/changelog/changeset/0026_legal_text/createLegalText-rollback.sql
+++ b/src/main/resources/db/changelog/changeset/0026_legal_text/createLegalText-rollback.sql
@@ -1,0 +1,2 @@
+DROP SEQUENCE IF EXISTS `agencyservice`.`sequence_legal_text`;
+DROP TABLE IF EXISTS `agencyservice`.`legal_text`;

--- a/src/main/resources/db/changelog/changeset/0026_legal_text/createLegalText.sql
+++ b/src/main/resources/db/changelog/changeset/0026_legal_text/createLegalText.sql
@@ -1,0 +1,20 @@
+-- ADR-014: legal texts (DPP / Impressum) become first-class shared objects owned by a Träger.
+CREATE TABLE IF NOT EXISTS `agencyservice`.`legal_text` (
+    `id` bigint(21) NOT NULL,
+    `tenant_id` bigint(21) NULL,
+    `kind` varchar(20) NOT NULL,
+    `label` varchar(255) NOT NULL,
+    `content` longtext NULL,
+    `publication_status` varchar(20) NOT NULL DEFAULT 'DRAFT',
+    `create_date` datetime NOT NULL DEFAULT (UTC_TIMESTAMP),
+    `update_date` datetime NOT NULL DEFAULT (UTC_TIMESTAMP),
+    PRIMARY KEY (`id`),
+    KEY `idx_legal_text_tenant_kind` (`tenant_id`, `kind`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+
+CREATE SEQUENCE IF NOT EXISTS `agencyservice`.`sequence_legal_text`
+INCREMENT BY 1
+MINVALUE = 0
+NOMAXVALUE
+START WITH 0
+CACHE 10;

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/service/legal/DepartmentDataProtectionServiceTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/service/legal/DepartmentDataProtectionServiceTest.java
@@ -16,6 +16,8 @@ import de.caritas.cob.agencyservice.api.repository.agency.Agency;
 import de.caritas.cob.agencyservice.api.repository.agencytopic.AgencyTopic;
 import de.caritas.cob.agencyservice.api.repository.agencytopic.AgencyTopicRepository;
 import de.caritas.cob.agencyservice.api.repository.agencytopic.PublicationStatus;
+import de.caritas.cob.agencyservice.api.repository.legaltext.LegalText;
+import de.caritas.cob.agencyservice.api.repository.legaltext.LegalTextKind;
 import de.caritas.cob.agencyservice.api.tenant.TenantContext;
 import de.caritas.cob.agencyservice.api.util.AuthenticatedUser;
 import de.caritas.cob.agencyservice.api.validation.InputSanitizer;
@@ -75,6 +77,57 @@ class DepartmentDataProtectionServiceTest {
     when(agencyTopicRepository.findByAgency_IdAndTopicId(7L, 42L))
         .thenReturn(Optional.of(department));
     return department;
+  }
+
+  @Test
+  void publish_Should_writeThroughToReferencedLegalText_When_departmentReferencesOne() {
+    // ADR-014: once a department references a shared legal-text object, that object is the truth.
+    // The legacy per-department publish endpoint must therefore update the referenced object —
+    // writing the inline column would be silently ignored by the read path.
+    when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(false);
+    var department = existingDepartment();
+    var referenced =
+        LegalText.builder()
+            .id(100L)
+            .kind(LegalTextKind.DPP)
+            .label("Geteilte DSE")
+            .content("{\"de\":\"<p>alt</p>\"}")
+            .publicationStatus(PublicationStatus.DRAFT)
+            .build();
+    department.setDpp(referenced);
+
+    var status =
+        service.publishDepartmentDataPrivacy(7L, 42L, Map.of("de", "<p>neu</p>"), true);
+
+    assertThat(status).isEqualTo(PublicationStatus.PUBLISHED);
+    assertThat(referenced.getContent()).contains("neu");
+    assertThat(referenced.getPublicationStatus()).isEqualTo(PublicationStatus.PUBLISHED);
+    assertThat(referenced.getUpdateDate()).isNotNull();
+    // the inline copy stays untouched — it is dead weight kept only for rollback
+    var saved = ArgumentCaptor.forClass(AgencyTopic.class);
+    verify(agencyTopicRepository).save(saved.capture());
+    assertThat(saved.getValue().getContentDpp()).isNull();
+  }
+
+  @Test
+  void read_Should_returnReferencedLegalText_When_departmentReferencesOne() {
+    when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(false);
+    var department = existingDepartment();
+    department.setContentDpp("{\"de\":\"<p>inline-alt</p>\"}");
+    department.setPublicationStatus(PublicationStatus.DRAFT);
+    department.setDpp(
+        LegalText.builder()
+            .id(100L)
+            .kind(LegalTextKind.DPP)
+            .label("Geteilte DSE")
+            .content("{\"de\":\"<p>geteilt</p>\"}")
+            .publicationStatus(PublicationStatus.PUBLISHED)
+            .build());
+
+    var view = service.getDepartmentDataPrivacy(7L, 42L);
+
+    assertThat(view.content()).isEqualTo("{\"de\":\"<p>geteilt</p>\"}");
+    assertThat(view.publicationStatus()).isEqualTo(PublicationStatus.PUBLISHED);
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/service/legal/DepartmentImprintServiceTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/service/legal/DepartmentImprintServiceTest.java
@@ -16,6 +16,8 @@ import de.caritas.cob.agencyservice.api.repository.agency.Agency;
 import de.caritas.cob.agencyservice.api.repository.agencytopic.AgencyTopic;
 import de.caritas.cob.agencyservice.api.repository.agencytopic.AgencyTopicRepository;
 import de.caritas.cob.agencyservice.api.repository.agencytopic.PublicationStatus;
+import de.caritas.cob.agencyservice.api.repository.legaltext.LegalText;
+import de.caritas.cob.agencyservice.api.repository.legaltext.LegalTextKind;
 import de.caritas.cob.agencyservice.api.tenant.TenantContext;
 import de.caritas.cob.agencyservice.api.util.AuthenticatedUser;
 import de.caritas.cob.agencyservice.api.validation.InputSanitizer;
@@ -75,6 +77,53 @@ class DepartmentImprintServiceTest {
     when(agencyTopicRepository.findByAgency_IdAndTopicId(7L, 42L))
         .thenReturn(Optional.of(department));
     return department;
+  }
+
+  @Test
+  void publish_Should_writeThroughToReferencedLegalText_When_departmentReferencesOne() {
+    // ADR-014: the referenced shared Impressum object is the truth; the legacy per-department
+    // endpoint writes through to it instead of the ignored inline column.
+    when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(false);
+    var department = existingDepartment();
+    var referenced =
+        LegalText.builder()
+            .id(101L)
+            .kind(LegalTextKind.IMPRINT)
+            .label("Geteiltes Impressum")
+            .content("{\"de\":\"<p>alt</p>\"}")
+            .publicationStatus(PublicationStatus.DRAFT)
+            .build();
+    department.setImprint(referenced);
+
+    var status = service.publishDepartmentImprint(7L, 42L, Map.of("de", "<p>neu</p>"), true);
+
+    assertThat(status).isEqualTo(PublicationStatus.PUBLISHED);
+    assertThat(referenced.getContent()).contains("neu");
+    assertThat(referenced.getPublicationStatus()).isEqualTo(PublicationStatus.PUBLISHED);
+    var saved = ArgumentCaptor.forClass(AgencyTopic.class);
+    verify(agencyTopicRepository).save(saved.capture());
+    assertThat(saved.getValue().getContentImprint()).isNull();
+  }
+
+  @Test
+  void read_Should_returnReferencedLegalText_When_departmentReferencesOne() {
+    when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(false);
+    var department = existingDepartment();
+    department.setContentImprint("{\"de\":\"<p>inline-alt</p>\"}");
+    department.setPublicationStatusImprint(PublicationStatus.DRAFT);
+    department.setImprint(
+        LegalText.builder()
+            .id(101L)
+            .kind(LegalTextKind.IMPRINT)
+            .label("Geteiltes Impressum")
+            .content("{\"de\":\"<p>geteilt</p>\"}")
+            .publicationStatus(PublicationStatus.PUBLISHED)
+            .build());
+
+    var view = service.getDepartmentImprint(7L, 42L);
+
+    assertThat(view.content()).isEqualTo("{\"de\":\"<p>geteilt</p>\"}");
+    assertThat(view.publicationStatus()).isEqualTo(PublicationStatus.PUBLISHED);
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/agencyservice/api/repository/legaltext/LegalTextRepositoryTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/repository/legaltext/LegalTextRepositoryTest.java
@@ -1,0 +1,167 @@
+package de.caritas.cob.agencyservice.api.repository.legaltext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import de.caritas.cob.agencyservice.api.repository.agency.Agency;
+import de.caritas.cob.agencyservice.api.repository.agency.DataProtectionResponsibleEntity;
+import de.caritas.cob.agencyservice.api.repository.agencytopic.AgencyTopic;
+import de.caritas.cob.agencyservice.api.repository.agencytopic.AgencyTopicRepository;
+import de.caritas.cob.agencyservice.api.repository.agencytopic.PublicationStatus;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.boot.jpa.test.autoconfigure.TestEntityManager;
+import org.springframework.boot.liquibase.autoconfigure.LiquibaseAutoConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+/**
+ * ADR-014 persistence model: legal texts (DPP / Impressum) are first-class shared objects owned by
+ * a Träger (tenant); a department (Fachbereich = agency × topic) references one per kind, and
+ * several departments may share the same text instead of maintaining N inline copies.
+ */
+@TestPropertySource(properties = {"spring.profiles.active=testing"})
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.ANY)
+@ExtendWith(SpringExtension.class)
+@DataJpaTest(excludeAutoConfiguration = LiquibaseAutoConfiguration.class)
+class LegalTextRepositoryTest {
+
+  @Autowired private TestEntityManager em;
+  @Autowired private LegalTextRepository legalTextRepository;
+  @Autowired private AgencyTopicRepository agencyTopicRepository;
+
+  private Agency persistAgency(String name) {
+    var now = LocalDateTime.now();
+    return em.persistFlushFind(
+        Agency.builder()
+            .name(name)
+            .consultingTypeId(1)
+            .dataProtectionResponsibleEntity(DataProtectionResponsibleEntity.AGENCY_RESPONSIBLE)
+            .dataProtectionOfficerContactData("officer")
+            .dataProtectionAlternativeContactData("alternative")
+            .dataProtectionAgencyResponsibleContactData("agency")
+            .createDate(now)
+            .updateDate(now)
+            .build());
+  }
+
+  private AgencyTopic persistDepartment(Agency agency, long topicId) {
+    var now = LocalDateTime.now();
+    return em.persistFlushFind(
+        AgencyTopic.builder().agency(agency).topicId(topicId).createDate(now).updateDate(now)
+            .build());
+  }
+
+  @Test
+  void persist_Should_storeLegalTextWithKindLabelContentAndStatus() {
+    var now = LocalDateTime.now();
+    LegalText text =
+        LegalText.builder()
+            .tenantId(1L)
+            .kind(LegalTextKind.DPP)
+            .label("Standard-DSE Träger")
+            .content("{\"de\":\"<p>DSE</p>\"}")
+            .publicationStatus(PublicationStatus.PUBLISHED)
+            .createDate(now)
+            .updateDate(now)
+            .build();
+
+    Long id = em.persistFlushFind(text).getId();
+    em.clear();
+
+    LegalText reloaded = em.find(LegalText.class, id);
+    assertThat(reloaded.getTenantId()).isEqualTo(1L);
+    assertThat(reloaded.getKind()).isEqualTo(LegalTextKind.DPP);
+    assertThat(reloaded.getLabel()).isEqualTo("Standard-DSE Träger");
+    assertThat(reloaded.getContent()).isEqualTo("{\"de\":\"<p>DSE</p>\"}");
+    assertThat(reloaded.getPublicationStatus()).isEqualTo(PublicationStatus.PUBLISHED);
+  }
+
+  @Test
+  void publicationStatus_Should_defaultToDraft_When_notSet() {
+    var now = LocalDateTime.now();
+    LegalText text =
+        LegalText.builder()
+            .tenantId(1L)
+            .kind(LegalTextKind.IMPRINT)
+            .label("Impressum")
+            .content("{\"de\":\"<p>Impressum</p>\"}")
+            .createDate(now)
+            .updateDate(now)
+            .build();
+
+    Long id = em.persistFlushFind(text).getId();
+    em.clear();
+
+    assertThat(em.find(LegalText.class, id).getPublicationStatus())
+        .isEqualTo(PublicationStatus.DRAFT);
+  }
+
+  @Test
+  void twoDepartments_Should_shareOneLegalText_And_usageCountReflectsIt() {
+    // given one shared DSE referenced by two Fachbereiche of the same agency
+    var now = LocalDateTime.now();
+    Agency agency = persistAgency("Beratungszentrum Süd");
+    LegalText sharedDpp =
+        em.persistFlushFind(
+            LegalText.builder()
+                .tenantId(1L)
+                .kind(LegalTextKind.DPP)
+                .label("Gemeinsame DSE")
+                .content("{\"de\":\"<p>geteilt</p>\"}")
+                .publicationStatus(PublicationStatus.PUBLISHED)
+                .createDate(now)
+                .updateDate(now)
+                .build());
+
+    AgencyTopic debtCounselling = persistDepartment(agency, 10L);
+    AgencyTopic pregnancy = persistDepartment(agency, 20L);
+    debtCounselling.setDpp(sharedDpp);
+    pregnancy.setDpp(sharedDpp);
+    em.persistAndFlush(debtCounselling);
+    em.persistAndFlush(pregnancy);
+    em.clear();
+
+    // then both departments resolve to the same text and the usage count is 2
+    AgencyTopic reloaded =
+        agencyTopicRepository.findByAgency_IdAndTopicId(agency.getId(), 10L).orElseThrow();
+    assertThat(reloaded.getDpp().getId()).isEqualTo(sharedDpp.getId());
+    assertThat(reloaded.getDpp().getContent()).isEqualTo("{\"de\":\"<p>geteilt</p>\"}");
+    assertThat(agencyTopicRepository.countByDpp_Id(sharedDpp.getId())).isEqualTo(2);
+    assertThat(agencyTopicRepository.countByImprint_Id(sharedDpp.getId())).isZero();
+  }
+
+  @Test
+  void findByTenantIdAndKind_Should_listOnlyThatTenantsTextsOfThatKind() {
+    var now = LocalDateTime.now();
+    em.persist(
+        LegalText.builder().tenantId(1L).kind(LegalTextKind.DPP).label("t1 dpp")
+            .content("{}").createDate(now).updateDate(now).build());
+    em.persist(
+        LegalText.builder().tenantId(1L).kind(LegalTextKind.IMPRINT).label("t1 imprint")
+            .content("{}").createDate(now).updateDate(now).build());
+    em.persist(
+        LegalText.builder().tenantId(2L).kind(LegalTextKind.DPP).label("t2 dpp")
+            .content("{}").createDate(now).updateDate(now).build());
+    em.flush();
+    em.clear();
+
+    assertThat(legalTextRepository.findByTenantIdAndKindOrderByLabelAsc(1L, LegalTextKind.DPP))
+        .extracting(LegalText::getLabel)
+        .containsExactly("t1 dpp");
+  }
+
+  @Test
+  void departmentWithoutReferences_Should_loadWithNullDppAndImprint() {
+    Agency agency = persistAgency("Zentrum ohne Texte");
+    AgencyTopic department = persistDepartment(agency, 30L);
+    em.clear();
+
+    AgencyTopic reloaded = em.find(AgencyTopic.class, department.getId());
+    assertThat(reloaded.getDpp()).isNull();
+    assertThat(reloaded.getImprint()).isNull();
+  }
+}

--- a/src/test/java/de/caritas/cob/agencyservice/api/repository/legaltext/LegalTextRepositoryTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/repository/legaltext/LegalTextRepositoryTest.java
@@ -1,6 +1,7 @@
 package de.caritas.cob.agencyservice.api.repository.legaltext;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import de.caritas.cob.agencyservice.api.repository.agency.Agency;
 import de.caritas.cob.agencyservice.api.repository.agency.DataProtectionResponsibleEntity;
@@ -152,6 +153,120 @@ class LegalTextRepositoryTest {
     assertThat(legalTextRepository.findByTenantIdAndKindOrderByLabelAsc(1L, LegalTextKind.DPP))
         .extracting(LegalText::getLabel)
         .containsExactly("t1 dpp");
+  }
+
+  @Test
+  void persist_Should_applyCreateAndUpdateDate_When_notSet() {
+    // the DB columns are NOT NULL; the entity must survive saves where no caller set the dates
+    LegalText text =
+        LegalText.builder()
+            .tenantId(1L)
+            .kind(LegalTextKind.DPP)
+            .label("Ohne Datum")
+            .content("{}")
+            .build();
+
+    Long id = em.persistFlushFind(text).getId();
+    em.clear();
+
+    LegalText reloaded = em.find(LegalText.class, id);
+    assertThat(reloaded.getCreateDate()).isNotNull();
+    assertThat(reloaded.getUpdateDate()).isNotNull();
+  }
+
+  @Test
+  void update_Should_refreshUpdateDate() {
+    var past = LocalDateTime.now().minusDays(3);
+    LegalText text =
+        em.persistFlushFind(
+            LegalText.builder()
+                .tenantId(1L)
+                .kind(LegalTextKind.DPP)
+                .label("Alt")
+                .content("{}")
+                .createDate(past)
+                .updateDate(past)
+                .build());
+
+    text.setLabel("Neu");
+    em.persistAndFlush(text);
+    em.clear();
+
+    assertThat(em.find(LegalText.class, text.getId()).getUpdateDate()).isAfter(past);
+  }
+
+  @Test
+  void persist_Should_rejectDppReferenceOfWrongKind() {
+    // a department's DPP slot must never point at an IMPRINT object — the consent screen would
+    // render the wrong document kind
+    Agency agency = persistAgency("Zentrum Guard");
+    var now = LocalDateTime.now();
+    LegalText imprintText =
+        em.persistFlushFind(
+            LegalText.builder()
+                .tenantId(null)
+                .kind(LegalTextKind.IMPRINT)
+                .label("Impressum")
+                .content("{}")
+                .createDate(now)
+                .updateDate(now)
+                .build());
+    AgencyTopic department =
+        AgencyTopic.builder().agency(agency).topicId(50L).createDate(now).updateDate(now).build();
+    department.setDpp(imprintText);
+
+    assertThatExceptionOfType(RuntimeException.class)
+        .isThrownBy(() -> em.persistAndFlush(department))
+        .withStackTraceContaining("kind");
+  }
+
+  @Test
+  void persist_Should_rejectImprintReferenceOfWrongKind() {
+    Agency agency = persistAgency("Zentrum Guard 2");
+    var now = LocalDateTime.now();
+    LegalText dppText =
+        em.persistFlushFind(
+            LegalText.builder()
+                .tenantId(null)
+                .kind(LegalTextKind.DPP)
+                .label("DSE")
+                .content("{}")
+                .createDate(now)
+                .updateDate(now)
+                .build());
+    AgencyTopic department =
+        AgencyTopic.builder().agency(agency).topicId(51L).createDate(now).updateDate(now).build();
+    department.setImprint(dppText);
+
+    assertThatExceptionOfType(RuntimeException.class)
+        .isThrownBy(() -> em.persistAndFlush(department))
+        .withStackTraceContaining("kind");
+  }
+
+  @Test
+  void persist_Should_rejectReferenceToAnotherTenantsText() {
+    // a department must never reference another Träger's legal document
+    var now = LocalDateTime.now();
+    Agency agency = persistAgency("Zentrum Tenant-Guard");
+    agency.setTenantId(5L);
+    em.persistAndFlush(agency);
+    LegalText foreignText =
+        em.persistFlushFind(
+            LegalText.builder()
+                .tenantId(9L)
+                .kind(LegalTextKind.DPP)
+                .label("Fremde DSE")
+                .content("{}")
+                .createDate(now)
+                .updateDate(now)
+                .build());
+    AgencyTopic department =
+        AgencyTopic.builder().agency(agency).topicId(52L).createDate(now).updateDate(now).build();
+    department.setDpp(foreignText);
+
+    assertThatExceptionOfType(RuntimeException.class)
+        .isThrownBy(() -> em.persistAndFlush(department))
+        .withStackTraceContaining("tenant");
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/agencyservice/api/service/AgencyServiceTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/service/AgencyServiceTest.java
@@ -46,6 +46,8 @@ import de.caritas.cob.agencyservice.api.repository.agency.Agency;
 import de.caritas.cob.agencyservice.api.repository.agency.AgencyRepository;
 import de.caritas.cob.agencyservice.api.repository.agencytopic.AgencyTopic;
 import de.caritas.cob.agencyservice.api.repository.agencytopic.PublicationStatus;
+import de.caritas.cob.agencyservice.api.repository.legaltext.LegalText;
+import de.caritas.cob.agencyservice.api.repository.legaltext.LegalTextKind;
 import de.caritas.cob.agencyservice.api.service.matrix.AgencyMatrixPasswordCipher;
 import de.caritas.cob.agencyservice.api.service.matrix.MatrixProvisioningService;
 import de.caritas.cob.agencyservice.api.tenant.TenantContext;
@@ -248,6 +250,52 @@ public class AgencyServiceTest {
     assertEquals(Boolean.FALSE, byTopicId.get(2L).getHasPublishedImprint());
     // the existing topicIds contract is untouched
     assertEquals(List.of(1L, 2L), result.get(0).getTopicIds());
+  }
+
+  @Test
+  public void getListOfAgencies_Should_DeriveLegalPublicationFlagsFromReferencedLegalText_WhenDepartmentReferencesOne()
+      throws MissingConsultingTypeException {
+
+    // ADR-014 write-through only updates the referenced legal_text object; the inline columns are
+    // intentionally kept stale. The search flags must therefore resolve reference-first, exactly
+    // like DepartmentLegalService — otherwise a publish/draft-save would not show up here.
+    Agency agency = Agency.builder().id(100L).name("Zentrum").consultingTypeId(CONSULTING_TYPE_SUCHT)
+        .build();
+    // referenced DPP is PUBLISHED while the stale inline copy says DRAFT → flag must be true
+    AgencyTopic publishedViaReference = AgencyTopic.builder().agency(agency).topicId(1L)
+        .contentDpp("{\"de\":\"<p>stale inline</p>\"}").publicationStatus(PublicationStatus.DRAFT)
+        .dpp(LegalText.builder().id(500L).kind(LegalTextKind.DPP).label("Geteilte DSE")
+            .content("{\"de\":\"<p>geteilt</p>\"}")
+            .publicationStatus(PublicationStatus.PUBLISHED).build())
+        .build();
+    // referenced imprint is DRAFT while the stale inline copy says PUBLISHED → flag must be false
+    AgencyTopic draftViaReference = AgencyTopic.builder().agency(agency).topicId(2L)
+        .contentImprint("{\"de\":\"<p>stale inline</p>\"}")
+        .publicationStatusImprint(PublicationStatus.PUBLISHED)
+        .imprint(LegalText.builder().id(501L).kind(LegalTextKind.IMPRINT)
+            .label("Geteiltes Impressum").content("{\"de\":\"<p>Entwurf</p>\"}")
+            .publicationStatus(PublicationStatus.DRAFT).build())
+        .build();
+    ReflectionTestUtils.setField(agency, "agencyTopics",
+        List.of(publishedViaReference, draftViaReference));
+
+    when(agencyRepository.searchWithoutTopic(VALID_POSTCODE, VALID_POSTCODE_LENGTH,
+        CONSULTING_TYPE_SUCHT, AGE, GENDER, COUNSELLING_RELATION, TENANT_ID))
+        .thenReturn(List.of(agency));
+    when(consultingTypeManager.getConsultingTypeSettings(Mockito.anyInt()))
+        .thenReturn(CONSULTING_TYPE_SETTINGS_WITH_WHITESPOT_AGENCY);
+
+    var result =
+        agencyService.getAgencies(Optional.of(VALID_POSTCODE), CONSULTING_TYPE_SUCHT,
+            Optional.empty());
+
+    assertEquals(1, result.size());
+    var byTopicId = result.get(0).getDepartments().stream()
+        .collect(java.util.stream.Collectors.toMap(d -> d.getTopicId(), d -> d));
+    assertTrue(byTopicId.get(1L).getHasPublishedDpp());
+    assertEquals(Boolean.FALSE, byTopicId.get(1L).getHasPublishedImprint());
+    assertEquals(Boolean.FALSE, byTopicId.get(2L).getHasPublishedDpp());
+    assertEquals(Boolean.FALSE, byTopicId.get(2L).getHasPublishedImprint());
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/agencyservice/api/service/DepartmentLegalServiceTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/service/DepartmentLegalServiceTest.java
@@ -9,6 +9,8 @@ import de.caritas.cob.agencyservice.api.repository.agency.Agency;
 import de.caritas.cob.agencyservice.api.repository.agencytopic.AgencyTopic;
 import de.caritas.cob.agencyservice.api.repository.agencytopic.AgencyTopicRepository;
 import de.caritas.cob.agencyservice.api.repository.agencytopic.PublicationStatus;
+import de.caritas.cob.agencyservice.api.repository.legaltext.LegalText;
+import de.caritas.cob.agencyservice.api.repository.legaltext.LegalTextKind;
 import java.time.LocalDateTime;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
@@ -101,6 +103,73 @@ class DepartmentLegalServiceTest {
 
     assertThat(view.dppContent()).isNull();
     assertThat(view.imprintContent()).isNull();
+  }
+
+  @Test
+  void getPublishedDepartmentLegal_Should_preferReferencedLegalText_OverInlineContent() {
+    // ADR-014: when the department references a shared legal-text object, that object is the
+    // truth — the leftover inline copy must be ignored entirely.
+    var department =
+        department(
+            "{\"de\":\"<p>alte Inline-DSE</p>\"}",
+            PublicationStatus.PUBLISHED,
+            null,
+            PublicationStatus.DRAFT);
+    department.setDpp(
+        LegalText.builder()
+            .id(100L)
+            .kind(LegalTextKind.DPP)
+            .label("Geteilte DSE")
+            .content("{\"de\":\"<p>geteilte DSE</p>\"}")
+            .publicationStatus(PublicationStatus.PUBLISHED)
+            .build());
+
+    var view = service.getPublishedDepartmentLegal(7L, 42L);
+
+    assertThat(view.dppContent()).isEqualTo("{\"de\":\"<p>geteilte DSE</p>\"}");
+  }
+
+  @Test
+  void getPublishedDepartmentLegal_Should_returnNull_When_referencedTextIsDraft() {
+    // a DRAFT shared object must not fall back to a published inline leftover — the reference,
+    // once set, fully replaces the inline column
+    var department =
+        department(
+            "{\"de\":\"<p>alte Inline-DSE</p>\"}",
+            PublicationStatus.PUBLISHED,
+            null,
+            PublicationStatus.DRAFT);
+    department.setDpp(
+        LegalText.builder()
+            .id(100L)
+            .kind(LegalTextKind.DPP)
+            .label("Entwurf")
+            .content("{\"de\":\"<p>Entwurf</p>\"}")
+            .publicationStatus(PublicationStatus.DRAFT)
+            .build());
+
+    var view = service.getPublishedDepartmentLegal(7L, 42L);
+
+    assertThat(view.dppContent()).isNull();
+  }
+
+  @Test
+  void getPublishedDepartmentLegal_Should_resolveImprintReferenceIndependently() {
+    var department =
+        department(null, PublicationStatus.DRAFT, null, PublicationStatus.DRAFT);
+    department.setImprint(
+        LegalText.builder()
+            .id(101L)
+            .kind(LegalTextKind.IMPRINT)
+            .label("Geteiltes Impressum")
+            .content("{\"de\":\"<p>Impressum</p>\"}")
+            .publicationStatus(PublicationStatus.PUBLISHED)
+            .build());
+
+    var view = service.getPublishedDepartmentLegal(7L, 42L);
+
+    assertThat(view.dppContent()).isNull();
+    assertThat(view.imprintContent()).isEqualTo("{\"de\":\"<p>Impressum</p>\"}");
   }
 
   @Test


### PR DESCRIPTION
## Problem

ADR-014: per-department legal texts stored inline (`agency_topic.content_dpp`/`content_imprint`) cannot be shared — one DPP legally covering four Fachbereiche means four maintained copies. Reverses the 2026-07-07 "keep inline, drop references" reconcile.

## What changed

- New `legal_text` entity/table (kind `DPP|IMPRINT`, multilingual JSON content, draft|published) + sequence — changeset `0026`
- `agency_topic` gains nullable `dpp_id`/`imprint_id` FKs; a referenced object **fully replaces** the inline column, unreferenced rows keep today's behaviour (inline → tenant fallback)
- `DepartmentLegalService` (public read): reference-first, published-only — client contract unchanged
- `DepartmentDataProtectionService`/`DepartmentImprintService`: **write-through** to the referenced object (writing inline would be silently ignored by the read path)
- Backfill migration lifts inline texts into `legal_text`, merging byte-identical (tenant, content, status) texts into one shared row; inline columns stay one release as rollback anchor
- Usage counts for the upcoming "used by N departments" admin UI (ORISO-Admin#335)

Out of scope (follow-up PR on the same parent): the legal-text library CRUD/assign admin API.

## Verification

- `mvn test`: 467 tests green (14 new: repository round-trip/sharing, reference-first resolution, write-through both kinds)
- `LiquibaseChangelogDriftIT` against fresh MariaDB 10.11: changelog incl. 0026 applies cleanly, Hibernate validates all entities
- Backfill functionally verified on seeded MariaDB: 2 departments with identical published DPP → **one** shared `legal_text` row; distinct draft stays separate; re-run is a no-op (idempotent)

Refs OpenResilienceInitiative/ORISO-AgencyService#132

🤖 Generated with [Claude Code](https://claude.com/claude-code)