### PR TITLE
fix: allow authorized agency operations without userId claim

### DIFF
--- a/src/main/java/de/caritas/cob/agencyservice/api/admin/service/agency/AgencyAdminSearchService.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/admin/service/agency/AgencyAdminSearchService.java
@@ -173,7 +173,7 @@ public class AgencyAdminSearchService {
   Predicate agencyAdminFilterPredicate(CriteriaBuilder criteriaBuilder, Root<Agency> root) {
     Predicate tenantScopePredicate = tenantScopePredicate(criteriaBuilder, root);
     if (authenticatedUser.hasRestrictedAgencyPriviliges()) {
-      var adminAgencyIds = userAdminService.getAdminUserAgencyIds(authenticatedUser.getUserId());
+      var adminAgencyIds = userAdminService.getAdminUserAgencyIds(authenticatedUser.requireUserId());
       if (!adminAgencyIds.isEmpty()) {
         return criteriaBuilder.and(
             tenantScopePredicate, createPredicateForAgencyAdmin(criteriaBuilder, root, adminAgencyIds));

--- a/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/DepartmentDataProtectionService.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/DepartmentDataProtectionService.java
@@ -126,11 +126,11 @@ public class DepartmentDataProtectionService {
    */
   private void assertRestrictedAdminOwnsAgency(Long agencyId) {
     if (authenticatedUser.hasRestrictedAgencyPriviliges()) {
-      var adminAgencyIds = userAdminService.getAdminUserAgencyIds(authenticatedUser.getUserId());
+      var adminAgencyIds = userAdminService.getAdminUserAgencyIds(authenticatedUser.requireUserId());
       if (adminAgencyIds == null || !adminAgencyIds.contains(agencyId)) {
         log.warn(
             "Admin user {} may not edit the data privacy policy of agency {}",
-            authenticatedUser.getUserId(),
+            authenticatedUser.requireUserId(),
             agencyId);
         throw new AgencyAccessDeniedException();
       }
@@ -152,7 +152,7 @@ public class DepartmentDataProtectionService {
     if (agency == null || !effectiveTenantId.equals(agency.getTenantId())) {
       log.warn(
           "Admin user {} (tenant {}) may not edit the data privacy policy of agency {} (tenant {})",
-          authenticatedUser.getUserId(),
+          authenticatedUser.requireUserId(),
           effectiveTenantId,
           agency == null ? null : agency.getId(),
           agency == null ? null : agency.getTenantId());

--- a/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/DepartmentImprintService.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/DepartmentImprintService.java
@@ -119,11 +119,11 @@ public class DepartmentImprintService {
    */
   private void assertRestrictedAdminOwnsAgency(Long agencyId) {
     if (authenticatedUser.hasRestrictedAgencyPriviliges()) {
-      var adminAgencyIds = userAdminService.getAdminUserAgencyIds(authenticatedUser.getUserId());
+      var adminAgencyIds = userAdminService.getAdminUserAgencyIds(authenticatedUser.requireUserId());
       if (adminAgencyIds == null || !adminAgencyIds.contains(agencyId)) {
         log.warn(
             "Admin user {} may not edit the imprint of agency {}",
-            authenticatedUser.getUserId(),
+            authenticatedUser.requireUserId(),
             agencyId);
         throw new AgencyAccessDeniedException();
       }
@@ -145,7 +145,7 @@ public class DepartmentImprintService {
     if (agency == null || !effectiveTenantId.equals(agency.getTenantId())) {
       log.warn(
           "Admin user {} (tenant {}) may not edit the imprint of agency {} (tenant {})",
-          authenticatedUser.getUserId(),
+          authenticatedUser.requireUserId(),
           effectiveTenantId,
           agency == null ? null : agency.getId(),
           agency == null ? null : agency.getTenantId());

--- a/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/LegalTextAdminService.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/LegalTextAdminService.java
@@ -113,7 +113,7 @@ public class LegalTextAdminService {
     if (authenticatedUser.hasRestrictedAgencyPriviliges()) {
       log.warn(
           "Restricted admin user {} may not manage the tenant-wide legal-text library",
-          authenticatedUser.getUserId());
+          authenticatedUser.requireUserId());
       throw new AgencyAccessDeniedException();
     }
   }
@@ -191,7 +191,7 @@ public class LegalTextAdminService {
     if (!effectiveTenantId.equals(text.getTenantId())) {
       log.warn(
           "Admin user {} (tenant {}) may not edit legal text {} (tenant {})",
-          authenticatedUser.getUserId(),
+          authenticatedUser.requireUserId(),
           effectiveTenantId,
           text.getId(),
           text.getTenantId());
@@ -224,11 +224,11 @@ public class LegalTextAdminService {
    */
   private void assertRestrictedAdminOwnsAgency(Long agencyId) {
     if (authenticatedUser.hasRestrictedAgencyPriviliges()) {
-      var adminAgencyIds = userAdminService.getAdminUserAgencyIds(authenticatedUser.getUserId());
+      var adminAgencyIds = userAdminService.getAdminUserAgencyIds(authenticatedUser.requireUserId());
       if (adminAgencyIds == null || !adminAgencyIds.contains(agencyId)) {
         log.warn(
             "Admin user {} may not assign legal texts of agency {}",
-            authenticatedUser.getUserId(),
+            authenticatedUser.requireUserId(),
             agencyId);
         throw new AgencyAccessDeniedException();
       }
@@ -244,7 +244,7 @@ public class LegalTextAdminService {
     if (agency == null || !effectiveTenantId.equals(agency.getTenantId())) {
       log.warn(
           "Admin user {} (tenant {}) may not assign legal texts of agency {} (tenant {})",
-          authenticatedUser.getUserId(),
+          authenticatedUser.requireUserId(),
           effectiveTenantId,
           agency == null ? null : agency.getId(),
           agency == null ? null : agency.getTenantId());

--- a/src/main/java/de/caritas/cob/agencyservice/api/admin/validation/validators/AgencyUpdatePermissionValidator.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/admin/validation/validators/AgencyUpdatePermissionValidator.java
@@ -22,9 +22,11 @@ public class AgencyUpdatePermissionValidator implements ConcreteAgencyValidator 
 
   public void validate(ValidateAgencyDTO validateAgencyDto) {
     if (authenticatedUser.hasRestrictedAgencyPriviliges()) {
-      var adminAgencyIds = userAdminService.getAdminUserAgencyIds(authenticatedUser.getUserId());
+      var userId = authenticatedUser.requireUserId();
+      var adminAgencyIds = userAdminService.getAdminUserAgencyIds(userId);
       if (!adminAgencyIds.contains(validateAgencyDto.getId())) {
-        log.warn("Admin user with id does not have permission to this agency: {}", authenticatedUser.getUserId(), validateAgencyDto.getId());
+        log.warn("Admin user with id does not have permission to this agency: {}", userId,
+            validateAgencyDto.getId());
         throw new AgencyAccessDeniedException();
       }
     }

--- a/src/main/java/de/caritas/cob/agencyservice/api/util/AuthenticatedUser.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/util/AuthenticatedUser.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
+import org.springframework.security.access.AccessDeniedException;
 
 import java.util.Set;
 
@@ -21,7 +22,6 @@ import static java.util.Objects.nonNull;
 @Setter
 public class AuthenticatedUser {
 
-  @NonNull
   private String userId;
 
   @NonNull
@@ -52,6 +52,18 @@ public class AuthenticatedUser {
   @JsonIgnore
   public boolean hasRestrictedAgencyPriviliges() {
     return isRestrictedAgencyAdmin() && !isAgencyAdmin();
+  }
+
+  /**
+   * Returns the domain user id for operations scoped to a concrete agency administrator.
+   * Platform and tenant administrators are not guaranteed to have this custom Keycloak claim.
+   */
+  @JsonIgnore
+  public String requireUserId() {
+    if (userId == null || userId.isBlank()) {
+      throw new AccessDeniedException("Domain user id is required for this operation");
+    }
+    return userId;
   }
 
 

--- a/src/main/java/de/caritas/cob/agencyservice/config/AuthenticatedUserConfig.java
+++ b/src/main/java/de/caritas/cob/agencyservice/config/AuthenticatedUserConfig.java
@@ -45,7 +45,7 @@ public class AuthenticatedUserConfig {
     Map<String, Object> claimMap = authenticationToken.getToken().getClaims();
     AuthenticatedUser authenticatedUser = new AuthenticatedUser();
     authenticatedUser.setAccessToken(authenticationToken.getToken().getTokenValue());
-    authenticatedUser.setUserId(getUserAttribute(claimMap, CLAIM_NAME_USER_ID));
+    authenticatedUser.setUserId(getOptionalUserAttribute(claimMap, CLAIM_NAME_USER_ID));
     authenticatedUser.setUsername(decodeUsername(getUserAttribute(claimMap, CLAIM_NAME_USERNAME)));
     authenticatedUser.setTenantId(getTenantId(claimMap));
     authenticatedUser.setRoles(extractRealmRoles(authenticationToken.getToken()).stream().collect(
@@ -79,6 +79,11 @@ public class AuthenticatedUserConfig {
       throw new KeycloakException("Keycloak user attribute '" + claimValue + "' not found.");
     }
     return claimMap.get(claimValue).toString();
+  }
+
+  private String getOptionalUserAttribute(Map<String, Object> claimMap, String claimValue) {
+    Object value = claimMap.get(claimValue);
+    return value == null ? null : value.toString();
   }
 
   private Long getTenantId(Map<String, Object> claimMap) {

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/service/agency/AgencyAdminSearchServiceIT.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/service/agency/AgencyAdminSearchServiceIT.java
@@ -69,7 +69,7 @@ class AgencyAdminSearchServiceIT {
   void searchAgency_Should_FindOnlyAgenciesManagedByTheAdmin_WhenUserIsAgencyAdmin() {
     // given
     when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(true);
-    when(authenticatedUser.getUserId()).thenReturn("userId");
+    when(authenticatedUser.requireUserId()).thenReturn("userId");
     when(securityHeaderSupplier.getKeycloakAndCsrfHttpHeaders()).thenReturn(new HttpHeaders());
     when(userAdminServiceApiControllerFactory.createControllerApi()).thenReturn(adminUserControllerApi);
     when(adminUserControllerApi.getAdminAgencies("userId")).thenReturn(Lists.newArrayList(2L, 3L));
@@ -86,7 +86,7 @@ class AgencyAdminSearchServiceIT {
   void searchAgency_Should_FindOnlyAgenciesManagedByTheAdmin_WhenUserIsAgencyAdmin_AndSortByPostcodeAscending() {
     // given
     when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(false);
-    when(authenticatedUser.getUserId()).thenReturn("userId");
+    when(authenticatedUser.requireUserId()).thenReturn("userId");
     when(securityHeaderSupplier.getKeycloakAndCsrfHttpHeaders()).thenReturn(new HttpHeaders());
     when(userAdminServiceApiControllerFactory.createControllerApi()).thenReturn(adminUserControllerApi);
     when(adminUserControllerApi.getAdminAgencies("userId")).thenReturn(Lists.newArrayList(2L, 3L));
@@ -105,7 +105,7 @@ class AgencyAdminSearchServiceIT {
   void searchAgency_Should_FindOnlyAgenciesManagedByTheAdmin_WhenUserIsAgencyAdmin_AndSortByOffline() {
     // given
     when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(false);
-    when(authenticatedUser.getUserId()).thenReturn("userId");
+    when(authenticatedUser.requireUserId()).thenReturn("userId");
     when(securityHeaderSupplier.getKeycloakAndCsrfHttpHeaders()).thenReturn(new HttpHeaders());
     when(userAdminServiceApiControllerFactory.createControllerApi()).thenReturn(adminUserControllerApi);
     when(adminUserControllerApi.getAdminAgencies("userId")).thenReturn(Lists.newArrayList(2L, 3L));
@@ -125,7 +125,7 @@ class AgencyAdminSearchServiceIT {
   void searchAgency_Should_FindOnlyAgenciesManagedByTheAdmin_WhenUserIsAgencyAdmin_AndSortByPostcodeDescending() {
     // given
     when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(false);
-    when(authenticatedUser.getUserId()).thenReturn("userId");
+    when(authenticatedUser.requireUserId()).thenReturn("userId");
     when(securityHeaderSupplier.getKeycloakAndCsrfHttpHeaders()).thenReturn(new HttpHeaders());
     when(userAdminServiceApiControllerFactory.createControllerApi()).thenReturn(adminUserControllerApi);
     when(adminUserControllerApi.getAdminAgencies("userId")).thenReturn(Lists.newArrayList(2L, 3L));
@@ -198,7 +198,7 @@ class AgencyAdminSearchServiceIT {
   void searchAgency_Should_NotFindAnyAgencies_WhenUserIsAgencyAdminButDoesntManageAnyAgencies() {
     // given
     when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(true);
-    when(authenticatedUser.getUserId()).thenReturn("userId");
+    when(authenticatedUser.requireUserId()).thenReturn("userId");
     when(securityHeaderSupplier.getKeycloakAndCsrfHttpHeaders()).thenReturn(new HttpHeaders());
     when(userAdminServiceApiControllerFactory.createControllerApi()).thenReturn(adminUserControllerApi);
     when(adminUserControllerApi.getAdminAgencies("userId")).thenReturn(Lists.newArrayList());

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/service/agency/AgencyAdminSearchTenantSupportServiceTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/service/agency/AgencyAdminSearchTenantSupportServiceTest.java
@@ -157,7 +157,7 @@ class AgencyAdminSearchTenantSupportServiceTest {
     stubTenantIdPath();
     TenantContext.setCurrentTenant(1L);
     when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(true);
-    when(authenticatedUser.getUserId()).thenReturn(USER_ID);
+    when(authenticatedUser.requireUserId()).thenReturn(USER_ID);
     when(authenticatedUser.getTenantId()).thenReturn(null);
     when(userAdminService.getAdminUserAgencyIds(USER_ID)).thenReturn(List.of(100L));
 
@@ -185,7 +185,7 @@ class AgencyAdminSearchTenantSupportServiceTest {
     stubTenantIdPath();
     TenantContext.setCurrentTenant(1L);
     when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(true);
-    when(authenticatedUser.getUserId()).thenReturn(USER_ID);
+    when(authenticatedUser.requireUserId()).thenReturn(USER_ID);
     when(authenticatedUser.getTenantId()).thenReturn(1L);
     when(userAdminService.getAdminUserAgencyIds(USER_ID)).thenReturn(Collections.emptyList());
 

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/service/legal/DepartmentDataProtectionServiceTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/service/legal/DepartmentDataProtectionServiceTest.java
@@ -173,7 +173,7 @@ class DepartmentDataProtectionServiceTest {
   @Test
   void publish_Should_allow_When_restrictedAdminOwnsTheAgency() {
     when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(true);
-    when(authenticatedUser.getUserId()).thenReturn("admin-1");
+    when(authenticatedUser.requireUserId()).thenReturn("admin-1");
     when(userAdminService.getAdminUserAgencyIds("admin-1")).thenReturn(List.of(7L, 9L));
     existingDepartment();
 
@@ -187,7 +187,7 @@ class DepartmentDataProtectionServiceTest {
   @Test
   void publish_Should_throwAccessDenied_When_restrictedAdminDoesNotOwnTheAgency() {
     when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(true);
-    when(authenticatedUser.getUserId()).thenReturn("admin-1");
+    when(authenticatedUser.requireUserId()).thenReturn("admin-1");
     when(userAdminService.getAdminUserAgencyIds("admin-1")).thenReturn(List.of(9L));
 
     assertThatExceptionOfType(AgencyAccessDeniedException.class)
@@ -228,7 +228,7 @@ class DepartmentDataProtectionServiceTest {
   @Test
   void getDepartmentDataPrivacy_Should_throwAccessDenied_When_restrictedAdminDoesNotOwnTheAgency() {
     when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(true);
-    when(authenticatedUser.getUserId()).thenReturn("admin-1");
+    when(authenticatedUser.requireUserId()).thenReturn("admin-1");
     when(userAdminService.getAdminUserAgencyIds("admin-1")).thenReturn(List.of(9L));
 
     assertThatExceptionOfType(AgencyAccessDeniedException.class)

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/service/legal/DepartmentImprintServiceTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/service/legal/DepartmentImprintServiceTest.java
@@ -184,7 +184,7 @@ class DepartmentImprintServiceTest {
   @Test
   void publish_Should_allow_When_restrictedAdminOwnsTheAgency() {
     when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(true);
-    when(authenticatedUser.getUserId()).thenReturn("admin-1");
+    when(authenticatedUser.requireUserId()).thenReturn("admin-1");
     when(userAdminService.getAdminUserAgencyIds("admin-1")).thenReturn(List.of(7L, 9L));
     existingDepartment();
 
@@ -197,7 +197,7 @@ class DepartmentImprintServiceTest {
   @Test
   void publish_Should_throwAccessDenied_When_restrictedAdminDoesNotOwnTheAgency() {
     when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(true);
-    when(authenticatedUser.getUserId()).thenReturn("admin-1");
+    when(authenticatedUser.requireUserId()).thenReturn("admin-1");
     when(userAdminService.getAdminUserAgencyIds("admin-1")).thenReturn(List.of(9L));
 
     assertThatExceptionOfType(AgencyAccessDeniedException.class)
@@ -322,7 +322,7 @@ class DepartmentImprintServiceTest {
   @Test
   void getDepartmentImprint_Should_throwAccessDenied_When_restrictedAdminDoesNotOwnTheAgency() {
     when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(true);
-    when(authenticatedUser.getUserId()).thenReturn("admin-1");
+    when(authenticatedUser.requireUserId()).thenReturn("admin-1");
     when(userAdminService.getAdminUserAgencyIds("admin-1")).thenReturn(List.of(9L));
 
     assertThatExceptionOfType(AgencyAccessDeniedException.class)

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/service/legal/LegalTextAdminServiceTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/service/legal/LegalTextAdminServiceTest.java
@@ -316,7 +316,7 @@ class LegalTextAdminServiceTest {
   @Test
   void assign_Should_throwAccessDenied_When_restrictedAdminDoesNotOwnTheAgency() {
     when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(true);
-    when(authenticatedUser.getUserId()).thenReturn("admin-1");
+    when(authenticatedUser.requireUserId()).thenReturn("admin-1");
     when(userAdminService.getAdminUserAgencyIds("admin-1")).thenReturn(List.of(99L));
 
     assertThatExceptionOfType(AgencyAccessDeniedException.class)

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/validation/validators/AgencyUpdatePermissionValidatorTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/validation/validators/AgencyUpdatePermissionValidatorTest.java
@@ -46,12 +46,12 @@ class AgencyUpdatePermissionValidatorTest {
     // given
     when(validateAgencyDto.getId()).thenReturn(AGENCY_ID);
     when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(true);
-    when(authenticatedUser.getUserId()).thenReturn("userId");
-    when(userAdminService.getAdminUserAgencyIds(authenticatedUser.getUserId())).thenReturn(Lists.newArrayList(AGENCY_ID, 2L));
+    when(authenticatedUser.requireUserId()).thenReturn("userId");
+    when(userAdminService.getAdminUserAgencyIds("userId")).thenReturn(Lists.newArrayList(AGENCY_ID, 2L));
     // when
     agencyUpdatePermissionValidator.validate(validateAgencyDto);
     // then
-    Mockito.verify(userAdminService).getAdminUserAgencyIds(authenticatedUser.getUserId());
+    Mockito.verify(userAdminService).getAdminUserAgencyIds("userId");
   }
 
   @Test
@@ -59,8 +59,8 @@ class AgencyUpdatePermissionValidatorTest {
     // given
     when(validateAgencyDto.getId()).thenReturn(AGENCY_ID);
     when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(true);
-    when(authenticatedUser.getUserId()).thenReturn("userId");
-    when(userAdminService.getAdminUserAgencyIds(authenticatedUser.getUserId())).thenReturn(Lists.newArrayList(2L, 3L));
+    when(authenticatedUser.requireUserId()).thenReturn("userId");
+    when(userAdminService.getAdminUserAgencyIds("userId")).thenReturn(Lists.newArrayList(2L, 3L));
     // when, then
     assertThrows(AgencyAccessDeniedException.class, () -> agencyUpdatePermissionValidator.validate(validateAgencyDto));
   }

--- a/src/test/java/de/caritas/cob/agencyservice/api/controller/AgencyAdminControllerIT.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/controller/AgencyAdminControllerIT.java
@@ -446,7 +446,8 @@ class AgencyAdminControllerIT {
     var extendedConsultingTypeResponseDTO = new ExtendedConsultingTypeResponseDTO();
     when(consultingTypeManager.getConsultingTypeSettings(anyInt()))
         .thenReturn(extendedConsultingTypeResponseDTO);
-    when(userAdminService.getAdminUserAgencyIds(authenticatedUser.getUserId())).thenReturn(
+    when(authenticatedUser.requireUserId()).thenReturn("userId");
+    when(userAdminService.getAdminUserAgencyIds("userId")).thenReturn(
         Lists.newArrayList(1L));
 
     UpdateAgencyDTO agencyDTO = new UpdateAgencyDTO()
@@ -489,7 +490,8 @@ class AgencyAdminControllerIT {
     when(consultingTypeManager.getConsultingTypeSettings(anyInt()))
         .thenReturn(extendedConsultingTypeResponseDTO);
     when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(true);
-    when(userAdminService.getAdminUserAgencyIds(authenticatedUser.getUserId())).thenReturn(
+    when(authenticatedUser.requireUserId()).thenReturn("userId");
+    when(userAdminService.getAdminUserAgencyIds("userId")).thenReturn(
         Lists.newArrayList(2L, 3L));
 
     UpdateAgencyDTO agencyDTO = new UpdateAgencyDTO()

--- a/src/test/java/de/caritas/cob/agencyservice/api/util/AuthenticatedUserTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/util/AuthenticatedUserTest.java
@@ -1,8 +1,12 @@
 package de.caritas.cob.agencyservice.api.util;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.security.access.AccessDeniedException;
 
 @RunWith(MockitoJUnitRunner.class)
 public class AuthenticatedUserTest {
@@ -12,15 +16,34 @@ public class AuthenticatedUserTest {
     new AuthenticatedUser(null, null, null, null, null);
   }
 
-  @Test(expected = NullPointerException.class)
-  public void AuthenticatedUser_Should_ThrowNullPointerExceptionWhenUserIdIsNull() {
+  @Test
+  public void AuthenticatedUser_Should_AllowUserIdToBeNull() {
     AuthenticatedUser authenticatedUser = new AuthenticatedUser();
     authenticatedUser.setUserId(null);
+
+    assertThat(authenticatedUser.getUserId()).isNull();
   }
 
   @Test(expected = NullPointerException.class)
   public void AuthenticatedUser_Should_ThrowNullPointerExceptionWhenUsernameIsNull() {
     AuthenticatedUser authenticatedUser = new AuthenticatedUser();
     authenticatedUser.setUsername(null);
+  }
+
+  @Test
+  public void requireUserId_Should_ReturnDomainUserId_WhenPresent() {
+    AuthenticatedUser authenticatedUser = new AuthenticatedUser();
+    authenticatedUser.setUserId("domain-user-id");
+
+    assertThat(authenticatedUser.requireUserId()).isEqualTo("domain-user-id");
+  }
+
+  @Test
+  public void requireUserId_Should_ThrowAccessDeniedException_WhenMissing() {
+    AuthenticatedUser authenticatedUser = new AuthenticatedUser();
+
+    assertThatExceptionOfType(AccessDeniedException.class)
+        .isThrownBy(authenticatedUser::requireUserId)
+        .withMessage("Domain user id is required for this operation");
   }
 }

--- a/src/test/java/de/caritas/cob/agencyservice/config/AuthenticatedUserConfigTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/config/AuthenticatedUserConfigTest.java
@@ -1,0 +1,41 @@
+package de.caritas.cob.agencyservice.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+import org.junit.After;
+import org.junit.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+public class AuthenticatedUserConfigTest {
+
+  private final AuthenticatedUserConfig authenticatedUserConfig = new AuthenticatedUserConfig();
+
+  @After
+  public void resetRequestContext() {
+    RequestContextHolder.resetRequestAttributes();
+  }
+
+  @Test
+  public void getAuthenticatedUser_Should_AllowAgencyAdminWithoutDomainUserId() {
+    var jwt = Jwt.withTokenValue("test-token")
+        .header("alg", "none")
+        .claim("username", "platform-admin")
+        .claim("realm_access", Map.of("roles", List.of("agency-admin")))
+        .build();
+    var request = new MockHttpServletRequest();
+    request.setUserPrincipal(new JwtAuthenticationToken(jwt));
+    RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+
+    var authenticatedUser = authenticatedUserConfig.getAuthenticatedUser();
+
+    assertThat(authenticatedUser.getUserId()).isNull();
+    assertThat(authenticatedUser.getUsername()).isEqualTo("platform-admin");
+    assertThat(authenticatedUser.isAgencyAdmin()).isTrue();
+  }
+}


### PR DESCRIPTION
## Summary

- allow platform and tenant agency administrators to authenticate without the custom domain `userId` claim
- keep `username` mandatory and do not substitute the Keycloak subject for the domain id
- require the domain id explicitly for restricted-agency authorization paths, returning HTTP 403 when it is unavailable
- cover optional and required claim behavior with focused tests

## Verification

- `./mvnw -Dtest=AuthenticatedUserConfigTest,AuthenticatedUserTest,AgencyAdminControllerAuthorizationIT,AgencyTenantValidatorTest,AgencyUpdatePermissionValidatorTest,AgencyAdminSearchTenantSupportServiceTest,DepartmentDataProtectionServiceTest,DepartmentImprintServiceTest,LegalTextAdminServiceTest test` — 109 tests passed
- `git diff --check` — passed
- broader `AgencyAdminSearchServiceIT` remains blocked by the existing H2 schema drift (`agency_topic.dpp_id` is missing); this reproduces independently of this claim change

Closes OpenResilienceInitiative/ORISO-AgencyService#143

🤖 Generated with [Claude Code](https://claude.com/claude-code)
