### PR TITLE
fix: bind upper-cased sort fields POSTCODE and CREATEDATE leniently

### DIFF
--- a/src/main/java/de/caritas/cob/agencyservice/config/SortParameterBindingConfig.java
+++ b/src/main/java/de/caritas/cob/agencyservice/config/SortParameterBindingConfig.java
@@ -1,0 +1,43 @@
+package de.caritas.cob.agencyservice.config;
+
+import de.caritas.cob.agencyservice.api.model.Sort;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.format.FormatterRegistry;
+import org.springframework.lang.NonNull;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+/**
+ * Binds the {@code field} query parameter of {@code GET /agencyadmin/agencies} leniently. The
+ * admin frontend sends upper-cased field names without separators (e.g. {@code POSTCODE},
+ * {@code CREATEDATE}), while the generated {@link Sort.FieldEnum} constants are underscore
+ * separated ({@code POST_CODE}, {@code CREATE_DATE}) — the default enum binding only accepts
+ * exact constant names and rejects those requests with HTTP 400.
+ */
+@Component
+public class SortParameterBindingConfig implements WebMvcConfigurer {
+
+  @Override
+  public void addFormatters(FormatterRegistry registry) {
+    registry.addConverter(String.class, Sort.FieldEnum.class, new LenientSortFieldConverter());
+  }
+
+  static class LenientSortFieldConverter implements Converter<String, Sort.FieldEnum> {
+
+    @Override
+    public Sort.FieldEnum convert(@NonNull String source) {
+      var canonicalSource = canonical(source);
+      for (var candidate : Sort.FieldEnum.values()) {
+        if (canonical(candidate.name()).equals(canonicalSource)
+            || canonical(candidate.getValue()).equals(canonicalSource)) {
+          return candidate;
+        }
+      }
+      throw new IllegalArgumentException("Unexpected sort field '" + source + "'");
+    }
+
+    private static String canonical(String value) {
+      return value.replaceAll("[^A-Za-z0-9]", "").toLowerCase();
+    }
+  }
+}

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/controller/AgencyAdminControllerTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/controller/AgencyAdminControllerTest.java
@@ -170,6 +170,33 @@ public class AgencyAdminControllerTest {
   }
 
   @Test
+  public void searchAgencies_Should_bindUpperCasedSortFieldsSentByAdminFrontend()
+      throws Exception {
+    // The admin frontend upper-cases sort fields (field=POSTCODE, field=CREATEDATE),
+    // while the generated FieldEnum constants are POST_CODE and CREATE_DATE.
+    for (var fieldParam : java.util.List.of(
+        "POSTCODE", "CREATEDATE", "ID", "NAME", "CITY", "OFFLINE",
+        "postCode", "createDate")) {
+      this.mvc
+          .perform(get(AGENCY_SEARCH_PATH)
+              .param(PAGE_PARAM, "1").param(PER_PAGE_PARAM, "10")
+              .param("field", fieldParam).param("order", "ASC"))
+          .andExpect(status().isOk());
+    }
+
+    var sortCaptor = org.mockito.ArgumentCaptor.forClass(
+        de.caritas.cob.agencyservice.api.model.Sort.class);
+    Mockito.verify(this.agencyAdminFullResponseDTO, Mockito.times(8))
+        .searchAgencies(any(), eq(1), eq(10), sortCaptor.capture());
+    var boundFields = sortCaptor.getAllValues().stream()
+        .map(s -> s == null || s.getField() == null ? null : s.getField().name())
+        .toList();
+    org.assertj.core.api.Assertions.assertThat(boundFields).containsExactly(
+        "POST_CODE", "CREATE_DATE", "ID", "NAME", "CITY", "OFFLINE",
+        "POST_CODE", "CREATE_DATE");
+  }
+
+  @Test
   @WithMockUser(authorities = {"AUTHORIZATION_AGENCY_ADMIN"})
   public void createAgency_Should_returnCreated_When_AgencyDtoIsGiven() throws Exception {
 


### PR DESCRIPTION
## Problem

Sorting the agency list by Postleitzahl or Erstellt am fails: the frontend sends `field=POSTCODE` / `field=CREATEDATE`, default enum binding only accepts exact constant names (`POST_CODE`, `CREATE_DATE`) → HTTP 400 before the service is reached. Found re-testing #128 on Pre-Dev (parent: OpenResilienceInitiative/ORISO-Admin#306).

## Changes

- `SortParameterBindingConfig`: lenient `Converter<String, Sort.FieldEnum>` (case-/separator-insensitive, matches constant name and value), registered via `addFormatters`.
- Controller binding test in `AgencyAdminControllerTest` covering POSTCODE, CREATEDATE, postCode, createDate, ID, NAME, CITY, OFFLINE (red before fix: 400; green after).

## Verification

- `mvn test -Dtest=AgencyAdminControllerTest`: 23/23 green.
- Full `mvn verify -DskipITs=false`: failure counts identical to unmodified pre-dev baseline (pre-existing, unrelated classes).

Closes #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)
