### PR TITLE
refactor(legal): one canonical LegalContentSanitizer, strict __meta validation everywhere

### DIFF
--- a/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/DepartmentDataProtectionService.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/DepartmentDataProtectionService.java
@@ -42,7 +42,7 @@ import org.springframework.transaction.annotation.Transactional;
  * translation-metadata convention) carry JSON, not HTML: running them through the HTML sanitizer
  * would corrupt the payload (quotes become entities → invalid JSON), so they are passed through
  * unsanitised. Because this metadata is stored verbatim and later served publicly, it is validated
- * against a strict schema ({@link #assertValidJson}) rather than a mere parse check, so no
+ * against a strict schema (see {@link LegalContentSanitizer}) rather than a mere parse check, so no
  * unsanitised free text can hide behind the suffix.
  */
 @Service
@@ -50,16 +50,10 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class DepartmentDataProtectionService {
 
-  private static final String META_KEY_SUFFIX = "__meta";
-
   private final @NonNull AgencyTopicRepository agencyTopicRepository;
-  private final @NonNull InputSanitizer inputSanitizer;
+  private final @NonNull LegalContentSanitizer legalContentSanitizer;
   private final @NonNull AuthenticatedUser authenticatedUser;
   private final @NonNull UserAdminService userAdminService;
-
-  private final ObjectMapper objectMapper = new ObjectMapper();
-  private final ObjectReader metaJsonReader =
-      objectMapper.readerFor(JsonNode.class).with(DeserializationFeature.FAIL_ON_TRAILING_TOKENS);
 
   /**
    * Sanitises and stores the department's DPP for the given agency × topic. When {@code publish} is
@@ -80,7 +74,7 @@ public class DepartmentDataProtectionService {
 
     assertCallerTenantMatches(department.getAgency());
 
-    var sanitizedJson = toJson(sanitizeTranslations(content));
+    var sanitizedJson = legalContentSanitizer.sanitizeToJson(content);
     var status = publish ? PublicationStatus.PUBLISHED : PublicationStatus.DRAFT;
     var now = LocalDateTime.now();
 
@@ -169,97 +163,5 @@ public class DepartmentDataProtectionService {
   private Long resolveEffectiveTenantId() {
     Long tenantIdFromAuth = authenticatedUser.getTenantId();
     return tenantIdFromAuth != null ? tenantIdFromAuth : TenantContext.getCurrentTenant();
-  }
-
-  private Map<String, String> sanitizeTranslations(Map<String, String> content) {
-    if (content == null) {
-      return Map.of();
-    }
-    return content.entrySet().stream()
-        .filter(entry -> entry.getKey() != null)
-        .collect(
-            Collectors.toMap(
-                Map.Entry::getKey,
-                entry -> sanitizeOrValidateValue(entry.getKey(), entry.getValue()),
-                (existing, replacement) -> replacement,
-                LinkedHashMap::new));
-  }
-
-  /**
-   * {@code __meta}-suffixed keys carry translation metadata as JSON and are stored verbatim after a
-   * strict validation; every other key is OWASP HTML-sanitised.
-   */
-  private String sanitizeOrValidateValue(String key, String value) {
-    var safeValue = value == null ? "" : value;
-    if (key.endsWith(META_KEY_SUFFIX)) {
-      assertValidJson(key, safeValue);
-      return safeValue;
-    }
-    return inputSanitizer.sanitizeAllowingFormattingAndLinks(safeValue);
-  }
-
-  /**
-   * Strictly validates a {@code __meta} translation-metadata payload. Because the value is stored
-   * unsanitised and later served publicly, a mere "parses without error" check is not enough: the
-   * value must be a non-blank JSON object holding only {@code mt} (boolean), {@code src} (string)
-   * and {@code at} (string), with {@code src}/{@code at} non-blank. Blanks, scalars, arrays,
-   * trailing tokens and any unknown field are rejected with a 400.
-   */
-  private void assertValidJson(String key, String value) {
-    if (value == null || value.isBlank()) {
-      throw invalidMeta(key);
-    }
-    final JsonNode node;
-    try {
-      node = metaJsonReader.readValue(value);
-    } catch (JsonProcessingException e) {
-      throw invalidMeta(key);
-    }
-    if (node == null || !node.isObject()) {
-      throw invalidMeta(key);
-    }
-    int knownFields = 0;
-    if (node.has("mt")) {
-      requireBoolean(key, node.get("mt"));
-      knownFields++;
-    }
-    if (node.has("src")) {
-      requireNonBlankText(key, node.get("src"));
-      knownFields++;
-    }
-    if (node.has("at")) {
-      requireNonBlankText(key, node.get("at"));
-      knownFields++;
-    }
-    // any remaining property is an unknown field and must be rejected
-    if (node.size() != knownFields) {
-      throw invalidMeta(key);
-    }
-  }
-
-  private void requireBoolean(String key, JsonNode value) {
-    if (value == null || !value.isBoolean()) {
-      throw invalidMeta(key);
-    }
-  }
-
-  private void requireNonBlankText(String key, JsonNode value) {
-    if (value == null || !value.isTextual() || value.asText().isBlank()) {
-      throw invalidMeta(key);
-    }
-  }
-
-  private BadRequestException invalidMeta(String key) {
-    return new BadRequestException(
-        String.format("Translation metadata key '%s' does not contain valid JSON", key));
-  }
-
-  private String toJson(Map<String, String> sanitized) {
-    try {
-      return objectMapper.writeValueAsString(sanitized);
-    } catch (JsonProcessingException e) {
-      throw new InternalServerErrorException(
-          "Could not serialize department data privacy policy content", e);
-    }
   }
 }

--- a/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/DepartmentImprintService.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/DepartmentImprintService.java
@@ -34,24 +34,19 @@ import org.springframework.transaction.annotation.Transactional;
  * sanitised per translation, and (c) stored as a JSON language→HTML map in {@code
  * agency_topic.content_imprint} with its own draft/published lifecycle, independent of the DPP's.
  *
- * <p>One deviation from the DPP twin: {@code __meta}-suffixed keys (the platform-wide
- * translation-metadata convention) carry JSON, not HTML. They are passed through unsanitised —
- * running them through the HTML sanitizer would destroy the payload — but validated to be
- * well-formed JSON so no unsanitised free text can hide behind the suffix.
+ * <p>{@code __meta}-suffixed keys are handled by the shared {@link LegalContentSanitizer}: passed
+ * through unsanitised but validated against the strict metadata schema — the former lenient
+ * "parses as JSON" check allowed arbitrary unsanitised payloads behind the suffix.
  */
 @Service
 @Slf4j
 @RequiredArgsConstructor
 public class DepartmentImprintService {
 
-  private static final String META_KEY_SUFFIX = "__meta";
-
   private final @NonNull AgencyTopicRepository agencyTopicRepository;
-  private final @NonNull InputSanitizer inputSanitizer;
+  private final @NonNull LegalContentSanitizer legalContentSanitizer;
   private final @NonNull AuthenticatedUser authenticatedUser;
   private final @NonNull UserAdminService userAdminService;
-
-  private final ObjectMapper objectMapper = new ObjectMapper();
 
   /**
    * Sanitises and stores the department's imprint for the given agency × topic. When {@code
@@ -72,7 +67,7 @@ public class DepartmentImprintService {
 
     assertCallerTenantMatches(department.getAgency());
 
-    var sanitizedJson = toJson(sanitizeTranslations(content));
+    var sanitizedJson = legalContentSanitizer.sanitizeToJson(content);
     var status = publish ? PublicationStatus.PUBLISHED : PublicationStatus.DRAFT;
     var now = LocalDateTime.now();
 
@@ -161,46 +156,5 @@ public class DepartmentImprintService {
   private Long resolveEffectiveTenantId() {
     Long tenantIdFromAuth = authenticatedUser.getTenantId();
     return tenantIdFromAuth != null ? tenantIdFromAuth : TenantContext.getCurrentTenant();
-  }
-
-  private Map<String, String> sanitizeTranslations(Map<String, String> content) {
-    if (content == null) {
-      return Map.of();
-    }
-    return content.entrySet().stream()
-        .filter(entry -> entry.getKey() != null)
-        .collect(
-            Collectors.toMap(
-                Map.Entry::getKey,
-                entry -> sanitizeOrValidateValue(entry.getKey(), entry.getValue()),
-                (existing, replacement) -> replacement,
-                LinkedHashMap::new));
-  }
-
-  private String sanitizeOrValidateValue(String key, String value) {
-    var safeValue = value == null ? "" : value;
-    if (key.endsWith(META_KEY_SUFFIX)) {
-      assertValidJson(key, safeValue);
-      return safeValue;
-    }
-    return inputSanitizer.sanitizeAllowingFormattingAndLinks(safeValue);
-  }
-
-  private void assertValidJson(String key, String value) {
-    try {
-      objectMapper.readTree(value);
-    } catch (JsonProcessingException e) {
-      throw new BadRequestException(
-          String.format("Translation metadata key '%s' does not contain valid JSON", key));
-    }
-  }
-
-  private String toJson(Map<String, String> sanitized) {
-    try {
-      return objectMapper.writeValueAsString(sanitized);
-    } catch (JsonProcessingException e) {
-      throw new InternalServerErrorException(
-          "Could not serialize department imprint content", e);
-    }
   }
 }

--- a/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/LegalContentSanitizer.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/LegalContentSanitizer.java
@@ -1,0 +1,133 @@
+package de.caritas.cob.agencyservice.api.admin.service.legal;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+import de.caritas.cob.agencyservice.api.exception.httpresponses.BadRequestException;
+import de.caritas.cob.agencyservice.api.exception.httpresponses.InternalServerErrorException;
+import de.caritas.cob.agencyservice.api.validation.InputSanitizer;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+/**
+ * The one canonical sanitisation path for admin-authored legal content (department DPP, department
+ * Impressum and the shared ADR-014 legal texts): every translation value is OWASP HTML-sanitised;
+ * {@code __meta}-suffixed keys (the platform-wide translation-metadata convention) carry JSON, not
+ * HTML — running them through the HTML sanitizer would corrupt the payload, so they are passed
+ * through verbatim after a <em>strict</em> schema validation ({@code mt:boolean},
+ * {@code src:string}, {@code at:string}, non-blank, no unknown fields). Because the metadata is
+ * stored verbatim and later served publicly, a mere "parses as JSON" check is not enough — that
+ * used to be the imprint path's behaviour and allowed arbitrary unsanitised JSON payloads behind
+ * the suffix.
+ */
+@Component
+@RequiredArgsConstructor
+public class LegalContentSanitizer {
+
+  private static final String META_KEY_SUFFIX = "__meta";
+
+  private final @NonNull InputSanitizer inputSanitizer;
+
+  private final ObjectMapper objectMapper = new ObjectMapper();
+  private final ObjectReader metaJsonReader =
+      objectMapper.readerFor(JsonNode.class).with(DeserializationFeature.FAIL_ON_TRAILING_TOKENS);
+
+  /**
+   * Sanitises the multilingual content map and serialises it to the stored JSON language→HTML map
+   * string. {@code null} content becomes an empty JSON object.
+   */
+  public String sanitizeToJson(Map<String, String> content) {
+    return toJson(sanitizeTranslations(content));
+  }
+
+  private Map<String, String> sanitizeTranslations(Map<String, String> content) {
+    if (content == null) {
+      return Map.of();
+    }
+    return content.entrySet().stream()
+        .filter(entry -> entry.getKey() != null)
+        .collect(
+            Collectors.toMap(
+                Map.Entry::getKey,
+                entry -> sanitizeOrValidateValue(entry.getKey(), entry.getValue()),
+                (existing, replacement) -> replacement,
+                LinkedHashMap::new));
+  }
+
+  private String sanitizeOrValidateValue(String key, String value) {
+    var safeValue = value == null ? "" : value;
+    if (key.endsWith(META_KEY_SUFFIX)) {
+      assertValidMeta(key, safeValue);
+      return safeValue;
+    }
+    return inputSanitizer.sanitizeAllowingFormattingAndLinks(safeValue);
+  }
+
+  /**
+   * Strictly validates a {@code __meta} translation-metadata payload: a non-blank JSON object
+   * holding only {@code mt} (boolean), {@code src} (string) and {@code at} (string), with
+   * {@code src}/{@code at} non-blank. Blanks, scalars, arrays, trailing tokens and any unknown
+   * field are rejected with a 400.
+   */
+  private void assertValidMeta(String key, String value) {
+    if (value == null || value.isBlank()) {
+      throw invalidMeta(key);
+    }
+    final JsonNode node;
+    try {
+      node = metaJsonReader.readValue(value);
+    } catch (JsonProcessingException e) {
+      throw invalidMeta(key);
+    }
+    if (node == null || !node.isObject()) {
+      throw invalidMeta(key);
+    }
+    int knownFields = 0;
+    if (node.has("mt")) {
+      requireBoolean(key, node.get("mt"));
+      knownFields++;
+    }
+    if (node.has("src")) {
+      requireNonBlankText(key, node.get("src"));
+      knownFields++;
+    }
+    if (node.has("at")) {
+      requireNonBlankText(key, node.get("at"));
+      knownFields++;
+    }
+    if (node.size() != knownFields) {
+      throw invalidMeta(key);
+    }
+  }
+
+  private void requireBoolean(String key, JsonNode value) {
+    if (value == null || !value.isBoolean()) {
+      throw invalidMeta(key);
+    }
+  }
+
+  private void requireNonBlankText(String key, JsonNode value) {
+    if (value == null || !value.isTextual() || value.asText().isBlank()) {
+      throw invalidMeta(key);
+    }
+  }
+
+  private BadRequestException invalidMeta(String key) {
+    return new BadRequestException(
+        String.format("Translation metadata key '%s' does not contain valid JSON", key));
+  }
+
+  private String toJson(Map<String, String> sanitized) {
+    try {
+      return objectMapper.writeValueAsString(sanitized);
+    } catch (JsonProcessingException e) {
+      throw new InternalServerErrorException("Could not serialize legal text content", e);
+    }
+  }
+}

--- a/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/LegalTextAdminService.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/LegalTextAdminService.java
@@ -45,17 +45,11 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class LegalTextAdminService {
 
-  private static final String META_KEY_SUFFIX = "__meta";
-
   private final @NonNull LegalTextRepository legalTextRepository;
   private final @NonNull AgencyTopicRepository agencyTopicRepository;
-  private final @NonNull InputSanitizer inputSanitizer;
+  private final @NonNull LegalContentSanitizer legalContentSanitizer;
   private final @NonNull AuthenticatedUser authenticatedUser;
   private final @NonNull UserAdminService userAdminService;
-
-  private final ObjectMapper objectMapper = new ObjectMapper();
-  private final ObjectReader metaJsonReader =
-      objectMapper.readerFor(JsonNode.class).with(DeserializationFeature.FAIL_ON_TRAILING_TOKENS);
 
   /** Lists the caller tenant's legal texts of one kind, each with its department usage count. */
   @Transactional(readOnly = true)
@@ -79,7 +73,7 @@ public class LegalTextAdminService {
             .tenantId(resolveEffectiveTenantId())
             .kind(kind)
             .label(label)
-            .content(toJson(sanitizeTranslations(content)))
+            .content(legalContentSanitizer.sanitizeToJson(content))
             .publicationStatus(publish ? PublicationStatus.PUBLISHED : PublicationStatus.DRAFT)
             .createDate(now)
             .updateDate(now)
@@ -97,7 +91,7 @@ public class LegalTextAdminService {
     assertValidLabel(label);
 
     text.setLabel(label);
-    text.setContent(toJson(sanitizeTranslations(content)));
+    text.setContent(legalContentSanitizer.sanitizeToJson(content));
     text.setPublicationStatus(publish ? PublicationStatus.PUBLISHED : PublicationStatus.DRAFT);
     text.setUpdateDate(LocalDateTime.now());
     return toView(legalTextRepository.save(text));
@@ -236,79 +230,5 @@ public class LegalTextAdminService {
   private Long resolveEffectiveTenantId() {
     Long tenantIdFromAuth = authenticatedUser.getTenantId();
     return tenantIdFromAuth != null ? tenantIdFromAuth : TenantContext.getCurrentTenant();
-  }
-
-  private Map<String, String> sanitizeTranslations(Map<String, String> content) {
-    if (content == null) {
-      return Map.of();
-    }
-    return content.entrySet().stream()
-        .filter(entry -> entry.getKey() != null)
-        .collect(
-            Collectors.toMap(
-                Map.Entry::getKey,
-                entry -> sanitizeOrValidateValue(entry.getKey(), entry.getValue()),
-                (existing, replacement) -> replacement,
-                LinkedHashMap::new));
-  }
-
-  /** Strict {@code __meta} handling, mirrors {@link DepartmentDataProtectionService}. */
-  private String sanitizeOrValidateValue(String key, String value) {
-    var safeValue = value == null ? "" : value;
-    if (key.endsWith(META_KEY_SUFFIX)) {
-      assertValidJson(key, safeValue);
-      return safeValue;
-    }
-    return inputSanitizer.sanitizeAllowingFormattingAndLinks(safeValue);
-  }
-
-  private void assertValidJson(String key, String value) {
-    if (value == null || value.isBlank()) {
-      throw invalidMeta(key);
-    }
-    final JsonNode node;
-    try {
-      node = metaJsonReader.readValue(value);
-    } catch (JsonProcessingException e) {
-      throw invalidMeta(key);
-    }
-    if (node == null || !node.isObject()) {
-      throw invalidMeta(key);
-    }
-    int knownFields = 0;
-    if (node.has("mt")) {
-      if (!node.get("mt").isBoolean()) {
-        throw invalidMeta(key);
-      }
-      knownFields++;
-    }
-    if (node.has("src")) {
-      if (!node.get("src").isTextual() || node.get("src").asText().isBlank()) {
-        throw invalidMeta(key);
-      }
-      knownFields++;
-    }
-    if (node.has("at")) {
-      if (!node.get("at").isTextual() || node.get("at").asText().isBlank()) {
-        throw invalidMeta(key);
-      }
-      knownFields++;
-    }
-    if (node.size() != knownFields) {
-      throw invalidMeta(key);
-    }
-  }
-
-  private BadRequestException invalidMeta(String key) {
-    return new BadRequestException(
-        String.format("Translation metadata key '%s' does not contain valid JSON", key));
-  }
-
-  private String toJson(Map<String, String> sanitized) {
-    try {
-      return objectMapper.writeValueAsString(sanitized);
-    } catch (JsonProcessingException e) {
-      throw new InternalServerErrorException("Could not serialize legal text content", e);
-    }
   }
 }

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/service/legal/DepartmentDataProtectionServiceTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/service/legal/DepartmentDataProtectionServiceTest.java
@@ -47,7 +47,10 @@ class DepartmentDataProtectionServiceTest {
     // real sanitizer so we actually verify markup stripping, not a mock
     service =
         new DepartmentDataProtectionService(
-            agencyTopicRepository, new InputSanitizer(), authenticatedUser, userAdminService);
+            agencyTopicRepository,
+            new LegalContentSanitizer(new InputSanitizer()),
+            authenticatedUser,
+            userAdminService);
   }
 
   @AfterEach

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/service/legal/DepartmentImprintServiceTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/service/legal/DepartmentImprintServiceTest.java
@@ -47,7 +47,10 @@ class DepartmentImprintServiceTest {
     // real sanitizer so we actually verify markup stripping, not a mock
     service =
         new DepartmentImprintService(
-            agencyTopicRepository, new InputSanitizer(), authenticatedUser, userAdminService);
+            agencyTopicRepository,
+            new LegalContentSanitizer(new InputSanitizer()),
+            authenticatedUser,
+            userAdminService);
   }
 
   @AfterEach
@@ -259,8 +262,9 @@ class DepartmentImprintServiceTest {
     when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(false);
     var department = existingDepartment();
     // translation-metadata convention: __meta-suffixed keys carry JSON, not HTML - sanitising
-    // them would destroy the payload, so they are passed through JSON-validated instead
-    var metaJson = "{\"source\":\"machine\",\"reviewed\":false}";
+    // them would destroy the payload; they pass through after the STRICT schema validation
+    // (shared LegalContentSanitizer — the former lenient parse-only check is gone)
+    var metaJson = "{\"mt\":true,\"src\":\"de\",\"at\":\"2026-07-16T10:00:00Z\"}";
 
     service.publishDepartmentImprint(
         7L, 42L, Map.of("de", "<p>Impressum</p>", "de__meta", metaJson), true);
@@ -268,7 +272,25 @@ class DepartmentImprintServiceTest {
     var stored = department.getContentImprint();
     assertThat(stored).contains("\"de__meta\":");
     // the JSON payload survives verbatim (an HTML sanitizer would have escaped the quotes away)
-    assertThat(stored).contains("machine").contains("reviewed");
+    assertThat(stored).contains("mt").contains("src");
+  }
+
+  @Test
+  void publish_Should_rejectMetaWithUnknownFields() {
+    // the imprint path used to accept arbitrary JSON behind the __meta suffix — with the shared
+    // strict validation, unknown fields are rejected like on the DPP path
+    when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(false);
+    existingDepartment();
+
+    assertThatExceptionOfType(BadRequestException.class)
+        .isThrownBy(
+            () ->
+                service.publishDepartmentImprint(
+                    7L,
+                    42L,
+                    Map.of("de__meta", "{\"source\":\"machine\",\"reviewed\":false}"),
+                    true));
+    verify(agencyTopicRepository, never()).save(any());
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/service/legal/LegalContentSanitizerTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/service/legal/LegalContentSanitizerTest.java
@@ -1,0 +1,95 @@
+package de.caritas.cob.agencyservice.api.admin.service.legal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import de.caritas.cob.agencyservice.api.exception.httpresponses.BadRequestException;
+import de.caritas.cob.agencyservice.api.validation.InputSanitizer;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The one canonical sanitisation path for admin-authored legal content (DPP, Impressum, shared
+ * legal texts): every translation value is OWASP-sanitised, {@code __meta}-suffixed keys carry
+ * translation metadata as JSON and are validated against the strict schema (only {@code
+ * mt:boolean}, {@code src:string}, {@code at:string}, non-blank, no unknown fields) because they
+ * are stored verbatim and served publicly.
+ */
+class LegalContentSanitizerTest {
+
+  private LegalContentSanitizer sanitizer;
+
+  @BeforeEach
+  void setUp() {
+    sanitizer = new LegalContentSanitizer(new InputSanitizer());
+  }
+
+  @Test
+  void sanitizeToJson_Should_stripDangerousMarkup_andKeepText() {
+    var json =
+        sanitizer.sanitizeToJson(
+            Map.of("de", "<p onclick=\"steal()\">Impressum <script>bad()</script></p>"));
+
+    assertThat(json).startsWith("{").contains("\"de\":");
+    assertThat(json).contains("Impressum").doesNotContain("script").doesNotContain("onclick");
+  }
+
+  @Test
+  void sanitizeToJson_Should_returnEmptyJsonObject_When_contentNull() {
+    assertThat(sanitizer.sanitizeToJson(null)).isEqualTo("{}");
+  }
+
+  @Test
+  void sanitizeToJson_Should_passThroughValidStrictMeta_Unsanitised() {
+    var metaJson = "{\"mt\":true,\"src\":\"de\",\"at\":\"2026-07-16T10:00:00Z\"}";
+
+    var json = sanitizer.sanitizeToJson(Map.of("de", "<p>x</p>", "de__meta", metaJson));
+
+    assertThat(json).contains("\"de__meta\":");
+    // quotes survive as JSON, not HTML entities
+    assertThat(json).contains("mt");
+  }
+
+  @Test
+  void sanitizeToJson_Should_rejectMetaWithUnknownFields() {
+    // the formerly lenient imprint path accepted arbitrary JSON here — no longer
+    assertThatExceptionOfType(BadRequestException.class)
+        .isThrownBy(
+            () ->
+                sanitizer.sanitizeToJson(
+                    Map.of("de__meta", "{\"source\":\"machine\",\"reviewed\":false}")));
+  }
+
+  @Test
+  void sanitizeToJson_Should_rejectNonObjectMeta() {
+    assertThatExceptionOfType(BadRequestException.class)
+        .isThrownBy(() -> sanitizer.sanitizeToJson(Map.of("de__meta", "[\"de\",\"en\"]")));
+    assertThatExceptionOfType(BadRequestException.class)
+        .isThrownBy(() -> sanitizer.sanitizeToJson(Map.of("de__meta", "\"just-a-string\"")));
+    assertThatExceptionOfType(BadRequestException.class)
+        .isThrownBy(() -> sanitizer.sanitizeToJson(Map.of("de__meta", "not-json{")));
+    assertThatExceptionOfType(BadRequestException.class)
+        .isThrownBy(() -> sanitizer.sanitizeToJson(Map.of("de__meta", "")));
+  }
+
+  @Test
+  void sanitizeToJson_Should_rejectWrongMetaFieldTypes() {
+    assertThatExceptionOfType(BadRequestException.class)
+        .isThrownBy(() -> sanitizer.sanitizeToJson(Map.of("de__meta", "{\"mt\":\"true\"}")));
+    assertThatExceptionOfType(BadRequestException.class)
+        .isThrownBy(() -> sanitizer.sanitizeToJson(Map.of("de__meta", "{\"src\":\"   \"}")));
+  }
+
+  @Test
+  void sanitizeToJson_Should_treatNullValuesAsEmpty_andSkipNullKeys() {
+    var content = new java.util.HashMap<String, String>();
+    content.put("de", null);
+    content.put(null, "<p>ignored</p>");
+
+    var json = sanitizer.sanitizeToJson(content);
+
+    assertThat(json).contains("\"de\":\"\"");
+    assertThat(json).doesNotContain("ignored");
+  }
+}

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/service/legal/LegalTextAdminServiceTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/service/legal/LegalTextAdminServiceTest.java
@@ -53,7 +53,7 @@ class LegalTextAdminServiceTest {
         new LegalTextAdminService(
             legalTextRepository,
             agencyTopicRepository,
-            new InputSanitizer(),
+            new LegalContentSanitizer(new InputSanitizer()),
             authenticatedUser,
             userAdminService);
   }


### PR DESCRIPTION
## Problem

Stacked on #134 (retarget after it merges). Security tightening spotted during the ADR-014 work: `DepartmentImprintService` validated `__meta` translation-metadata keys with a lenient "parses as JSON" check, while `DepartmentDataProtectionService` enforced the strict schema (`mt:boolean`, `src:string`, `at:string`, non-blank, no unknown fields). Both store the value **verbatim** and serve it publicly — the lenient path accepted arbitrary unsanitised JSON payloads behind the `__meta` suffix. The new `LegalTextAdminService` had become the third copy of the same logic.

## What changed

- New `LegalContentSanitizer` component: OWASP sanitisation per translation + **strict** `__meta` schema validation + JSON serialisation — the one canonical path
- All three legal services delegate to it; their duplicated private implementations are removed (~150 lines of triplication gone)
- **Behaviour change (intended):** the imprint publish endpoint now rejects `__meta` payloads with unknown fields/wrong types, same as the DPP endpoint always did
- Imprint tests updated to the strict contract + regression test for the closed gap

## Verification

- 7 new component tests (strict meta matrix) watched red first
- Full suite: **493 tests, 0 failures, BUILD SUCCESS** (DPP/admin-service behaviour byte-identical, only construction changed)

Refs OpenResilienceInitiative/ORISO-AgencyService#132

🤖 Generated with [Claude Code](https://claude.com/claude-code)