### PR TITLE
Promote pre-dev → dev

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,75 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+
+language: en-US
+
+tone_instructions: "Be a strict, practical ORISO reviewer for this Spring Boot service. Keep comments concise, concrete, and focused on correctness, mergeability, privacy, security, tests, and maintainability."
+
+reviews:
+  profile: assertive
+  request_changes_workflow: true
+  high_level_summary: true
+  review_status: true
+  review_details: true
+  poem: false
+
+  auto_review:
+    enabled: true
+    description_keyword: "coderabbit: review"
+    auto_incremental_review: false
+    drafts: false
+    labels:
+      - "coderabbit"
+    base_branches:
+      - "dev"
+
+  path_filters:
+    - "!target/**"
+    - "!**/generated/**"
+    - "src/**"
+    - "pom.xml"
+    - ".github/**"
+    - "*.md"
+
+  path_instructions:
+    - path: "src/main/**/*.java"
+      instructions: |
+        Check behavior against the surrounding ORISO flow, not only types. Flag
+        missing transaction boundaries, swallowed exceptions, N+1 queries, and
+        privacy regressions around Matrix identifiers, chat content and user data.
+        Configuration must stay environment-driven — never hardcode hosts, IPs or
+        credentials (see ADR-005 / finding DB-M04).
+    - path: "src/main/resources/db/**"
+      instructions: |
+        Liquibase changesets are append-only. Flag edits to already-applied
+        changesets, missing rollback, and changes that are not idempotent.
+    - path: "src/test/**/*.java"
+      instructions: |
+        Tests must be able to fail. Flag over-mocking that hides the defect,
+        assertions that cannot break, and missing edge cases.
+
+  pre_merge_checks:
+    title:
+      mode: warning
+      requirements: "Use a concise conventional title that names the affected ORISO area."
+    description:
+      mode: warning
+    custom_checks:
+      - name: "Validation evidence"
+        mode: error
+        instructions: |
+          Pass for docs/config-only PRs. For behavior-affecting product code,
+          pass only if the PR includes relevant automated tests or clearly lists
+          the exact validation command and result. Fail if product behavior
+          changed with no test/validation evidence and no explicit rationale.
+
+knowledge_base:
+  code_guidelines:
+    enabled: true
+    filePatterns:
+      - "README.md"
+      - ".understand-anything/README.md"
+      - ".understand-anything/ARCHITECTURE.md"
+      - ".understand-anything/ORISO-ECOSYSTEM.md"
+
+chat:
+  auto_reply: true

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,10 @@
+ORISO AgencyService
+Copyright 2025-2026 Open Resilience Initiative
+
+This repository is a modified version of Onlineberatung/onlineBeratung-agencyService
+(original work Copyright virtualidentity AG and contributors /
+Caritas Deutschland, licensed under AGPL-3.0).
+
+This version has been modified by the Open Resilience Initiative,
+2025-2026. The git history is the record of modifications
+(AGPL-3.0 section 5(a)).

--- a/api/agencyadminservice.yaml
+++ b/api/agencyadminservice.yaml
@@ -1123,14 +1123,16 @@ components:
       properties:
         field:
           type: string
-          example: 'name|description|postcode|city|teamAgency|offline'
+          example: 'id|name|description|postcode|city|teamAgency|offline|createDate'
           enum:
+            - 'id'
             - 'name'
             - 'description'
             - 'postCode'
             - 'city'
             - 'teamAgency'
             - 'offline'
+            - 'createDate'
         order:
           type: string
           example: 'ASC|DESC'

--- a/api/agencyadminservice.yaml
+++ b/api/agencyadminservice.yaml
@@ -344,6 +344,149 @@ paths:
       security:
         - Bearer: [ ]
 
+  /agencyadmin/legaltexts:
+    get:
+      tags:
+        - admin-agency-controller
+      summary: 'List the caller tenant''s shared legal texts of one kind, each with its department
+      usage count ("used by N departments", ADR-014). [Authorization: Role: agency-admin or
+      restricted-agency-admin]'
+      operationId: getLegalTexts
+      parameters:
+        - name: kind
+          in: query
+          description: Which library to list (data privacy policies or imprints)
+          required: true
+          schema:
+            type: string
+            enum: [ DPP, IMPRINT ]
+      responses:
+        200:
+          description: OK - the tenant's legal texts of that kind
+          content:
+            'application/json':
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/LegalTextAdminDTO'
+        401:
+          description: UNAUTHORIZED - no/invalid role/authorization
+        500:
+          description: INTERNAL SERVER ERROR - server encountered unexpected condition
+      security:
+        - Bearer: [ ]
+    post:
+      tags:
+        - admin-agency-controller
+      summary: 'Create a shared legal text owned by the caller''s tenant (ADR-014).
+      [Authorization: Role: agency-admin or restricted-agency-admin]'
+      operationId: createLegalText
+      requestBody:
+        content:
+          'application/json':
+            schema:
+              $ref: '#/components/schemas/CreateLegalTextDTO'
+        required: true
+      responses:
+        200:
+          description: OK - legal text stored
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/LegalTextAdminDTO'
+        400:
+          description: BAD REQUEST - invalid/incomplete request (e.g. blank label)
+        401:
+          description: UNAUTHORIZED - no/invalid role/authorization
+        500:
+          description: INTERNAL SERVER ERROR - server encountered unexpected condition
+      security:
+        - Bearer: [ ]
+
+  /agencyadmin/legaltexts/{legalTextId}:
+    put:
+      tags:
+        - admin-agency-controller
+      summary: 'Update a shared legal text (label, multilingual content, publication status).
+      Changes apply to every department referencing the text. [Authorization: Role: agency-admin
+      or restricted-agency-admin, scoped to the owning tenant]'
+      operationId: updateLegalText
+      parameters:
+        - name: legalTextId
+          in: path
+          description: Legal text id
+          required: true
+          schema:
+            type: integer
+            format: int64
+      requestBody:
+        content:
+          'application/json':
+            schema:
+              $ref: '#/components/schemas/UpdateLegalTextDTO'
+        required: true
+      responses:
+        200:
+          description: OK - legal text updated
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/LegalTextAdminDTO'
+        400:
+          description: BAD REQUEST - invalid request, or caller may not edit this tenant's text
+        401:
+          description: UNAUTHORIZED - no/invalid role/authorization
+        404:
+          description: NOT FOUND - legal text not found
+        500:
+          description: INTERNAL SERVER ERROR - server encountered unexpected condition
+      security:
+        - Bearer: [ ]
+
+  /agencyadmin/agencies/{agencyId}/topics/{topicId}/legaltext-assignment:
+    put:
+      tags:
+        - admin-agency-controller
+      summary: 'Assign a shared legal text to a department''s DPP or imprint slot, or clear the
+      slot (null = the tenant-level fallback document applies). The text''s kind must match the
+      slot and the text must belong to the agency''s tenant. [Authorization: Role: agency-admin or
+      restricted-agency-admin scoped to its own agencies]'
+      operationId: assignDepartmentLegalText
+      parameters:
+        - name: agencyId
+          in: path
+          description: Agency Id (Beratungszentrum)
+          required: true
+          schema:
+            type: integer
+            format: int64
+        - name: topicId
+          in: path
+          description: Topic Id (Fachbereich)
+          required: true
+          schema:
+            type: integer
+            format: int64
+      requestBody:
+        content:
+          'application/json':
+            schema:
+              $ref: '#/components/schemas/LegalTextAssignmentDTO'
+        required: true
+      responses:
+        204:
+          description: NO CONTENT - assignment stored
+        400:
+          description: BAD REQUEST - kind mismatch, cross-tenant text, or caller may not edit this agency
+        401:
+          description: UNAUTHORIZED - no/invalid role/authorization
+        404:
+          description: NOT FOUND - department or legal text not found
+        500:
+          description: INTERNAL SERVER ERROR - server encountered unexpected condition
+      security:
+        - Bearer: [ ]
+
   /agencyadmin/agencies/{agencyId}/topics/{topicId}/imprint:
     get:
       tags:
@@ -1139,6 +1282,92 @@ components:
           enum:
             - 'ASC'
             - 'DESC'
+
+    LegalTextAdminDTO:
+      type: object
+      required:
+        - id
+        - kind
+        - label
+        - publicationStatus
+        - usageCount
+      properties:
+        id:
+          type: integer
+          format: int64
+        kind:
+          type: string
+          enum: [ DPP, IMPRINT ]
+        label:
+          type: string
+          description: Admin-facing name shown in the legal-text library
+        content:
+          type: string
+          nullable: true
+          description: Stored multilingual content as a JSON language->HTML map string
+        publicationStatus:
+          type: string
+          enum: [ DRAFT, PUBLISHED ]
+        usageCount:
+          type: integer
+          format: int64
+          description: How many departments currently reference this text
+
+    CreateLegalTextDTO:
+      type: object
+      required:
+        - kind
+        - label
+        - content
+      properties:
+        kind:
+          type: string
+          enum: [ DPP, IMPRINT ]
+        label:
+          type: string
+        content:
+          type: object
+          description: Language code (e.g. de, en) to HTML text (multilingual map).
+            Keys with the __meta suffix carry JSON translation metadata instead of HTML.
+          additionalProperties:
+            type: string
+        publish:
+          type: boolean
+          description: 'true = mark PUBLISHED; false/absent = keep as DRAFT'
+          default: false
+
+    UpdateLegalTextDTO:
+      type: object
+      required:
+        - label
+        - content
+      properties:
+        label:
+          type: string
+        content:
+          type: object
+          description: Language code (e.g. de, en) to HTML text (multilingual map).
+            Keys with the __meta suffix carry JSON translation metadata instead of HTML.
+          additionalProperties:
+            type: string
+        publish:
+          type: boolean
+          default: false
+
+    LegalTextAssignmentDTO:
+      type: object
+      required:
+        - kind
+      properties:
+        kind:
+          type: string
+          enum: [ DPP, IMPRINT ]
+          description: Which slot of the department to assign
+        legalTextId:
+          type: integer
+          format: int64
+          nullable: true
+          description: Legal text to reference; null clears the slot (tenant fallback applies)
 
     DepartmentDataProtectionDTO:
       type: object

--- a/api/agencyadminservice.yaml
+++ b/api/agencyadminservice.yaml
@@ -349,8 +349,8 @@ paths:
       tags:
         - admin-agency-controller
       summary: 'List the caller tenant''s shared legal texts of one kind, each with its department
-      usage count ("used by N departments", ADR-014). [Authorization: Role: agency-admin or
-      restricted-agency-admin]'
+      usage count ("used by N departments", ADR-014). Library CRUD is full-admin only: a shared
+      text applies tenant-wide. [Authorization: Role: agency-admin]'
       operationId: getLegalTexts
       parameters:
         - name: kind
@@ -379,7 +379,7 @@ paths:
       tags:
         - admin-agency-controller
       summary: 'Create a shared legal text owned by the caller''s tenant (ADR-014).
-      [Authorization: Role: agency-admin or restricted-agency-admin]'
+      [Authorization: Role: agency-admin — full admins only, see GET]'
       operationId: createLegalText
       requestBody:
         content:
@@ -407,9 +407,10 @@ paths:
     put:
       tags:
         - admin-agency-controller
-      summary: 'Update a shared legal text (label, multilingual content, publication status).
-      Changes apply to every department referencing the text. [Authorization: Role: agency-admin
-      or restricted-agency-admin, scoped to the owning tenant]'
+      summary: 'Update a shared legal text (label, multilingual content, optionally publication
+      status — omitted publish keeps the current status). Changes apply to every department
+      referencing the text. [Authorization: Role: agency-admin — full admins only, scoped to the
+      owning tenant]'
       operationId: updateLegalText
       parameters:
         - name: legalTextId
@@ -1352,7 +1353,9 @@ components:
             type: string
         publish:
           type: boolean
-          default: false
+          nullable: true
+          description: 'true = PUBLISHED, false = DRAFT; omitted/null = keep the current
+            publication status (a label/content-only update never unpublishes)'
 
     LegalTextAssignmentDTO:
       type: object

--- a/api/agencyadminservice.yaml
+++ b/api/agencyadminservice.yaml
@@ -449,7 +449,8 @@ paths:
       tags:
         - admin-agency-controller
       summary: 'Assign a shared legal text to a department''s DPP or imprint slot, or clear the
-      slot (null = the tenant-level fallback document applies). The text''s kind must match the
+      slot (null = department falls back to its own inline content, content_dpp/content_imprint;
+      tenant-level fallback is future work, ADR-014 / #136). The text''s kind must match the
       slot and the text must belong to the agency''s tenant. [Authorization: Role: agency-admin or
       restricted-agency-admin scoped to its own agencies]'
       operationId: assignDepartmentLegalText
@@ -1370,7 +1371,9 @@ components:
           type: integer
           format: int64
           nullable: true
-          description: Legal text to reference; null clears the slot (tenant fallback applies)
+          description: 'Legal text to reference; null clears the slot — the department falls back
+            to its own inline content (content_dpp/content_imprint). Tenant-level fallback is
+            future work (ADR-014 / #136).'
 
     DepartmentDataProtectionDTO:
       type: object

--- a/api/components/agency-settings.yaml
+++ b/api/components/agency-settings.yaml
@@ -88,6 +88,51 @@ components:
         voiceMessagesSupervisionChats:
           type: boolean
           example: true
+        mediaUpload:
+          type: boolean
+          example: true
+        mediaUploadAnonymousChats:
+          type: boolean
+          example: true
+        mediaUploadOneOnOneChats:
+          type: boolean
+          example: true
+        mediaUploadGroupChats:
+          type: boolean
+          example: true
+        mediaUploadSupervisionChats:
+          type: boolean
+          example: true
+        mediaInlineDisplay:
+          type: boolean
+          example: true
+        mediaInlineDisplayAnonymousChats:
+          type: boolean
+          example: true
+        mediaInlineDisplayOneOnOneChats:
+          type: boolean
+          example: true
+        mediaInlineDisplayGroupChats:
+          type: boolean
+          example: true
+        mediaInlineDisplaySupervisionChats:
+          type: boolean
+          example: true
+        mediaAiScan:
+          type: boolean
+          example: true
+        mediaAiScanAnonymousChats:
+          type: boolean
+          example: true
+        mediaAiScanOneOnOneChats:
+          type: boolean
+          example: true
+        mediaAiScanGroupChats:
+          type: boolean
+          example: true
+        mediaAiScanSupervisionChats:
+          type: boolean
+          example: true
 
     AgencyAdminControls:
       type: object
@@ -225,9 +270,66 @@ components:
           type: boolean
           example: true
           description: "Enable voice messages when a user is in supervision mode."
-        featureAttachmentUploadDisabled:
+        featureMediaUploadEnabled:
+          type: boolean
+          example: true
+          description: "Master toggle: may images/media be uploaded into chats at all. Replaces the retired featureAttachmentUploadDisabled (ADR-015)."
+        featureMediaUploadAnonymousChatsEnabled:
+          type: boolean
+          example: true
+          description: "Enable media upload in anonymous chats."
+        featureMediaUploadOneOnOneChatsEnabled:
+          type: boolean
+          example: true
+          description: "Enable media upload in 1-on-1 chats."
+        featureMediaUploadGroupChatsEnabled:
+          type: boolean
+          example: true
+          description: "Enable media upload in group chats."
+        featureMediaUploadSupervisionChatsEnabled:
+          type: boolean
+          example: true
+          description: "Enable media upload when a user is in supervision mode."
+        featureMediaInlineDisplayEnabled:
+          type: boolean
+          example: true
+          description: "Master toggle: render media as scaled thumbnails (on) or deliver as downloadable file only (off). The virus-scan requirement is attached to this switch."
+        featureMediaInlineDisplayAnonymousChatsEnabled:
+          type: boolean
+          example: true
+          description: "Inline media display in anonymous chats."
+        featureMediaInlineDisplayOneOnOneChatsEnabled:
+          type: boolean
+          example: true
+          description: "Inline media display in 1-on-1 chats."
+        featureMediaInlineDisplayGroupChatsEnabled:
+          type: boolean
+          example: true
+          description: "Inline media display in group chats."
+        featureMediaInlineDisplaySupervisionChatsEnabled:
+          type: boolean
+          example: true
+          description: "Inline media display when a user is in supervision mode."
+        featureMediaAiScanEnabled:
           type: boolean
           example: false
+          description: "Master toggle: AI content check sets the media check state automatically; off = blurred until counsellor click-to-reveal."
+        featureMediaAiScanAnonymousChatsEnabled:
+          type: boolean
+          example: false
+          description: "AI media scan for anonymous chats."
+        featureMediaAiScanOneOnOneChatsEnabled:
+          type: boolean
+          example: false
+          description: "AI media scan for 1-on-1 chats."
+        featureMediaAiScanGroupChatsEnabled:
+          type: boolean
+          example: false
+          description: "AI media scan for group chats."
+        featureMediaAiScanSupervisionChatsEnabled:
+          type: boolean
+          example: false
+          description: "AI media scan when a user is in supervision mode."
         featureToolsOICDToken:
           type: string
           example: "1234-1234-1234-1234"

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,6 @@
     <maven.compiler.target>21</maven.compiler.target>
     <hibernate.search.version>6.1.1.Final</hibernate.search.version>
     <springfox.boot.starter.version>3.0.0</springfox.boot.starter.version>
-    <sentry.version>8.46.0</sentry.version>
     <owasp.java.html.sanitizer>20211018.1</owasp.java.html.sanitizer>
   </properties>
 
@@ -107,16 +106,6 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-freemarker</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.sentry</groupId>
-      <artifactId>sentry-spring-boot-4-starter</artifactId>
-      <version>${sentry.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>io.sentry</groupId>
-      <artifactId>sentry-logback</artifactId>
-      <version>${sentry.version}</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>

--- a/src/main/java/de/caritas/cob/agencyservice/api/admin/controller/AgencyAdminController.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/admin/controller/AgencyAdminController.java
@@ -365,8 +365,9 @@ public class AgencyAdminController implements AgencyadminApi {
   }
 
   /**
-   * Assigns a shared legal text to a department's DPP or imprint slot, or clears the slot
-   * (tenant-level fallback applies again). IDOR/tenant guards live in the service.
+   * Assigns a shared legal text to a department's DPP or imprint slot, or clears the slot (the
+   * department falls back to its own inline content_dpp/content_imprint; tenant-level fallback is
+   * future work, ADR-014 / #136). IDOR/tenant guards live in the service.
    */
   @Override
   public ResponseEntity<Void> assignDepartmentLegalText(

--- a/src/main/java/de/caritas/cob/agencyservice/api/admin/controller/AgencyAdminController.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/admin/controller/AgencyAdminController.java
@@ -8,8 +8,14 @@ import de.caritas.cob.agencyservice.api.admin.service.agency.AgencyAdminSearchSe
 import de.caritas.cob.agencyservice.api.admin.service.agencypostcoderange.AgencyPostcodeRangeAdminService;
 import de.caritas.cob.agencyservice.api.admin.service.legal.DepartmentDataProtectionService;
 import de.caritas.cob.agencyservice.api.admin.service.legal.DepartmentImprintService;
+import de.caritas.cob.agencyservice.api.admin.service.legal.LegalTextAdminService;
+import de.caritas.cob.agencyservice.api.repository.legaltext.LegalTextKind;
 import de.caritas.cob.agencyservice.api.admin.validation.AgencyValidator;
 import de.caritas.cob.agencyservice.api.model.AgencyAdminControls;
+import de.caritas.cob.agencyservice.api.model.CreateLegalTextDTO;
+import de.caritas.cob.agencyservice.api.model.LegalTextAdminDTO;
+import de.caritas.cob.agencyservice.api.model.LegalTextAssignmentDTO;
+import de.caritas.cob.agencyservice.api.model.UpdateLegalTextDTO;
 import de.caritas.cob.agencyservice.api.model.AgencyAdminFullResponseDTO;
 import de.caritas.cob.agencyservice.api.model.AgencyAdminSearchResultDTO;
 import de.caritas.cob.agencyservice.api.model.AgencyDTO;
@@ -53,6 +59,7 @@ public class AgencyAdminController implements AgencyadminApi {
   private final @NonNull AgencyAdminControlsFacade agencyAdminControlsFacade;
   private final @NonNull DepartmentDataProtectionService departmentDataProtectionService;
   private final @NonNull DepartmentImprintService departmentImprintService;
+  private final @NonNull LegalTextAdminService legalTextAdminService;
 
   /**
    * Creates the root hal based navigation entity.
@@ -318,6 +325,69 @@ public class AgencyAdminController implements AgencyadminApi {
             .publicationStatus(
                 DepartmentImprintResponseDTO.PublicationStatusEnum.fromValue(status.name()));
     return ResponseEntity.ok(response);
+  }
+
+  /**
+   * Lists the caller tenant's shared legal texts of one kind, each with its "used by N
+   * departments" count (ADR-014 legal-text library).
+   */
+  @Override
+  public ResponseEntity<List<LegalTextAdminDTO>> getLegalTexts(String kind) {
+    var views = legalTextAdminService.listLegalTexts(LegalTextKind.valueOf(kind));
+    return ResponseEntity.ok(views.stream().map(this::toLegalTextAdminDto).toList());
+  }
+
+  /** Creates a shared legal text owned by the caller's tenant (ADR-014). */
+  @Override
+  public ResponseEntity<LegalTextAdminDTO> createLegalText(
+      CreateLegalTextDTO createLegalTextDTO) {
+    var view =
+        legalTextAdminService.createLegalText(
+            LegalTextKind.valueOf(createLegalTextDTO.getKind().getValue()),
+            createLegalTextDTO.getLabel(),
+            createLegalTextDTO.getContent(),
+            Boolean.TRUE.equals(createLegalTextDTO.getPublish()));
+    return ResponseEntity.ok(toLegalTextAdminDto(view));
+  }
+
+  /** Updates a shared legal text; the change applies to every department referencing it. */
+  @Override
+  public ResponseEntity<LegalTextAdminDTO> updateLegalText(
+      Long legalTextId, UpdateLegalTextDTO updateLegalTextDTO) {
+    var view =
+        legalTextAdminService.updateLegalText(
+            legalTextId,
+            updateLegalTextDTO.getLabel(),
+            updateLegalTextDTO.getContent(),
+            Boolean.TRUE.equals(updateLegalTextDTO.getPublish()));
+    return ResponseEntity.ok(toLegalTextAdminDto(view));
+  }
+
+  /**
+   * Assigns a shared legal text to a department's DPP or imprint slot, or clears the slot
+   * (tenant-level fallback applies again). IDOR/tenant guards live in the service.
+   */
+  @Override
+  public ResponseEntity<Void> assignDepartmentLegalText(
+      Long agencyId, Long topicId, LegalTextAssignmentDTO legalTextAssignmentDTO) {
+    legalTextAdminService.assignDepartmentLegalText(
+        agencyId,
+        topicId,
+        LegalTextKind.valueOf(legalTextAssignmentDTO.getKind().getValue()),
+        legalTextAssignmentDTO.getLegalTextId());
+    return ResponseEntity.noContent().build();
+  }
+
+  private LegalTextAdminDTO toLegalTextAdminDto(
+      de.caritas.cob.agencyservice.api.admin.service.legal.LegalTextAdminView view) {
+    return new LegalTextAdminDTO()
+        .id(view.id())
+        .kind(LegalTextAdminDTO.KindEnum.fromValue(view.kind().name()))
+        .label(view.label())
+        .content(view.content())
+        .publicationStatus(
+            LegalTextAdminDTO.PublicationStatusEnum.fromValue(view.publicationStatus().name()))
+        .usageCount(view.usageCount());
   }
 
   @Override

--- a/src/main/java/de/caritas/cob/agencyservice/api/admin/controller/AgencyAdminController.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/admin/controller/AgencyAdminController.java
@@ -359,7 +359,8 @@ public class AgencyAdminController implements AgencyadminApi {
             legalTextId,
             updateLegalTextDTO.getLabel(),
             updateLegalTextDTO.getContent(),
-            Boolean.TRUE.equals(updateLegalTextDTO.getPublish()));
+            // null = preserve the current publication status (see service javadoc)
+            updateLegalTextDTO.getPublish());
     return ResponseEntity.ok(toLegalTextAdminDto(view));
   }
 

--- a/src/main/java/de/caritas/cob/agencyservice/api/admin/service/agency/AgencyAdminSearchService.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/admin/service/agency/AgencyAdminSearchService.java
@@ -173,7 +173,7 @@ public class AgencyAdminSearchService {
   Predicate agencyAdminFilterPredicate(CriteriaBuilder criteriaBuilder, Root<Agency> root) {
     Predicate tenantScopePredicate = tenantScopePredicate(criteriaBuilder, root);
     if (authenticatedUser.hasRestrictedAgencyPriviliges()) {
-      var adminAgencyIds = userAdminService.getAdminUserAgencyIds(authenticatedUser.getUserId());
+      var adminAgencyIds = userAdminService.getAdminUserAgencyIds(authenticatedUser.requireUserId());
       if (!adminAgencyIds.isEmpty()) {
         return criteriaBuilder.and(
             tenantScopePredicate, createPredicateForAgencyAdmin(criteriaBuilder, root, adminAgencyIds));

--- a/src/main/java/de/caritas/cob/agencyservice/api/admin/service/agency/AgencySettingsService.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/admin/service/agency/AgencySettingsService.java
@@ -1,6 +1,8 @@
 package de.caritas.cob.agencyservice.api.admin.service.agency;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.RuntimeJsonMappingException;
 import de.caritas.cob.agencyservice.api.model.Settings;
@@ -10,17 +12,55 @@ import org.springframework.stereotype.Service;
 @Service
 public class AgencySettingsService {
 
-  private final ObjectMapper objectMapper = new ObjectMapper();
+  /** Retired key, superseded by the featureMediaUpload* family (ADR-015). */
+  private static final String LEGACY_ATTACHMENT_UPLOAD_DISABLED = "featureAttachmentUploadDisabled";
+
+  // Lenient on unknown properties: stored agency settings may still carry keys removed from
+  // the schema (e.g. the retired attachment flag); a read must never fail because of them.
+  private final ObjectMapper objectMapper =
+      new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
   public Settings toSettings(String settingsJson) {
     if (StringUtils.isBlank(settingsJson)) {
       return new Settings();
     }
     try {
-      Settings settings = objectMapper.readValue(settingsJson, Settings.class);
-      return settings != null ? settings : new Settings();
+      JsonNode root = objectMapper.readTree(settingsJson);
+      Settings settings = objectMapper.treeToValue(root, Settings.class);
+      if (settings == null) {
+        return new Settings();
+      }
+      translateLegacyAttachmentUploadDisabled(root, settings);
+      return settings;
     } catch (JsonProcessingException exception) {
       throw new RuntimeJsonMappingException(exception.getMessage());
+    }
+  }
+
+  /**
+   * One-time translation of the retired {@code featureAttachmentUploadDisabled} key (ADR-015): a
+   * stored {@code true} means the agency had switched uploads off, so absent upload-family keys
+   * become {@code false}. Explicitly stored media keys always win; the legacy key itself is never
+   * written back (the schema no longer knows it), so it disappears with the next save.
+   */
+  private void translateLegacyAttachmentUploadDisabled(JsonNode root, Settings settings) {
+    if (!root.path(LEGACY_ATTACHMENT_UPLOAD_DISABLED).asBoolean(false)) {
+      return;
+    }
+    if (settings.getFeatureMediaUploadEnabled() == null) {
+      settings.setFeatureMediaUploadEnabled(false);
+    }
+    if (settings.getFeatureMediaUploadAnonymousChatsEnabled() == null) {
+      settings.setFeatureMediaUploadAnonymousChatsEnabled(false);
+    }
+    if (settings.getFeatureMediaUploadOneOnOneChatsEnabled() == null) {
+      settings.setFeatureMediaUploadOneOnOneChatsEnabled(false);
+    }
+    if (settings.getFeatureMediaUploadGroupChatsEnabled() == null) {
+      settings.setFeatureMediaUploadGroupChatsEnabled(false);
+    }
+    if (settings.getFeatureMediaUploadSupervisionChatsEnabled() == null) {
+      settings.setFeatureMediaUploadSupervisionChatsEnabled(false);
     }
   }
 

--- a/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/DepartmentDataProtectionService.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/DepartmentDataProtectionService.java
@@ -42,7 +42,7 @@ import org.springframework.transaction.annotation.Transactional;
  * translation-metadata convention) carry JSON, not HTML: running them through the HTML sanitizer
  * would corrupt the payload (quotes become entities → invalid JSON), so they are passed through
  * unsanitised. Because this metadata is stored verbatim and later served publicly, it is validated
- * against a strict schema ({@link #assertValidJson}) rather than a mere parse check, so no
+ * against a strict schema (see {@link LegalContentSanitizer}) rather than a mere parse check, so no
  * unsanitised free text can hide behind the suffix.
  */
 @Service
@@ -50,16 +50,10 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class DepartmentDataProtectionService {
 
-  private static final String META_KEY_SUFFIX = "__meta";
-
   private final @NonNull AgencyTopicRepository agencyTopicRepository;
-  private final @NonNull InputSanitizer inputSanitizer;
+  private final @NonNull LegalContentSanitizer legalContentSanitizer;
   private final @NonNull AuthenticatedUser authenticatedUser;
   private final @NonNull UserAdminService userAdminService;
-
-  private final ObjectMapper objectMapper = new ObjectMapper();
-  private final ObjectReader metaJsonReader =
-      objectMapper.readerFor(JsonNode.class).with(DeserializationFeature.FAIL_ON_TRAILING_TOKENS);
 
   /**
    * Sanitises and stores the department's DPP for the given agency × topic. When {@code publish} is
@@ -80,7 +74,7 @@ public class DepartmentDataProtectionService {
 
     assertCallerTenantMatches(department.getAgency());
 
-    var sanitizedJson = toJson(sanitizeTranslations(content));
+    var sanitizedJson = legalContentSanitizer.sanitizeToJson(content);
     var status = publish ? PublicationStatus.PUBLISHED : PublicationStatus.DRAFT;
     var now = LocalDateTime.now();
 
@@ -169,97 +163,5 @@ public class DepartmentDataProtectionService {
   private Long resolveEffectiveTenantId() {
     Long tenantIdFromAuth = authenticatedUser.getTenantId();
     return tenantIdFromAuth != null ? tenantIdFromAuth : TenantContext.getCurrentTenant();
-  }
-
-  private Map<String, String> sanitizeTranslations(Map<String, String> content) {
-    if (content == null) {
-      return Map.of();
-    }
-    return content.entrySet().stream()
-        .filter(entry -> entry.getKey() != null)
-        .collect(
-            Collectors.toMap(
-                Map.Entry::getKey,
-                entry -> sanitizeOrValidateValue(entry.getKey(), entry.getValue()),
-                (existing, replacement) -> replacement,
-                LinkedHashMap::new));
-  }
-
-  /**
-   * {@code __meta}-suffixed keys carry translation metadata as JSON and are stored verbatim after a
-   * strict validation; every other key is OWASP HTML-sanitised.
-   */
-  private String sanitizeOrValidateValue(String key, String value) {
-    var safeValue = value == null ? "" : value;
-    if (key.endsWith(META_KEY_SUFFIX)) {
-      assertValidJson(key, safeValue);
-      return safeValue;
-    }
-    return inputSanitizer.sanitizeAllowingFormattingAndLinks(safeValue);
-  }
-
-  /**
-   * Strictly validates a {@code __meta} translation-metadata payload. Because the value is stored
-   * unsanitised and later served publicly, a mere "parses without error" check is not enough: the
-   * value must be a non-blank JSON object holding only {@code mt} (boolean), {@code src} (string)
-   * and {@code at} (string), with {@code src}/{@code at} non-blank. Blanks, scalars, arrays,
-   * trailing tokens and any unknown field are rejected with a 400.
-   */
-  private void assertValidJson(String key, String value) {
-    if (value == null || value.isBlank()) {
-      throw invalidMeta(key);
-    }
-    final JsonNode node;
-    try {
-      node = metaJsonReader.readValue(value);
-    } catch (JsonProcessingException e) {
-      throw invalidMeta(key);
-    }
-    if (node == null || !node.isObject()) {
-      throw invalidMeta(key);
-    }
-    int knownFields = 0;
-    if (node.has("mt")) {
-      requireBoolean(key, node.get("mt"));
-      knownFields++;
-    }
-    if (node.has("src")) {
-      requireNonBlankText(key, node.get("src"));
-      knownFields++;
-    }
-    if (node.has("at")) {
-      requireNonBlankText(key, node.get("at"));
-      knownFields++;
-    }
-    // any remaining property is an unknown field and must be rejected
-    if (node.size() != knownFields) {
-      throw invalidMeta(key);
-    }
-  }
-
-  private void requireBoolean(String key, JsonNode value) {
-    if (value == null || !value.isBoolean()) {
-      throw invalidMeta(key);
-    }
-  }
-
-  private void requireNonBlankText(String key, JsonNode value) {
-    if (value == null || !value.isTextual() || value.asText().isBlank()) {
-      throw invalidMeta(key);
-    }
-  }
-
-  private BadRequestException invalidMeta(String key) {
-    return new BadRequestException(
-        String.format("Translation metadata key '%s' does not contain valid JSON", key));
-  }
-
-  private String toJson(Map<String, String> sanitized) {
-    try {
-      return objectMapper.writeValueAsString(sanitized);
-    } catch (JsonProcessingException e) {
-      throw new InternalServerErrorException(
-          "Could not serialize department data privacy policy content", e);
-    }
   }
 }

--- a/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/DepartmentDataProtectionService.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/DepartmentDataProtectionService.java
@@ -14,6 +14,7 @@ import de.caritas.cob.agencyservice.api.repository.agency.Agency;
 import de.caritas.cob.agencyservice.api.repository.agencytopic.AgencyTopic;
 import de.caritas.cob.agencyservice.api.repository.agencytopic.AgencyTopicRepository;
 import de.caritas.cob.agencyservice.api.repository.agencytopic.PublicationStatus;
+import de.caritas.cob.agencyservice.api.repository.legaltext.LegalText;
 import de.caritas.cob.agencyservice.api.tenant.TenantContext;
 import de.caritas.cob.agencyservice.api.util.AuthenticatedUser;
 import de.caritas.cob.agencyservice.api.validation.InputSanitizer;
@@ -79,13 +80,25 @@ public class DepartmentDataProtectionService {
 
     assertCallerTenantMatches(department.getAgency());
 
-    department.setContentDpp(toJson(sanitizeTranslations(content)));
-    department.setPublicationStatus(
-        publish ? PublicationStatus.PUBLISHED : PublicationStatus.DRAFT);
-    department.setUpdateDate(LocalDateTime.now());
+    var sanitizedJson = toJson(sanitizeTranslations(content));
+    var status = publish ? PublicationStatus.PUBLISHED : PublicationStatus.DRAFT;
+    var now = LocalDateTime.now();
+
+    LegalText referenced = department.getDpp();
+    if (referenced != null) {
+      // ADR-014: the referenced shared object is the truth — write through to it; the inline
+      // column stays untouched (the read path ignores it once a reference exists).
+      referenced.setContent(sanitizedJson);
+      referenced.setPublicationStatus(status);
+      referenced.setUpdateDate(now);
+    } else {
+      department.setContentDpp(sanitizedJson);
+      department.setPublicationStatus(status);
+    }
+    department.setUpdateDate(now);
     agencyTopicRepository.save(department);
 
-    return department.getPublicationStatus();
+    return status;
   }
 
   /**
@@ -104,6 +117,11 @@ public class DepartmentDataProtectionService {
 
     assertCallerTenantMatches(department.getAgency());
 
+    LegalText referenced = department.getDpp();
+    if (referenced != null) {
+      return new DepartmentDataProtectionView(
+          referenced.getContent(), referenced.getPublicationStatus());
+    }
     return new DepartmentDataProtectionView(
         department.getContentDpp(), department.getPublicationStatus());
   }

--- a/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/DepartmentDataProtectionService.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/DepartmentDataProtectionService.java
@@ -126,11 +126,11 @@ public class DepartmentDataProtectionService {
    */
   private void assertRestrictedAdminOwnsAgency(Long agencyId) {
     if (authenticatedUser.hasRestrictedAgencyPriviliges()) {
-      var adminAgencyIds = userAdminService.getAdminUserAgencyIds(authenticatedUser.getUserId());
+      var adminAgencyIds = userAdminService.getAdminUserAgencyIds(authenticatedUser.requireUserId());
       if (adminAgencyIds == null || !adminAgencyIds.contains(agencyId)) {
         log.warn(
             "Admin user {} may not edit the data privacy policy of agency {}",
-            authenticatedUser.getUserId(),
+            authenticatedUser.requireUserId(),
             agencyId);
         throw new AgencyAccessDeniedException();
       }
@@ -152,7 +152,7 @@ public class DepartmentDataProtectionService {
     if (agency == null || !effectiveTenantId.equals(agency.getTenantId())) {
       log.warn(
           "Admin user {} (tenant {}) may not edit the data privacy policy of agency {} (tenant {})",
-          authenticatedUser.getUserId(),
+          authenticatedUser.requireUserId(),
           effectiveTenantId,
           agency == null ? null : agency.getId(),
           agency == null ? null : agency.getTenantId());

--- a/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/DepartmentImprintService.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/DepartmentImprintService.java
@@ -34,24 +34,19 @@ import org.springframework.transaction.annotation.Transactional;
  * sanitised per translation, and (c) stored as a JSON language→HTML map in {@code
  * agency_topic.content_imprint} with its own draft/published lifecycle, independent of the DPP's.
  *
- * <p>One deviation from the DPP twin: {@code __meta}-suffixed keys (the platform-wide
- * translation-metadata convention) carry JSON, not HTML. They are passed through unsanitised —
- * running them through the HTML sanitizer would destroy the payload — but validated to be
- * well-formed JSON so no unsanitised free text can hide behind the suffix.
+ * <p>{@code __meta}-suffixed keys are handled by the shared {@link LegalContentSanitizer}: passed
+ * through unsanitised but validated against the strict metadata schema — the former lenient
+ * "parses as JSON" check allowed arbitrary unsanitised payloads behind the suffix.
  */
 @Service
 @Slf4j
 @RequiredArgsConstructor
 public class DepartmentImprintService {
 
-  private static final String META_KEY_SUFFIX = "__meta";
-
   private final @NonNull AgencyTopicRepository agencyTopicRepository;
-  private final @NonNull InputSanitizer inputSanitizer;
+  private final @NonNull LegalContentSanitizer legalContentSanitizer;
   private final @NonNull AuthenticatedUser authenticatedUser;
   private final @NonNull UserAdminService userAdminService;
-
-  private final ObjectMapper objectMapper = new ObjectMapper();
 
   /**
    * Sanitises and stores the department's imprint for the given agency × topic. When {@code
@@ -72,7 +67,7 @@ public class DepartmentImprintService {
 
     assertCallerTenantMatches(department.getAgency());
 
-    var sanitizedJson = toJson(sanitizeTranslations(content));
+    var sanitizedJson = legalContentSanitizer.sanitizeToJson(content);
     var status = publish ? PublicationStatus.PUBLISHED : PublicationStatus.DRAFT;
     var now = LocalDateTime.now();
 
@@ -161,46 +156,5 @@ public class DepartmentImprintService {
   private Long resolveEffectiveTenantId() {
     Long tenantIdFromAuth = authenticatedUser.getTenantId();
     return tenantIdFromAuth != null ? tenantIdFromAuth : TenantContext.getCurrentTenant();
-  }
-
-  private Map<String, String> sanitizeTranslations(Map<String, String> content) {
-    if (content == null) {
-      return Map.of();
-    }
-    return content.entrySet().stream()
-        .filter(entry -> entry.getKey() != null)
-        .collect(
-            Collectors.toMap(
-                Map.Entry::getKey,
-                entry -> sanitizeOrValidateValue(entry.getKey(), entry.getValue()),
-                (existing, replacement) -> replacement,
-                LinkedHashMap::new));
-  }
-
-  private String sanitizeOrValidateValue(String key, String value) {
-    var safeValue = value == null ? "" : value;
-    if (key.endsWith(META_KEY_SUFFIX)) {
-      assertValidJson(key, safeValue);
-      return safeValue;
-    }
-    return inputSanitizer.sanitizeAllowingFormattingAndLinks(safeValue);
-  }
-
-  private void assertValidJson(String key, String value) {
-    try {
-      objectMapper.readTree(value);
-    } catch (JsonProcessingException e) {
-      throw new BadRequestException(
-          String.format("Translation metadata key '%s' does not contain valid JSON", key));
-    }
-  }
-
-  private String toJson(Map<String, String> sanitized) {
-    try {
-      return objectMapper.writeValueAsString(sanitized);
-    } catch (JsonProcessingException e) {
-      throw new InternalServerErrorException(
-          "Could not serialize department imprint content", e);
-    }
   }
 }

--- a/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/DepartmentImprintService.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/DepartmentImprintService.java
@@ -11,6 +11,7 @@ import de.caritas.cob.agencyservice.api.repository.agency.Agency;
 import de.caritas.cob.agencyservice.api.repository.agencytopic.AgencyTopic;
 import de.caritas.cob.agencyservice.api.repository.agencytopic.AgencyTopicRepository;
 import de.caritas.cob.agencyservice.api.repository.agencytopic.PublicationStatus;
+import de.caritas.cob.agencyservice.api.repository.legaltext.LegalText;
 import de.caritas.cob.agencyservice.api.tenant.TenantContext;
 import de.caritas.cob.agencyservice.api.util.AuthenticatedUser;
 import de.caritas.cob.agencyservice.api.validation.InputSanitizer;
@@ -71,13 +72,25 @@ public class DepartmentImprintService {
 
     assertCallerTenantMatches(department.getAgency());
 
-    department.setContentImprint(toJson(sanitizeTranslations(content)));
-    department.setPublicationStatusImprint(
-        publish ? PublicationStatus.PUBLISHED : PublicationStatus.DRAFT);
-    department.setUpdateDate(LocalDateTime.now());
+    var sanitizedJson = toJson(sanitizeTranslations(content));
+    var status = publish ? PublicationStatus.PUBLISHED : PublicationStatus.DRAFT;
+    var now = LocalDateTime.now();
+
+    LegalText referenced = department.getImprint();
+    if (referenced != null) {
+      // ADR-014: the referenced shared object is the truth — write through to it; the inline
+      // column stays untouched (the read path ignores it once a reference exists).
+      referenced.setContent(sanitizedJson);
+      referenced.setPublicationStatus(status);
+      referenced.setUpdateDate(now);
+    } else {
+      department.setContentImprint(sanitizedJson);
+      department.setPublicationStatusImprint(status);
+    }
+    department.setUpdateDate(now);
     agencyTopicRepository.save(department);
 
-    return department.getPublicationStatusImprint();
+    return status;
   }
 
   /**
@@ -96,6 +109,11 @@ public class DepartmentImprintService {
 
     assertCallerTenantMatches(department.getAgency());
 
+    LegalText referenced = department.getImprint();
+    if (referenced != null) {
+      return new DepartmentImprintView(
+          referenced.getContent(), referenced.getPublicationStatus());
+    }
     return new DepartmentImprintView(
         department.getContentImprint(), department.getPublicationStatusImprint());
   }

--- a/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/DepartmentImprintService.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/DepartmentImprintService.java
@@ -119,11 +119,11 @@ public class DepartmentImprintService {
    */
   private void assertRestrictedAdminOwnsAgency(Long agencyId) {
     if (authenticatedUser.hasRestrictedAgencyPriviliges()) {
-      var adminAgencyIds = userAdminService.getAdminUserAgencyIds(authenticatedUser.getUserId());
+      var adminAgencyIds = userAdminService.getAdminUserAgencyIds(authenticatedUser.requireUserId());
       if (adminAgencyIds == null || !adminAgencyIds.contains(agencyId)) {
         log.warn(
             "Admin user {} may not edit the imprint of agency {}",
-            authenticatedUser.getUserId(),
+            authenticatedUser.requireUserId(),
             agencyId);
         throw new AgencyAccessDeniedException();
       }
@@ -145,7 +145,7 @@ public class DepartmentImprintService {
     if (agency == null || !effectiveTenantId.equals(agency.getTenantId())) {
       log.warn(
           "Admin user {} (tenant {}) may not edit the imprint of agency {} (tenant {})",
-          authenticatedUser.getUserId(),
+          authenticatedUser.requireUserId(),
           effectiveTenantId,
           agency == null ? null : agency.getId(),
           agency == null ? null : agency.getTenantId());

--- a/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/LegalContentSanitizer.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/LegalContentSanitizer.java
@@ -1,0 +1,133 @@
+package de.caritas.cob.agencyservice.api.admin.service.legal;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+import de.caritas.cob.agencyservice.api.exception.httpresponses.BadRequestException;
+import de.caritas.cob.agencyservice.api.exception.httpresponses.InternalServerErrorException;
+import de.caritas.cob.agencyservice.api.validation.InputSanitizer;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+/**
+ * The one canonical sanitisation path for admin-authored legal content (department DPP, department
+ * Impressum and the shared ADR-014 legal texts): every translation value is OWASP HTML-sanitised;
+ * {@code __meta}-suffixed keys (the platform-wide translation-metadata convention) carry JSON, not
+ * HTML — running them through the HTML sanitizer would corrupt the payload, so they are passed
+ * through verbatim after a <em>strict</em> schema validation ({@code mt:boolean},
+ * {@code src:string}, {@code at:string}, non-blank, no unknown fields). Because the metadata is
+ * stored verbatim and later served publicly, a mere "parses as JSON" check is not enough — that
+ * used to be the imprint path's behaviour and allowed arbitrary unsanitised JSON payloads behind
+ * the suffix.
+ */
+@Component
+@RequiredArgsConstructor
+public class LegalContentSanitizer {
+
+  private static final String META_KEY_SUFFIX = "__meta";
+
+  private final @NonNull InputSanitizer inputSanitizer;
+
+  private final ObjectMapper objectMapper = new ObjectMapper();
+  private final ObjectReader metaJsonReader =
+      objectMapper.readerFor(JsonNode.class).with(DeserializationFeature.FAIL_ON_TRAILING_TOKENS);
+
+  /**
+   * Sanitises the multilingual content map and serialises it to the stored JSON language→HTML map
+   * string. {@code null} content becomes an empty JSON object.
+   */
+  public String sanitizeToJson(Map<String, String> content) {
+    return toJson(sanitizeTranslations(content));
+  }
+
+  private Map<String, String> sanitizeTranslations(Map<String, String> content) {
+    if (content == null) {
+      return Map.of();
+    }
+    return content.entrySet().stream()
+        .filter(entry -> entry.getKey() != null)
+        .collect(
+            Collectors.toMap(
+                Map.Entry::getKey,
+                entry -> sanitizeOrValidateValue(entry.getKey(), entry.getValue()),
+                (existing, replacement) -> replacement,
+                LinkedHashMap::new));
+  }
+
+  private String sanitizeOrValidateValue(String key, String value) {
+    var safeValue = value == null ? "" : value;
+    if (key.endsWith(META_KEY_SUFFIX)) {
+      assertValidMeta(key, safeValue);
+      return safeValue;
+    }
+    return inputSanitizer.sanitizeAllowingFormattingAndLinks(safeValue);
+  }
+
+  /**
+   * Strictly validates a {@code __meta} translation-metadata payload: a non-blank JSON object
+   * holding only {@code mt} (boolean), {@code src} (string) and {@code at} (string), with
+   * {@code src}/{@code at} non-blank. Blanks, scalars, arrays, trailing tokens and any unknown
+   * field are rejected with a 400.
+   */
+  private void assertValidMeta(String key, String value) {
+    if (value == null || value.isBlank()) {
+      throw invalidMeta(key);
+    }
+    final JsonNode node;
+    try {
+      node = metaJsonReader.readValue(value);
+    } catch (JsonProcessingException e) {
+      throw invalidMeta(key);
+    }
+    if (node == null || !node.isObject()) {
+      throw invalidMeta(key);
+    }
+    int knownFields = 0;
+    if (node.has("mt")) {
+      requireBoolean(key, node.get("mt"));
+      knownFields++;
+    }
+    if (node.has("src")) {
+      requireNonBlankText(key, node.get("src"));
+      knownFields++;
+    }
+    if (node.has("at")) {
+      requireNonBlankText(key, node.get("at"));
+      knownFields++;
+    }
+    if (node.size() != knownFields) {
+      throw invalidMeta(key);
+    }
+  }
+
+  private void requireBoolean(String key, JsonNode value) {
+    if (value == null || !value.isBoolean()) {
+      throw invalidMeta(key);
+    }
+  }
+
+  private void requireNonBlankText(String key, JsonNode value) {
+    if (value == null || !value.isTextual() || value.asText().isBlank()) {
+      throw invalidMeta(key);
+    }
+  }
+
+  private BadRequestException invalidMeta(String key) {
+    return new BadRequestException(
+        String.format("Translation metadata key '%s' does not contain valid JSON", key));
+  }
+
+  private String toJson(Map<String, String> sanitized) {
+    try {
+      return objectMapper.writeValueAsString(sanitized);
+    } catch (JsonProcessingException e) {
+      throw new InternalServerErrorException("Could not serialize legal text content", e);
+    }
+  }
+}

--- a/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/LegalTextAdminService.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/LegalTextAdminService.java
@@ -113,7 +113,7 @@ public class LegalTextAdminService {
     if (authenticatedUser.hasRestrictedAgencyPriviliges()) {
       log.warn(
           "Restricted admin user {} may not manage the tenant-wide legal-text library",
-          authenticatedUser.getUserId());
+          authenticatedUser.requireUserId());
       throw new AgencyAccessDeniedException();
     }
   }
@@ -191,7 +191,7 @@ public class LegalTextAdminService {
     if (!effectiveTenantId.equals(text.getTenantId())) {
       log.warn(
           "Admin user {} (tenant {}) may not edit legal text {} (tenant {})",
-          authenticatedUser.getUserId(),
+          authenticatedUser.requireUserId(),
           effectiveTenantId,
           text.getId(),
           text.getTenantId());
@@ -224,11 +224,11 @@ public class LegalTextAdminService {
    */
   private void assertRestrictedAdminOwnsAgency(Long agencyId) {
     if (authenticatedUser.hasRestrictedAgencyPriviliges()) {
-      var adminAgencyIds = userAdminService.getAdminUserAgencyIds(authenticatedUser.getUserId());
+      var adminAgencyIds = userAdminService.getAdminUserAgencyIds(authenticatedUser.requireUserId());
       if (adminAgencyIds == null || !adminAgencyIds.contains(agencyId)) {
         log.warn(
             "Admin user {} may not assign legal texts of agency {}",
-            authenticatedUser.getUserId(),
+            authenticatedUser.requireUserId(),
             agencyId);
         throw new AgencyAccessDeniedException();
       }
@@ -244,7 +244,7 @@ public class LegalTextAdminService {
     if (agency == null || !effectiveTenantId.equals(agency.getTenantId())) {
       log.warn(
           "Admin user {} (tenant {}) may not assign legal texts of agency {} (tenant {})",
-          authenticatedUser.getUserId(),
+          authenticatedUser.requireUserId(),
           effectiveTenantId,
           agency == null ? null : agency.getId(),
           agency == null ? null : agency.getTenantId());

--- a/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/LegalTextAdminService.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/LegalTextAdminService.java
@@ -57,9 +57,17 @@ public class LegalTextAdminService {
   private final ObjectReader metaJsonReader =
       objectMapper.readerFor(JsonNode.class).with(DeserializationFeature.FAIL_ON_TRAILING_TOKENS);
 
-  /** Lists the caller tenant's legal texts of one kind, each with its department usage count. */
+  /**
+   * Lists the caller tenant's legal texts of one kind, each with its department usage count.
+   *
+   * <p>Library CRUD is full-agency-admin only: a shared text applies to every referencing
+   * department, so a restricted admin (scoped to specific agencies) must not read or change
+   * tenant-wide legal content. Restricted admins keep the per-department publish endpoints and the
+   * agency-scoped assignment below.
+   */
   @Transactional(readOnly = true)
   public List<LegalTextAdminView> listLegalTexts(LegalTextKind kind) {
+    assertFullAgencyAdmin();
     Long tenantId = resolveEffectiveTenantId();
     List<LegalText> texts =
         isUnrestricted(tenantId)
@@ -68,10 +76,11 @@ public class LegalTextAdminService {
     return texts.stream().map(this::toView).toList();
   }
 
-  /** Creates a legal text owned by the caller's tenant. */
+  /** Creates a legal text owned by the caller's tenant (full agency admins only). */
   @Transactional
   public LegalTextAdminView createLegalText(
       LegalTextKind kind, String label, Map<String, String> content, boolean publish) {
+    assertFullAgencyAdmin();
     assertValidLabel(label);
     var now = LocalDateTime.now();
     var text =
@@ -87,10 +96,15 @@ public class LegalTextAdminService {
     return toView(legalTextRepository.save(text));
   }
 
-  /** Updates label, content and publication status of a caller-tenant text. */
+  /**
+   * Updates label, content and (optionally) publication status of a caller-tenant text (full
+   * agency admins only). A {@code null} publish flag preserves the current publication status — a
+   * label/content-only update must never silently unpublish a published text.
+   */
   @Transactional
   public LegalTextAdminView updateLegalText(
-      Long legalTextId, String label, Map<String, String> content, boolean publish) {
+      Long legalTextId, String label, Map<String, String> content, Boolean publish) {
+    assertFullAgencyAdmin();
     LegalText text =
         legalTextRepository.findById(legalTextId).orElseThrow(NotFoundException::new);
     assertCallerTenantOwnsText(text);
@@ -98,9 +112,24 @@ public class LegalTextAdminService {
 
     text.setLabel(label);
     text.setContent(toJson(sanitizeTranslations(content)));
-    text.setPublicationStatus(publish ? PublicationStatus.PUBLISHED : PublicationStatus.DRAFT);
+    if (publish != null) {
+      text.setPublicationStatus(publish ? PublicationStatus.PUBLISHED : PublicationStatus.DRAFT);
+    }
     text.setUpdateDate(LocalDateTime.now());
     return toView(legalTextRepository.save(text));
+  }
+
+  /**
+   * Library CRUD guard: shared texts apply tenant-wide, so restricted agency admins (scoped to
+   * specific agencies) are rejected here and use the per-department endpoints instead.
+   */
+  private void assertFullAgencyAdmin() {
+    if (authenticatedUser.hasRestrictedAgencyPriviliges()) {
+      log.warn(
+          "Restricted admin user {} may not manage the tenant-wide legal-text library",
+          authenticatedUser.getUserId());
+      throw new AgencyAccessDeniedException();
+    }
   }
 
   /**

--- a/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/LegalTextAdminService.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/LegalTextAdminService.java
@@ -214,12 +214,19 @@ public class LegalTextAdminService {
 
   /** A department must never reference another Träger's document. */
   private void assertTextBelongsToAgencyTenant(LegalText text, Agency agency) {
-    Long textTenant = text.getTenantId();
     Long agencyTenant = agency == null ? null : agency.getTenantId();
-    if (textTenant != null && agencyTenant != null && !textTenant.equals(agencyTenant)) {
+    // Single-tenant / technical agencies (tenant null or 0) carry no cross-tenant risk.
+    if (isUnrestricted(agencyTenant)) {
+      return;
+    }
+    // A tenant-scoped agency may only reference a text of its own Träger. A null-tenant
+    // (global/orphan) or different-tenant text is rejected — a null tenant must not bypass the
+    // cross-tenant guard and leak into a specific Träger's department in multi-tenant mode.
+    Long textTenant = text.getTenantId();
+    if (!agencyTenant.equals(textTenant)) {
       throw new BadRequestException(
           String.format(
-              "Legal text %d belongs to tenant %d, not to the agency's tenant %d",
+              "Legal text %d belongs to tenant %s, not to the agency's tenant %d",
               text.getId(), textTenant, agencyTenant));
     }
   }

--- a/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/LegalTextAdminService.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/LegalTextAdminService.java
@@ -45,17 +45,11 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class LegalTextAdminService {
 
-  private static final String META_KEY_SUFFIX = "__meta";
-
   private final @NonNull LegalTextRepository legalTextRepository;
   private final @NonNull AgencyTopicRepository agencyTopicRepository;
-  private final @NonNull InputSanitizer inputSanitizer;
+  private final @NonNull LegalContentSanitizer legalContentSanitizer;
   private final @NonNull AuthenticatedUser authenticatedUser;
   private final @NonNull UserAdminService userAdminService;
-
-  private final ObjectMapper objectMapper = new ObjectMapper();
-  private final ObjectReader metaJsonReader =
-      objectMapper.readerFor(JsonNode.class).with(DeserializationFeature.FAIL_ON_TRAILING_TOKENS);
 
   /** Lists the caller tenant's legal texts of one kind, each with its department usage count. */
   @Transactional(readOnly = true)
@@ -79,7 +73,7 @@ public class LegalTextAdminService {
             .tenantId(resolveEffectiveTenantId())
             .kind(kind)
             .label(label)
-            .content(toJson(sanitizeTranslations(content)))
+            .content(legalContentSanitizer.sanitizeToJson(content))
             .publicationStatus(publish ? PublicationStatus.PUBLISHED : PublicationStatus.DRAFT)
             .createDate(now)
             .updateDate(now)
@@ -97,7 +91,7 @@ public class LegalTextAdminService {
     assertValidLabel(label);
 
     text.setLabel(label);
-    text.setContent(toJson(sanitizeTranslations(content)));
+    text.setContent(legalContentSanitizer.sanitizeToJson(content));
     text.setPublicationStatus(publish ? PublicationStatus.PUBLISHED : PublicationStatus.DRAFT);
     text.setUpdateDate(LocalDateTime.now());
     return toView(legalTextRepository.save(text));
@@ -236,79 +230,5 @@ public class LegalTextAdminService {
   private Long resolveEffectiveTenantId() {
     Long tenantIdFromAuth = authenticatedUser.getTenantId();
     return tenantIdFromAuth != null ? tenantIdFromAuth : TenantContext.getCurrentTenant();
-  }
-
-  private Map<String, String> sanitizeTranslations(Map<String, String> content) {
-    if (content == null) {
-      return Map.of();
-    }
-    return content.entrySet().stream()
-        .filter(entry -> entry.getKey() != null)
-        .collect(
-            Collectors.toMap(
-                Map.Entry::getKey,
-                entry -> sanitizeOrValidateValue(entry.getKey(), entry.getValue()),
-                (existing, replacement) -> replacement,
-                LinkedHashMap::new));
-  }
-
-  /** Strict {@code __meta} handling, mirrors {@link DepartmentDataProtectionService}. */
-  private String sanitizeOrValidateValue(String key, String value) {
-    var safeValue = value == null ? "" : value;
-    if (key.endsWith(META_KEY_SUFFIX)) {
-      assertValidJson(key, safeValue);
-      return safeValue;
-    }
-    return inputSanitizer.sanitizeAllowingFormattingAndLinks(safeValue);
-  }
-
-  private void assertValidJson(String key, String value) {
-    if (value == null || value.isBlank()) {
-      throw invalidMeta(key);
-    }
-    final JsonNode node;
-    try {
-      node = metaJsonReader.readValue(value);
-    } catch (JsonProcessingException e) {
-      throw invalidMeta(key);
-    }
-    if (node == null || !node.isObject()) {
-      throw invalidMeta(key);
-    }
-    int knownFields = 0;
-    if (node.has("mt")) {
-      if (!node.get("mt").isBoolean()) {
-        throw invalidMeta(key);
-      }
-      knownFields++;
-    }
-    if (node.has("src")) {
-      if (!node.get("src").isTextual() || node.get("src").asText().isBlank()) {
-        throw invalidMeta(key);
-      }
-      knownFields++;
-    }
-    if (node.has("at")) {
-      if (!node.get("at").isTextual() || node.get("at").asText().isBlank()) {
-        throw invalidMeta(key);
-      }
-      knownFields++;
-    }
-    if (node.size() != knownFields) {
-      throw invalidMeta(key);
-    }
-  }
-
-  private BadRequestException invalidMeta(String key) {
-    return new BadRequestException(
-        String.format("Translation metadata key '%s' does not contain valid JSON", key));
-  }
-
-  private String toJson(Map<String, String> sanitized) {
-    try {
-      return objectMapper.writeValueAsString(sanitized);
-    } catch (JsonProcessingException e) {
-      throw new InternalServerErrorException("Could not serialize legal text content", e);
-    }
   }
 }

--- a/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/LegalTextAdminService.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/LegalTextAdminService.java
@@ -1,0 +1,314 @@
+package de.caritas.cob.agencyservice.api.admin.service.legal;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+import de.caritas.cob.agencyservice.api.admin.service.UserAdminService;
+import de.caritas.cob.agencyservice.api.exception.httpresponses.AgencyAccessDeniedException;
+import de.caritas.cob.agencyservice.api.exception.httpresponses.BadRequestException;
+import de.caritas.cob.agencyservice.api.exception.httpresponses.InternalServerErrorException;
+import de.caritas.cob.agencyservice.api.exception.httpresponses.NotFoundException;
+import de.caritas.cob.agencyservice.api.repository.agency.Agency;
+import de.caritas.cob.agencyservice.api.repository.agencytopic.AgencyTopic;
+import de.caritas.cob.agencyservice.api.repository.agencytopic.AgencyTopicRepository;
+import de.caritas.cob.agencyservice.api.repository.agencytopic.PublicationStatus;
+import de.caritas.cob.agencyservice.api.repository.legaltext.LegalText;
+import de.caritas.cob.agencyservice.api.repository.legaltext.LegalTextKind;
+import de.caritas.cob.agencyservice.api.repository.legaltext.LegalTextRepository;
+import de.caritas.cob.agencyservice.api.tenant.TenantContext;
+import de.caritas.cob.agencyservice.api.util.AuthenticatedUser;
+import de.caritas.cob.agencyservice.api.validation.InputSanitizer;
+import java.time.LocalDateTime;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * ADR-014 legal-text library: tenant-scoped CRUD over the shared {@link LegalText} objects plus
+ * the per-department assignment. A department may share a tenant-wide text, carry its own, or stay
+ * unassigned (= tenant-level fallback document applies).
+ *
+ * <p>Sanitisation mirrors {@link DepartmentDataProtectionService} (the strict variant):
+ * multilingual HTML is OWASP-sanitised per translation, {@code __meta}-suffixed keys carry
+ * translation metadata as JSON and are schema-validated instead of sanitised.
+ */
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class LegalTextAdminService {
+
+  private static final String META_KEY_SUFFIX = "__meta";
+
+  private final @NonNull LegalTextRepository legalTextRepository;
+  private final @NonNull AgencyTopicRepository agencyTopicRepository;
+  private final @NonNull InputSanitizer inputSanitizer;
+  private final @NonNull AuthenticatedUser authenticatedUser;
+  private final @NonNull UserAdminService userAdminService;
+
+  private final ObjectMapper objectMapper = new ObjectMapper();
+  private final ObjectReader metaJsonReader =
+      objectMapper.readerFor(JsonNode.class).with(DeserializationFeature.FAIL_ON_TRAILING_TOKENS);
+
+  /** Lists the caller tenant's legal texts of one kind, each with its department usage count. */
+  @Transactional(readOnly = true)
+  public List<LegalTextAdminView> listLegalTexts(LegalTextKind kind) {
+    Long tenantId = resolveEffectiveTenantId();
+    List<LegalText> texts =
+        isUnrestricted(tenantId)
+            ? legalTextRepository.findByKindOrderByLabelAsc(kind)
+            : legalTextRepository.findByTenantIdAndKindOrderByLabelAsc(tenantId, kind);
+    return texts.stream().map(this::toView).toList();
+  }
+
+  /** Creates a legal text owned by the caller's tenant. */
+  @Transactional
+  public LegalTextAdminView createLegalText(
+      LegalTextKind kind, String label, Map<String, String> content, boolean publish) {
+    assertValidLabel(label);
+    var now = LocalDateTime.now();
+    var text =
+        LegalText.builder()
+            .tenantId(resolveEffectiveTenantId())
+            .kind(kind)
+            .label(label)
+            .content(toJson(sanitizeTranslations(content)))
+            .publicationStatus(publish ? PublicationStatus.PUBLISHED : PublicationStatus.DRAFT)
+            .createDate(now)
+            .updateDate(now)
+            .build();
+    return toView(legalTextRepository.save(text));
+  }
+
+  /** Updates label, content and publication status of a caller-tenant text. */
+  @Transactional
+  public LegalTextAdminView updateLegalText(
+      Long legalTextId, String label, Map<String, String> content, boolean publish) {
+    LegalText text =
+        legalTextRepository.findById(legalTextId).orElseThrow(NotFoundException::new);
+    assertCallerTenantOwnsText(text);
+    assertValidLabel(label);
+
+    text.setLabel(label);
+    text.setContent(toJson(sanitizeTranslations(content)));
+    text.setPublicationStatus(publish ? PublicationStatus.PUBLISHED : PublicationStatus.DRAFT);
+    text.setUpdateDate(LocalDateTime.now());
+    return toView(legalTextRepository.save(text));
+  }
+
+  /**
+   * Assigns a shared legal text to a department's DPP or imprint slot, or clears the slot when
+   * {@code legalTextId} is {@code null} (the tenant-level fallback document applies again).
+   *
+   * <p>Guards: the restricted-admin IDOR check and the cross-tenant agency guard mirror the
+   * department publish endpoints; additionally the text's kind must match the slot and the text
+   * must belong to the agency's tenant.
+   */
+  @Transactional
+  public void assignDepartmentLegalText(
+      Long agencyId, Long topicId, LegalTextKind kind, Long legalTextId) {
+    assertRestrictedAdminOwnsAgency(agencyId);
+
+    AgencyTopic department =
+        agencyTopicRepository
+            .findByAgency_IdAndTopicId(agencyId, topicId)
+            .orElseThrow(NotFoundException::new);
+
+    assertCallerTenantMatches(department.getAgency());
+
+    LegalText text = null;
+    if (legalTextId != null) {
+      text = legalTextRepository.findById(legalTextId).orElseThrow(NotFoundException::new);
+      if (text.getKind() != kind) {
+        throw new BadRequestException(
+            String.format(
+                "Legal text %d has kind %s and cannot be assigned to the %s slot",
+                legalTextId, text.getKind(), kind));
+      }
+      assertTextBelongsToAgencyTenant(text, department.getAgency());
+    }
+
+    if (kind == LegalTextKind.DPP) {
+      department.setDpp(text);
+    } else {
+      department.setImprint(text);
+    }
+    department.setUpdateDate(LocalDateTime.now());
+    agencyTopicRepository.save(department);
+  }
+
+  private LegalTextAdminView toView(LegalText text) {
+    long usage =
+        text.getId() == null
+            ? 0L
+            : (text.getKind() == LegalTextKind.DPP
+                ? agencyTopicRepository.countByDpp_Id(text.getId())
+                : agencyTopicRepository.countByImprint_Id(text.getId()));
+    return new LegalTextAdminView(
+        text.getId(),
+        text.getKind(),
+        text.getLabel(),
+        text.getContent(),
+        text.getPublicationStatus(),
+        usage);
+  }
+
+  private void assertValidLabel(String label) {
+    if (label == null || label.isBlank()) {
+      throw new BadRequestException("Legal text label must not be blank");
+    }
+  }
+
+  /** A text may only be edited by its owning tenant (technical tenant 0 is unrestricted). */
+  private void assertCallerTenantOwnsText(LegalText text) {
+    Long effectiveTenantId = resolveEffectiveTenantId();
+    if (isUnrestricted(effectiveTenantId)) {
+      return;
+    }
+    if (!effectiveTenantId.equals(text.getTenantId())) {
+      log.warn(
+          "Admin user {} (tenant {}) may not edit legal text {} (tenant {})",
+          authenticatedUser.getUserId(),
+          effectiveTenantId,
+          text.getId(),
+          text.getTenantId());
+      throw new AgencyAccessDeniedException();
+    }
+  }
+
+  /** A department must never reference another Träger's document. */
+  private void assertTextBelongsToAgencyTenant(LegalText text, Agency agency) {
+    Long textTenant = text.getTenantId();
+    Long agencyTenant = agency == null ? null : agency.getTenantId();
+    if (textTenant != null && agencyTenant != null && !textTenant.equals(agencyTenant)) {
+      throw new BadRequestException(
+          String.format(
+              "Legal text %d belongs to tenant %d, not to the agency's tenant %d",
+              text.getId(), textTenant, agencyTenant));
+    }
+  }
+
+  /**
+   * Restricted agency admins may only touch agencies they administer (mirrors {@code
+   * DepartmentDataProtectionService}).
+   */
+  private void assertRestrictedAdminOwnsAgency(Long agencyId) {
+    if (authenticatedUser.hasRestrictedAgencyPriviliges()) {
+      var adminAgencyIds = userAdminService.getAdminUserAgencyIds(authenticatedUser.getUserId());
+      if (adminAgencyIds == null || !adminAgencyIds.contains(agencyId)) {
+        log.warn(
+            "Admin user {} may not assign legal texts of agency {}",
+            authenticatedUser.getUserId(),
+            agencyId);
+        throw new AgencyAccessDeniedException();
+      }
+    }
+  }
+
+  /** Cross-tenant guard, mirrors the department publish endpoints. */
+  private void assertCallerTenantMatches(Agency agency) {
+    Long effectiveTenantId = resolveEffectiveTenantId();
+    if (isUnrestricted(effectiveTenantId)) {
+      return;
+    }
+    if (agency == null || !effectiveTenantId.equals(agency.getTenantId())) {
+      log.warn(
+          "Admin user {} (tenant {}) may not assign legal texts of agency {} (tenant {})",
+          authenticatedUser.getUserId(),
+          effectiveTenantId,
+          agency == null ? null : agency.getId(),
+          agency == null ? null : agency.getTenantId());
+      throw new AgencyAccessDeniedException();
+    }
+  }
+
+  private boolean isUnrestricted(Long effectiveTenantId) {
+    return effectiveTenantId == null || effectiveTenantId.equals(0L);
+  }
+
+  private Long resolveEffectiveTenantId() {
+    Long tenantIdFromAuth = authenticatedUser.getTenantId();
+    return tenantIdFromAuth != null ? tenantIdFromAuth : TenantContext.getCurrentTenant();
+  }
+
+  private Map<String, String> sanitizeTranslations(Map<String, String> content) {
+    if (content == null) {
+      return Map.of();
+    }
+    return content.entrySet().stream()
+        .filter(entry -> entry.getKey() != null)
+        .collect(
+            Collectors.toMap(
+                Map.Entry::getKey,
+                entry -> sanitizeOrValidateValue(entry.getKey(), entry.getValue()),
+                (existing, replacement) -> replacement,
+                LinkedHashMap::new));
+  }
+
+  /** Strict {@code __meta} handling, mirrors {@link DepartmentDataProtectionService}. */
+  private String sanitizeOrValidateValue(String key, String value) {
+    var safeValue = value == null ? "" : value;
+    if (key.endsWith(META_KEY_SUFFIX)) {
+      assertValidJson(key, safeValue);
+      return safeValue;
+    }
+    return inputSanitizer.sanitizeAllowingFormattingAndLinks(safeValue);
+  }
+
+  private void assertValidJson(String key, String value) {
+    if (value == null || value.isBlank()) {
+      throw invalidMeta(key);
+    }
+    final JsonNode node;
+    try {
+      node = metaJsonReader.readValue(value);
+    } catch (JsonProcessingException e) {
+      throw invalidMeta(key);
+    }
+    if (node == null || !node.isObject()) {
+      throw invalidMeta(key);
+    }
+    int knownFields = 0;
+    if (node.has("mt")) {
+      if (!node.get("mt").isBoolean()) {
+        throw invalidMeta(key);
+      }
+      knownFields++;
+    }
+    if (node.has("src")) {
+      if (!node.get("src").isTextual() || node.get("src").asText().isBlank()) {
+        throw invalidMeta(key);
+      }
+      knownFields++;
+    }
+    if (node.has("at")) {
+      if (!node.get("at").isTextual() || node.get("at").asText().isBlank()) {
+        throw invalidMeta(key);
+      }
+      knownFields++;
+    }
+    if (node.size() != knownFields) {
+      throw invalidMeta(key);
+    }
+  }
+
+  private BadRequestException invalidMeta(String key) {
+    return new BadRequestException(
+        String.format("Translation metadata key '%s' does not contain valid JSON", key));
+  }
+
+  private String toJson(Map<String, String> sanitized) {
+    try {
+      return objectMapper.writeValueAsString(sanitized);
+    } catch (JsonProcessingException e) {
+      throw new InternalServerErrorException("Could not serialize legal text content", e);
+    }
+  }
+}

--- a/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/LegalTextAdminService.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/LegalTextAdminService.java
@@ -1,14 +1,8 @@
 package de.caritas.cob.agencyservice.api.admin.service.legal;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ObjectReader;
 import de.caritas.cob.agencyservice.api.admin.service.UserAdminService;
 import de.caritas.cob.agencyservice.api.exception.httpresponses.AgencyAccessDeniedException;
 import de.caritas.cob.agencyservice.api.exception.httpresponses.BadRequestException;
-import de.caritas.cob.agencyservice.api.exception.httpresponses.InternalServerErrorException;
 import de.caritas.cob.agencyservice.api.exception.httpresponses.NotFoundException;
 import de.caritas.cob.agencyservice.api.repository.agency.Agency;
 import de.caritas.cob.agencyservice.api.repository.agencytopic.AgencyTopic;
@@ -19,12 +13,9 @@ import de.caritas.cob.agencyservice.api.repository.legaltext.LegalTextKind;
 import de.caritas.cob.agencyservice.api.repository.legaltext.LegalTextRepository;
 import de.caritas.cob.agencyservice.api.tenant.TenantContext;
 import de.caritas.cob.agencyservice.api.util.AuthenticatedUser;
-import de.caritas.cob.agencyservice.api.validation.InputSanitizer;
 import java.time.LocalDateTime;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -34,7 +25,8 @@ import org.springframework.transaction.annotation.Transactional;
 /**
  * ADR-014 legal-text library: tenant-scoped CRUD over the shared {@link LegalText} objects plus
  * the per-department assignment. A department may share a tenant-wide text, carry its own, or stay
- * unassigned (= tenant-level fallback document applies).
+ * unassigned (= it falls back to its own inline {@code content_dpp}/{@code content_imprint};
+ * tenant-level fallback is future work, ADR-014 / #136).
  *
  * <p>Sanitisation mirrors {@link DepartmentDataProtectionService} (the strict variant):
  * multilingual HTML is OWASP-sanitised per translation, {@code __meta}-suffixed keys carry
@@ -128,7 +120,8 @@ public class LegalTextAdminService {
 
   /**
    * Assigns a shared legal text to a department's DPP or imprint slot, or clears the slot when
-   * {@code legalTextId} is {@code null} (the tenant-level fallback document applies again).
+   * {@code legalTextId} is {@code null} (the department falls back to its own inline {@code
+   * content_dpp}/{@code content_imprint}; tenant-level fallback is future work, ADR-014 / #136).
    *
    * <p>Guards: the restricted-admin IDOR check and the cross-tenant agency guard mirror the
    * department publish endpoints; additionally the text's kind must match the slot and the text

--- a/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/LegalTextAdminView.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/LegalTextAdminView.java
@@ -1,0 +1,16 @@
+package de.caritas.cob.agencyservice.api.admin.service.legal;
+
+import de.caritas.cob.agencyservice.api.repository.agencytopic.PublicationStatus;
+import de.caritas.cob.agencyservice.api.repository.legaltext.LegalTextKind;
+
+/**
+ * Admin view of a shared legal text (ADR-014): the stored object plus how many departments
+ * currently reference it ("used by N departments").
+ */
+public record LegalTextAdminView(
+    Long id,
+    LegalTextKind kind,
+    String label,
+    String content,
+    PublicationStatus publicationStatus,
+    long usageCount) {}

--- a/src/main/java/de/caritas/cob/agencyservice/api/admin/validation/validators/AgencyUpdatePermissionValidator.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/admin/validation/validators/AgencyUpdatePermissionValidator.java
@@ -22,9 +22,11 @@ public class AgencyUpdatePermissionValidator implements ConcreteAgencyValidator 
 
   public void validate(ValidateAgencyDTO validateAgencyDto) {
     if (authenticatedUser.hasRestrictedAgencyPriviliges()) {
-      var adminAgencyIds = userAdminService.getAdminUserAgencyIds(authenticatedUser.getUserId());
+      var userId = authenticatedUser.requireUserId();
+      var adminAgencyIds = userAdminService.getAdminUserAgencyIds(userId);
       if (!adminAgencyIds.contains(validateAgencyDto.getId())) {
-        log.warn("Admin user with id does not have permission to this agency: {}", authenticatedUser.getUserId(), validateAgencyDto.getId());
+        log.warn("Admin user with id does not have permission to this agency: {}", userId,
+            validateAgencyDto.getId());
         throw new AgencyAccessDeniedException();
       }
     }

--- a/src/main/java/de/caritas/cob/agencyservice/api/repository/agency/AgencyRepository.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/repository/agency/AgencyRepository.java
@@ -95,10 +95,10 @@ public interface AgencyRepository extends JpaRepository<Agency, Long> {
 
   Optional<Agency> findByIdAndDeleteDateNull(Long agencyId);
 
-  @EntityGraph(attributePaths = {"agencyTopics"})
+  @EntityGraph(attributePaths = {"agencyTopics", "agencyTopics.dpp", "agencyTopics.imprint"})
   List<Agency> findByIdIn(List<Long> agencyIds);
 
-  @EntityGraph(attributePaths = {"agencyTopics"})
+  @EntityGraph(attributePaths = {"agencyTopics", "agencyTopics.dpp", "agencyTopics.imprint"})
   List<Agency> findByConsultingTypeId(int consultingTypeId);
 
   Optional<Agency> findById(Long agencyIds);

--- a/src/main/java/de/caritas/cob/agencyservice/api/repository/agency/AgencyTenantAwareRepository.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/repository/agency/AgencyTenantAwareRepository.java
@@ -63,10 +63,10 @@ public interface AgencyTenantAwareRepository extends JpaRepository<Agency, Long>
 
   Optional<Agency> findByIdAndDeleteDateNull(Long agencyId);
 
-  @EntityGraph(attributePaths = {"agencyTopics"})
+  @EntityGraph(attributePaths = {"agencyTopics", "agencyTopics.dpp", "agencyTopics.imprint"})
   List<Agency> findByIdIn(List<Long> agencyIds);
 
-  @EntityGraph(attributePaths = {"agencyTopics"})
+  @EntityGraph(attributePaths = {"agencyTopics", "agencyTopics.dpp", "agencyTopics.imprint"})
   List<Agency> findByConsultingTypeId(int consultingTypeId);
 
 }

--- a/src/main/java/de/caritas/cob/agencyservice/api/repository/agency/AgencyTenantUnawareRepository.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/repository/agency/AgencyTenantUnawareRepository.java
@@ -41,10 +41,10 @@ public interface AgencyTenantUnawareRepository extends JpaRepository<Agency, Lon
 
   Optional<Agency> findByIdAndDeleteDateNull(Long agencyId);
 
-  @EntityGraph(attributePaths = {"agencyTopics"})
+  @EntityGraph(attributePaths = {"agencyTopics", "agencyTopics.dpp", "agencyTopics.imprint"})
   List<Agency> findByIdIn(List<Long> agencyIds);
 
-  @EntityGraph(attributePaths = {"agencyTopics"})
+  @EntityGraph(attributePaths = {"agencyTopics", "agencyTopics.dpp", "agencyTopics.imprint"})
   List<Agency> findByConsultingTypeId(int consultingTypeId);
 
   List<Agency> findByTenantId(Long tenantId);

--- a/src/main/java/de/caritas/cob/agencyservice/api/repository/agencytopic/AgencyTopic.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/repository/agencytopic/AgencyTopic.java
@@ -2,6 +2,7 @@ package de.caritas.cob.agencyservice.api.repository.agencytopic;
 
 import de.caritas.cob.agencyservice.api.model.TopicDTO;
 import de.caritas.cob.agencyservice.api.repository.agency.Agency;
+import de.caritas.cob.agencyservice.api.repository.legaltext.LegalText;
 import java.time.LocalDateTime;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -74,6 +75,20 @@ public class AgencyTopic {
   @Enumerated(EnumType.STRING)
   @Column(name = "publication_status_imprint", nullable = false)
   private PublicationStatus publicationStatusImprint = PublicationStatus.DRAFT;
+
+  /**
+   * ADR-014: reference to the shared data privacy policy object. When set it wins over the inline
+   * {@link #contentDpp}; several departments may point at the same text. {@code null} = fall back
+   * to the inline column (pre-backfill rows) or, if that is empty too, to the tenant-level text.
+   */
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "dpp_id")
+  private LegalText dpp;
+
+  /** ADR-014: reference to the shared Impressum object, same semantics as {@link #dpp}. */
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "imprint_id")
+  private LegalText imprint;
 
   @Transient TopicDTO topicData = new TopicDTO();
 

--- a/src/main/java/de/caritas/cob/agencyservice/api/repository/agencytopic/AgencyTopic.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/repository/agencytopic/AgencyTopic.java
@@ -118,8 +118,10 @@ public class AgencyTopic {
    * ADR-014 invariants, enforced at the persistence boundary so no future write path can slip a
    * bad assignment past the service-level guards: the DPP slot only accepts {@code
    * LegalTextKind.DPP} objects, the imprint slot only {@code IMPRINT}, and a department must never
-   * reference another Träger's document (checked only when both tenant ids are known —
-   * single-tenant mode carries nulls).
+   * reference another Träger's document. Mirrors the service rule: a tenant-scoped agency (tenant
+   * not null/0) may only reference a text of its own tenant — a null-tenant (global/orphan) or
+   * different-tenant text is rejected; single-tenant / technical agencies (tenant null or 0) stay
+   * unrestricted.
    */
   private void validateLegalTextReferences() {
     assertReferenceKind(dpp, LegalTextKind.DPP, "dpp");
@@ -139,12 +141,19 @@ public class AgencyTopic {
   }
 
   private void assertReferenceTenant(LegalText reference, String slot) {
-    Long referenceTenant = reference == null ? null : reference.getTenantId();
+    if (reference == null) {
+      return;
+    }
     Long agencyTenant = agency == null ? null : agency.getTenantId();
-    if (referenceTenant != null && agencyTenant != null && !referenceTenant.equals(agencyTenant)) {
+    // Single-tenant / technical agencies (tenant null or 0) carry no cross-tenant risk.
+    if (agencyTenant == null || agencyTenant.equals(0L)) {
+      return;
+    }
+    Long referenceTenant = reference.getTenantId();
+    if (!agencyTenant.equals(referenceTenant)) {
       throw new IllegalStateException(
           String.format(
-              "agency_topic.%s_id references a legal text of tenant %d but the agency belongs to tenant %d",
+              "agency_topic.%s_id references a legal text of tenant %s but the agency belongs to tenant %d",
               slot, referenceTenant, agencyTenant));
     }
   }

--- a/src/main/java/de/caritas/cob/agencyservice/api/repository/agencytopic/AgencyTopic.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/repository/agencytopic/AgencyTopic.java
@@ -3,6 +3,7 @@ package de.caritas.cob.agencyservice.api.repository.agencytopic;
 import de.caritas.cob.agencyservice.api.model.TopicDTO;
 import de.caritas.cob.agencyservice.api.repository.agency.Agency;
 import de.caritas.cob.agencyservice.api.repository.legaltext.LegalText;
+import de.caritas.cob.agencyservice.api.repository.legaltext.LegalTextKind;
 import java.time.LocalDateTime;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -15,6 +16,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
 import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
@@ -103,6 +105,47 @@ public class AgencyTopic {
     }
     if (publicationStatusImprint == null) {
       publicationStatusImprint = PublicationStatus.DRAFT;
+    }
+    validateLegalTextReferences();
+  }
+
+  @PreUpdate
+  void validateOnUpdate() {
+    validateLegalTextReferences();
+  }
+
+  /**
+   * ADR-014 invariants, enforced at the persistence boundary so no future write path can slip a
+   * bad assignment past the service-level guards: the DPP slot only accepts {@code
+   * LegalTextKind.DPP} objects, the imprint slot only {@code IMPRINT}, and a department must never
+   * reference another Träger's document (checked only when both tenant ids are known —
+   * single-tenant mode carries nulls).
+   */
+  private void validateLegalTextReferences() {
+    assertReferenceKind(dpp, LegalTextKind.DPP, "dpp");
+    assertReferenceKind(imprint, LegalTextKind.IMPRINT, "imprint");
+    assertReferenceTenant(dpp, "dpp");
+    assertReferenceTenant(imprint, "imprint");
+  }
+
+  private void assertReferenceKind(
+      LegalText reference, LegalTextKind expectedKind, String slot) {
+    if (reference != null && reference.getKind() != expectedKind) {
+      throw new IllegalStateException(
+          String.format(
+              "agency_topic.%s_id must reference a legal text of kind %s but got %s",
+              slot, expectedKind, reference.getKind()));
+    }
+  }
+
+  private void assertReferenceTenant(LegalText reference, String slot) {
+    Long referenceTenant = reference == null ? null : reference.getTenantId();
+    Long agencyTenant = agency == null ? null : agency.getTenantId();
+    if (referenceTenant != null && agencyTenant != null && !referenceTenant.equals(agencyTenant)) {
+      throw new IllegalStateException(
+          String.format(
+              "agency_topic.%s_id references a legal text of tenant %d but the agency belongs to tenant %d",
+              slot, referenceTenant, agencyTenant));
     }
   }
 }

--- a/src/main/java/de/caritas/cob/agencyservice/api/repository/agencytopic/AgencyTopicRepository.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/repository/agencytopic/AgencyTopicRepository.java
@@ -19,4 +19,10 @@ public interface AgencyTopicRepository extends JpaRepository<AgencyTopic, Long> 
   /** Finds all department rows for a given agency. */
   @Query(value = "select * from agency_topic where agency_id = :agencyId", nativeQuery = true)
   List<AgencyTopic> findAllByAgencyId(@Param("agencyId") Long agencyId);
+
+  /** How many departments reference this shared DPP text ("used by N", ADR-014). */
+  long countByDpp_Id(Long legalTextId);
+
+  /** How many departments reference this shared Impressum text ("used by N", ADR-014). */
+  long countByImprint_Id(Long legalTextId);
 }

--- a/src/main/java/de/caritas/cob/agencyservice/api/repository/legaltext/LegalText.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/repository/legaltext/LegalText.java
@@ -1,0 +1,78 @@
+package de.caritas.cob.agencyservice.api.repository.legaltext;
+
+import de.caritas.cob.agencyservice.api.repository.agencytopic.PublicationStatus;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+
+/**
+ * A reusable legal text (data privacy policy or Impressum) owned by a Träger (tenant), per
+ * ADR-014: departments (Fachbereich = agency × topic) reference one text per kind, and several
+ * departments may share the same text — one maintained document instead of N inline copies.
+ *
+ * <p>{@code content} is a JSON language→HTML map, the same shape the inline
+ * {@code agency_topic.content_dpp}/{@code content_imprint} columns use, so the admin editor and the
+ * public read side keep working unchanged.
+ */
+@Entity
+@Table(name = "legal_text")
+@AllArgsConstructor
+@RequiredArgsConstructor
+@Getter
+@Setter
+@Builder
+public class LegalText {
+
+  @Id
+  @SequenceGenerator(name = "id_seq", allocationSize = 1, sequenceName = "sequence_legal_text")
+  @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "id_seq")
+  @Column(name = "id", updatable = false, nullable = false)
+  private Long id;
+
+  @Column(name = "tenant_id")
+  private Long tenantId;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "kind", nullable = false)
+  private LegalTextKind kind;
+
+  /** Admin-facing name, e.g. "Standard-DSE Träger" — shown in the legal-text library. */
+  @Column(name = "label", nullable = false)
+  private String label;
+
+  /** JSON language→HTML map, same shape as the former inline department columns. */
+  @Column(name = "content")
+  private String content;
+
+  @Builder.Default
+  @Enumerated(EnumType.STRING)
+  @Column(name = "publication_status", nullable = false)
+  private PublicationStatus publicationStatus = PublicationStatus.DRAFT;
+
+  @Column(name = "create_date")
+  private LocalDateTime createDate;
+
+  @Column(name = "update_date")
+  private LocalDateTime updateDate;
+
+  /** Mirrors {@code AgencyTopic#applyDefaults}: NOT NULL status survives non-builder paths. */
+  @PrePersist
+  void applyDefaults() {
+    if (publicationStatus == null) {
+      publicationStatus = PublicationStatus.DRAFT;
+    }
+  }
+}

--- a/src/main/java/de/caritas/cob/agencyservice/api/repository/legaltext/LegalText.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/repository/legaltext/LegalText.java
@@ -9,6 +9,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
 import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
@@ -68,11 +69,26 @@ public class LegalText {
   @Column(name = "update_date")
   private LocalDateTime updateDate;
 
-  /** Mirrors {@code AgencyTopic#applyDefaults}: NOT NULL status survives non-builder paths. */
+  /**
+   * Mirrors {@code AgencyTopic#applyDefaults}: the NOT NULL columns (status, dates) survive
+   * non-builder construction paths and repository saves where no caller set them explicitly.
+   */
   @PrePersist
   void applyDefaults() {
     if (publicationStatus == null) {
       publicationStatus = PublicationStatus.DRAFT;
     }
+    var now = LocalDateTime.now();
+    if (createDate == null) {
+      createDate = now;
+    }
+    if (updateDate == null) {
+      updateDate = now;
+    }
+  }
+
+  @PreUpdate
+  void refreshUpdateDate() {
+    updateDate = LocalDateTime.now();
   }
 }

--- a/src/main/java/de/caritas/cob/agencyservice/api/repository/legaltext/LegalTextKind.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/repository/legaltext/LegalTextKind.java
@@ -1,0 +1,7 @@
+package de.caritas.cob.agencyservice.api.repository.legaltext;
+
+/** The two kinds of department legal texts a Träger can author (ADR-014). */
+public enum LegalTextKind {
+  DPP,
+  IMPRINT
+}

--- a/src/main/java/de/caritas/cob/agencyservice/api/repository/legaltext/LegalTextRepository.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/repository/legaltext/LegalTextRepository.java
@@ -6,4 +6,6 @@ import org.springframework.data.repository.CrudRepository;
 public interface LegalTextRepository extends CrudRepository<LegalText, Long> {
 
   List<LegalText> findByTenantIdAndKindOrderByLabelAsc(Long tenantId, LegalTextKind kind);
+
+  List<LegalText> findByKindOrderByLabelAsc(LegalTextKind kind);
 }

--- a/src/main/java/de/caritas/cob/agencyservice/api/repository/legaltext/LegalTextRepository.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/repository/legaltext/LegalTextRepository.java
@@ -1,0 +1,9 @@
+package de.caritas.cob.agencyservice.api.repository.legaltext;
+
+import java.util.List;
+import org.springframework.data.repository.CrudRepository;
+
+public interface LegalTextRepository extends CrudRepository<LegalText, Long> {
+
+  List<LegalText> findByTenantIdAndKindOrderByLabelAsc(Long tenantId, LegalTextKind kind);
+}

--- a/src/main/java/de/caritas/cob/agencyservice/api/service/AgencyService.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/service/AgencyService.java
@@ -22,6 +22,7 @@ import de.caritas.cob.agencyservice.api.repository.agency.Agency;
 import de.caritas.cob.agencyservice.api.repository.agency.AgencyRepository;
 import de.caritas.cob.agencyservice.api.repository.agencytopic.AgencyTopic;
 import de.caritas.cob.agencyservice.api.repository.agencytopic.PublicationStatus;
+import de.caritas.cob.agencyservice.api.repository.legaltext.LegalText;
 import de.caritas.cob.agencyservice.api.tenant.TenantContext;
 import de.caritas.cob.agencyservice.consultingtypeservice.generated.web.model.ExtendedConsultingTypeResponseDTO;
 import de.caritas.cob.agencyservice.tenantservice.generated.web.model.RestrictedTenantDTO;
@@ -496,15 +497,33 @@ public class AgencyService {
    * plus whether its own legal texts (ADR-003) are published. Uses the already-loaded {@code
    * agencyTopics} association (the same one {@code topicIds} is built from), so no additional
    * query is issued per agency or topic.
+   *
+   * <p>ADR-014: like {@link DepartmentLegalService}, a referenced shared legal-text object fully
+   * replaces the inline column — the flags must follow the same resolution order, otherwise the
+   * registration search would report stale inline state after a write-through publish/draft-save.
    */
   private AgencyDepartmentDTO convertToAgencyDepartmentDTO(AgencyTopic agencyTopic) {
     return new AgencyDepartmentDTO()
         .topicId(agencyTopic.getTopicId())
-        .hasPublishedDpp(
-            hasPublishedContent(agencyTopic.getContentDpp(), agencyTopic.getPublicationStatus()))
-        .hasPublishedImprint(
-            hasPublishedContent(
-                agencyTopic.getContentImprint(), agencyTopic.getPublicationStatusImprint()));
+        .hasPublishedDpp(hasPublishedDpp(agencyTopic))
+        .hasPublishedImprint(hasPublishedImprint(agencyTopic));
+  }
+
+  private boolean hasPublishedDpp(AgencyTopic agencyTopic) {
+    LegalText referenced = agencyTopic.getDpp();
+    if (referenced != null) {
+      return hasPublishedContent(referenced.getContent(), referenced.getPublicationStatus());
+    }
+    return hasPublishedContent(agencyTopic.getContentDpp(), agencyTopic.getPublicationStatus());
+  }
+
+  private boolean hasPublishedImprint(AgencyTopic agencyTopic) {
+    LegalText referenced = agencyTopic.getImprint();
+    if (referenced != null) {
+      return hasPublishedContent(referenced.getContent(), referenced.getPublicationStatus());
+    }
+    return hasPublishedContent(
+        agencyTopic.getContentImprint(), agencyTopic.getPublicationStatusImprint());
   }
 
   private boolean hasPublishedContent(String content, PublicationStatus status) {

--- a/src/main/java/de/caritas/cob/agencyservice/api/service/DepartmentLegalService.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/service/DepartmentLegalService.java
@@ -5,6 +5,7 @@ import de.caritas.cob.agencyservice.api.repository.agency.Agency;
 import de.caritas.cob.agencyservice.api.repository.agencytopic.AgencyTopic;
 import de.caritas.cob.agencyservice.api.repository.agencytopic.AgencyTopicRepository;
 import de.caritas.cob.agencyservice.api.repository.agencytopic.PublicationStatus;
+import de.caritas.cob.agencyservice.api.repository.legaltext.LegalText;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -39,9 +40,30 @@ public class DepartmentLegalService {
     assertAgencyIsNotDeleted(department.getAgency());
 
     return new DepartmentLegalView(
-        publishedContentOrNull(department.getContentDpp(), department.getPublicationStatus()),
-        publishedContentOrNull(
-            department.getContentImprint(), department.getPublicationStatusImprint()));
+        resolveDpp(department), resolveImprint(department));
+  }
+
+  /**
+   * ADR-014 resolution order: a referenced shared legal-text object, once assigned, fully replaces
+   * the legacy inline column — including its DRAFT state. Only reference-less (pre-backfill) rows
+   * fall back to the inline content.
+   */
+  private String resolveDpp(AgencyTopic department) {
+    LegalText referenced = department.getDpp();
+    if (referenced != null) {
+      return publishedContentOrNull(referenced.getContent(), referenced.getPublicationStatus());
+    }
+    return publishedContentOrNull(
+        department.getContentDpp(), department.getPublicationStatus());
+  }
+
+  private String resolveImprint(AgencyTopic department) {
+    LegalText referenced = department.getImprint();
+    if (referenced != null) {
+      return publishedContentOrNull(referenced.getContent(), referenced.getPublicationStatus());
+    }
+    return publishedContentOrNull(
+        department.getContentImprint(), department.getPublicationStatusImprint());
   }
 
   private void assertAgencyIsNotDeleted(Agency agency) {

--- a/src/main/java/de/caritas/cob/agencyservice/api/service/DepartmentLegalService.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/service/DepartmentLegalService.java
@@ -45,8 +45,14 @@ public class DepartmentLegalService {
 
   /**
    * ADR-014 resolution order: a referenced shared legal-text object, once assigned, fully replaces
-   * the legacy inline column — including its DRAFT state. Only reference-less (pre-backfill) rows
-   * fall back to the inline content.
+   * the legacy inline column — including its DRAFT state. Only reference-less rows fall back to the
+   * inline content.
+   *
+   * <p><b>Unassign semantics (this release):</b> clearing {@code dpp_id}/{@code imprint_id} makes a
+   * department reference-less again, so it falls back to its own inline {@code content_dpp}/{@code
+   * content_imprint} — NOT to a tenant-level fallback document. The backfill deliberately keeps the
+   * inline columns for one release as this read-fallback and as the rollback anchor; they are not
+   * cleared on unassign. Tenant-level fallback is future work (see ADR-014 / #134).
    */
   private String resolveDpp(AgencyTopic department) {
     LegalText referenced = department.getDpp();

--- a/src/main/java/de/caritas/cob/agencyservice/api/util/AuthenticatedUser.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/util/AuthenticatedUser.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
+import org.springframework.security.access.AccessDeniedException;
 
 import java.util.Set;
 
@@ -21,7 +22,6 @@ import static java.util.Objects.nonNull;
 @Setter
 public class AuthenticatedUser {
 
-  @NonNull
   private String userId;
 
   @NonNull
@@ -52,6 +52,18 @@ public class AuthenticatedUser {
   @JsonIgnore
   public boolean hasRestrictedAgencyPriviliges() {
     return isRestrictedAgencyAdmin() && !isAgencyAdmin();
+  }
+
+  /**
+   * Returns the domain user id for operations scoped to a concrete agency administrator.
+   * Platform and tenant administrators are not guaranteed to have this custom Keycloak claim.
+   */
+  @JsonIgnore
+  public String requireUserId() {
+    if (userId == null || userId.isBlank()) {
+      throw new AccessDeniedException("Domain user id is required for this operation");
+    }
+    return userId;
   }
 
 

--- a/src/main/java/de/caritas/cob/agencyservice/config/AuthenticatedUserConfig.java
+++ b/src/main/java/de/caritas/cob/agencyservice/config/AuthenticatedUserConfig.java
@@ -45,7 +45,7 @@ public class AuthenticatedUserConfig {
     Map<String, Object> claimMap = authenticationToken.getToken().getClaims();
     AuthenticatedUser authenticatedUser = new AuthenticatedUser();
     authenticatedUser.setAccessToken(authenticationToken.getToken().getTokenValue());
-    authenticatedUser.setUserId(getUserAttribute(claimMap, CLAIM_NAME_USER_ID));
+    authenticatedUser.setUserId(getOptionalUserAttribute(claimMap, CLAIM_NAME_USER_ID));
     authenticatedUser.setUsername(decodeUsername(getUserAttribute(claimMap, CLAIM_NAME_USERNAME)));
     authenticatedUser.setTenantId(getTenantId(claimMap));
     authenticatedUser.setRoles(extractRealmRoles(authenticationToken.getToken()).stream().collect(
@@ -79,6 +79,11 @@ public class AuthenticatedUserConfig {
       throw new KeycloakException("Keycloak user attribute '" + claimValue + "' not found.");
     }
     return claimMap.get(claimValue).toString();
+  }
+
+  private String getOptionalUserAttribute(Map<String, Object> claimMap, String claimValue) {
+    Object value = claimMap.get(claimValue);
+    return value == null ? null : value.toString();
   }
 
   private Long getTenantId(Map<String, Object> claimMap) {

--- a/src/main/java/de/caritas/cob/agencyservice/config/SortParameterBindingConfig.java
+++ b/src/main/java/de/caritas/cob/agencyservice/config/SortParameterBindingConfig.java
@@ -1,0 +1,43 @@
+package de.caritas.cob.agencyservice.config;
+
+import de.caritas.cob.agencyservice.api.model.Sort;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.format.FormatterRegistry;
+import org.springframework.lang.NonNull;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+/**
+ * Binds the {@code field} query parameter of {@code GET /agencyadmin/agencies} leniently. The
+ * admin frontend sends upper-cased field names without separators (e.g. {@code POSTCODE},
+ * {@code CREATEDATE}), while the generated {@link Sort.FieldEnum} constants are underscore
+ * separated ({@code POST_CODE}, {@code CREATE_DATE}) — the default enum binding only accepts
+ * exact constant names and rejects those requests with HTTP 400.
+ */
+@Component
+public class SortParameterBindingConfig implements WebMvcConfigurer {
+
+  @Override
+  public void addFormatters(FormatterRegistry registry) {
+    registry.addConverter(String.class, Sort.FieldEnum.class, new LenientSortFieldConverter());
+  }
+
+  static class LenientSortFieldConverter implements Converter<String, Sort.FieldEnum> {
+
+    @Override
+    public Sort.FieldEnum convert(@NonNull String source) {
+      var canonicalSource = canonical(source);
+      for (var candidate : Sort.FieldEnum.values()) {
+        if (canonical(candidate.name()).equals(canonicalSource)
+            || canonical(candidate.getValue()).equals(canonicalSource)) {
+          return candidate;
+        }
+      }
+      throw new IllegalArgumentException("Unexpected sort field '" + source + "'");
+    }
+
+    private static String canonical(String value) {
+      return value.replaceAll("[^A-Za-z0-9]", "").toLowerCase();
+    }
+  }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,15 +8,6 @@ spring.data.jpa.repositories.bootstrap-mode=default
 spring.main.banner-mode=off
 spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.mongo.MongoAutoConfiguration,org.springframework.boot.autoconfigure.data.mongo.MongoDataAutoConfiguration
 
-# ---------------- Sentry ----------------
-sentry.dsn=${SENTRY_DSN:}
-sentry.environment=${SENTRY_ENVIRONMENT:dev}
-sentry.release=${SENTRY_RELEASE:oriso-agencyservice@local}
-sentry.traces-sample-rate=${SENTRY_TRACES_SAMPLE_RATE:0.0}
-sentry.send-default-pii=${SENTRY_SEND_DEFAULT_PII:false}
-sentry.logging.minimum-event-level=${SENTRY_LOGGING_MINIMUM_EVENT_LEVEL:warn}
-sentry.logging.minimum-breadcrumb-level=${SENTRY_LOGGING_MINIMUM_BREADCRUMB_LEVEL:info}
-
 # ---------------- Server ----------------
 server.port=8084
 server.host=http://localhost

--- a/src/main/resources/db/changelog/agencyservice-master.xml
+++ b/src/main/resources/db/changelog/agencyservice-master.xml
@@ -68,6 +68,9 @@
   <!-- Demo/initial-delivery data is opt-in. Enable with Liquibase context
        "demo-baseline" for demo environments or before customer-facing demo runs. -->
   <include file="db/changelog/changeset/0025_demo_baseline/0025_changeSet.xml" contextFilter="demo-baseline"/>
+  <!-- ADR-014: shared legal-text objects (legal_text table + department references + backfill
+       that merges byte-identical inline texts into one shared row per tenant/kind/status). -->
+  <include file="db/changelog/changeset/0026_legal_text/0026_changeSet.xml"/>
 
   <!--
     L1 gap detection (2026-07-04): the consolidated changelog was run against a fresh MariaDB

--- a/src/main/resources/db/changelog/changeset/0026_legal_text/0026_changeSet.xml
+++ b/src/main/resources/db/changelog/changeset/0026_legal_text/0026_changeSet.xml
@@ -1,0 +1,37 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd">
+    <!-- ADR-014 step 1: legal texts become first-class shared objects owned by a Träger. -->
+    <changeSet author="oriso" id="createLegalTextTable">
+        <sqlFile path="db/changelog/changeset/0026_legal_text/createLegalText.sql" stripComments="true"/>
+        <rollback>
+            <sqlFile path="db/changelog/changeset/0026_legal_text/createLegalText-rollback.sql" stripComments="true"/>
+        </rollback>
+    </changeSet>
+
+    <!-- ADR-014 step 2: departments reference their legal texts (nullable = tenant fallback). -->
+    <changeSet author="oriso" id="addAgencyTopicLegalTextReferences">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">
+                SELECT COUNT(*) FROM information_schema.TABLE_CONSTRAINTS
+                WHERE TABLE_SCHEMA = 'agencyservice'
+                  AND TABLE_NAME = 'agency_topic'
+                  AND CONSTRAINT_NAME = 'fk_agency_topic_dpp'
+            </sqlCheck>
+        </preConditions>
+        <sqlFile path="db/changelog/changeset/0026_legal_text/addAgencyTopicLegalTextReferences.sql" stripComments="true"/>
+        <rollback>
+            <sqlFile path="db/changelog/changeset/0026_legal_text/addAgencyTopicLegalTextReferences-rollback.sql" stripComments="true"/>
+        </rollback>
+    </changeSet>
+
+    <!-- ADR-014 step 3: lift inline department texts into shared objects, merging byte-identical
+         (tenant, content, status) texts into one row. Inline columns stay as rollback anchor. -->
+    <changeSet author="oriso" id="backfillLegalTextFromInline">
+        <sqlFile path="db/changelog/changeset/0026_legal_text/backfillLegalTextFromInline.sql" stripComments="true"/>
+        <rollback>
+            <sqlFile path="db/changelog/changeset/0026_legal_text/backfillLegalTextFromInline-rollback.sql" stripComments="true"/>
+        </rollback>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changeset/0026_legal_text/addAgencyTopicLegalTextReferences-rollback.sql
+++ b/src/main/resources/db/changelog/changeset/0026_legal_text/addAgencyTopicLegalTextReferences-rollback.sql
@@ -1,0 +1,4 @@
+ALTER TABLE `agencyservice`.`agency_topic` DROP FOREIGN KEY IF EXISTS `fk_agency_topic_dpp`;
+ALTER TABLE `agencyservice`.`agency_topic` DROP FOREIGN KEY IF EXISTS `fk_agency_topic_imprint`;
+ALTER TABLE `agencyservice`.`agency_topic` DROP COLUMN IF EXISTS `dpp_id`;
+ALTER TABLE `agencyservice`.`agency_topic` DROP COLUMN IF EXISTS `imprint_id`;

--- a/src/main/resources/db/changelog/changeset/0026_legal_text/addAgencyTopicLegalTextReferences-rollback.sql
+++ b/src/main/resources/db/changelog/changeset/0026_legal_text/addAgencyTopicLegalTextReferences-rollback.sql
@@ -1,4 +1,6 @@
 ALTER TABLE `agencyservice`.`agency_topic` DROP FOREIGN KEY IF EXISTS `fk_agency_topic_dpp`;
 ALTER TABLE `agencyservice`.`agency_topic` DROP FOREIGN KEY IF EXISTS `fk_agency_topic_imprint`;
+ALTER TABLE `agencyservice`.`agency_topic` DROP INDEX IF EXISTS `idx_agency_topic_dpp_id`;
+ALTER TABLE `agencyservice`.`agency_topic` DROP INDEX IF EXISTS `idx_agency_topic_imprint_id`;
 ALTER TABLE `agencyservice`.`agency_topic` DROP COLUMN IF EXISTS `dpp_id`;
 ALTER TABLE `agencyservice`.`agency_topic` DROP COLUMN IF EXISTS `imprint_id`;

--- a/src/main/resources/db/changelog/changeset/0026_legal_text/addAgencyTopicLegalTextReferences.sql
+++ b/src/main/resources/db/changelog/changeset/0026_legal_text/addAgencyTopicLegalTextReferences.sql
@@ -1,0 +1,16 @@
+-- ADR-014: departments reference their legal texts instead of owning inline copies. The inline
+-- content_dpp / content_imprint columns stay for one release as a read-fallback and rollback
+-- anchor; the read path ignores them once a reference is set.
+ALTER TABLE `agencyservice`.`agency_topic`
+ADD COLUMN IF NOT EXISTS `dpp_id` bigint(21) NULL;
+
+ALTER TABLE `agencyservice`.`agency_topic`
+ADD COLUMN IF NOT EXISTS `imprint_id` bigint(21) NULL;
+
+ALTER TABLE `agencyservice`.`agency_topic`
+ADD CONSTRAINT `fk_agency_topic_dpp` FOREIGN KEY (`dpp_id`)
+REFERENCES `agencyservice`.`legal_text` (`id`) ON UPDATE CASCADE;
+
+ALTER TABLE `agencyservice`.`agency_topic`
+ADD CONSTRAINT `fk_agency_topic_imprint` FOREIGN KEY (`imprint_id`)
+REFERENCES `agencyservice`.`legal_text` (`id`) ON UPDATE CASCADE;

--- a/src/main/resources/db/changelog/changeset/0026_legal_text/addAgencyTopicLegalTextReferences.sql
+++ b/src/main/resources/db/changelog/changeset/0026_legal_text/addAgencyTopicLegalTextReferences.sql
@@ -7,6 +7,15 @@ ADD COLUMN IF NOT EXISTS `dpp_id` bigint(21) NULL;
 ALTER TABLE `agencyservice`.`agency_topic`
 ADD COLUMN IF NOT EXISTS `imprint_id` bigint(21) NULL;
 
+-- Explicit, predictably-named indexes created before the FK constraints so InnoDB reuses them
+-- instead of auto-generating one per FK. countByDpp_Id / countByImprint_Id and the assignment
+-- joins would otherwise table-scan agency_topic at scale.
+ALTER TABLE `agencyservice`.`agency_topic`
+ADD INDEX IF NOT EXISTS `idx_agency_topic_dpp_id` (`dpp_id`);
+
+ALTER TABLE `agencyservice`.`agency_topic`
+ADD INDEX IF NOT EXISTS `idx_agency_topic_imprint_id` (`imprint_id`);
+
 ALTER TABLE `agencyservice`.`agency_topic`
 ADD CONSTRAINT `fk_agency_topic_dpp` FOREIGN KEY (`dpp_id`)
 REFERENCES `agencyservice`.`legal_text` (`id`) ON UPDATE CASCADE;

--- a/src/main/resources/db/changelog/changeset/0026_legal_text/backfillLegalTextFromInline-rollback.sql
+++ b/src/main/resources/db/changelog/changeset/0026_legal_text/backfillLegalTextFromInline-rollback.sql
@@ -1,0 +1,4 @@
+-- Unlink and remove only the migrated objects; the inline columns still hold the original texts.
+UPDATE `agencyservice`.`agency_topic` SET `dpp_id` = NULL WHERE `dpp_id` IS NOT NULL;
+UPDATE `agencyservice`.`agency_topic` SET `imprint_id` = NULL WHERE `imprint_id` IS NOT NULL;
+DELETE FROM `agencyservice`.`legal_text` WHERE `label` LIKE 'Migrated %';

--- a/src/main/resources/db/changelog/changeset/0026_legal_text/backfillLegalTextFromInline.sql
+++ b/src/main/resources/db/changelog/changeset/0026_legal_text/backfillLegalTextFromInline.sql
@@ -1,0 +1,67 @@
+-- ADR-014 backfill: lift the inline per-department legal texts into shared legal_text objects.
+-- Byte-identical texts (same tenant, same content, same publication status) collapse into ONE
+-- shared row, so departments that legally share a document reference a single maintained object.
+-- Only reference-less rows with real content are lifted; re-running is a no-op because linked
+-- rows are excluded by the dpp_id/imprint_id IS NULL guards.
+
+-- 1) one legal_text per distinct (tenant, content, status) DPP
+INSERT INTO `agencyservice`.`legal_text`
+    (`id`, `tenant_id`, `kind`, `label`, `content`, `publication_status`, `create_date`, `update_date`)
+SELECT NEXT VALUE FOR `agencyservice`.`sequence_legal_text`,
+       src.`tenant_id`,
+       'DPP',
+       CONCAT('Migrated data privacy policy ', ROW_NUMBER() OVER (ORDER BY src.`tenant_id`)),
+       src.`content`,
+       src.`status`,
+       UTC_TIMESTAMP(),
+       UTC_TIMESTAMP()
+FROM (
+    SELECT DISTINCT a.`tenant_id` AS `tenant_id`,
+                    at.`content_dpp` AS `content`,
+                    at.`publication_status` AS `status`
+    FROM `agencyservice`.`agency_topic` at
+    JOIN `agencyservice`.`agency` a ON a.`id` = at.`agency_id`
+    WHERE at.`content_dpp` IS NOT NULL AND at.`content_dpp` <> '' AND at.`dpp_id` IS NULL
+) src;
+
+-- 2) link each department to its (possibly shared) DPP object
+UPDATE `agencyservice`.`agency_topic` at
+JOIN `agencyservice`.`agency` a ON a.`id` = at.`agency_id`
+JOIN `agencyservice`.`legal_text` lt
+    ON lt.`kind` = 'DPP'
+    AND (lt.`tenant_id` <=> a.`tenant_id`)
+    AND lt.`content` = at.`content_dpp`
+    AND lt.`publication_status` = at.`publication_status`
+SET at.`dpp_id` = lt.`id`
+WHERE at.`content_dpp` IS NOT NULL AND at.`content_dpp` <> '' AND at.`dpp_id` IS NULL;
+
+-- 3) one legal_text per distinct (tenant, content, status) imprint
+INSERT INTO `agencyservice`.`legal_text`
+    (`id`, `tenant_id`, `kind`, `label`, `content`, `publication_status`, `create_date`, `update_date`)
+SELECT NEXT VALUE FOR `agencyservice`.`sequence_legal_text`,
+       src.`tenant_id`,
+       'IMPRINT',
+       CONCAT('Migrated imprint ', ROW_NUMBER() OVER (ORDER BY src.`tenant_id`)),
+       src.`content`,
+       src.`status`,
+       UTC_TIMESTAMP(),
+       UTC_TIMESTAMP()
+FROM (
+    SELECT DISTINCT a.`tenant_id` AS `tenant_id`,
+                    at.`content_imprint` AS `content`,
+                    at.`publication_status_imprint` AS `status`
+    FROM `agencyservice`.`agency_topic` at
+    JOIN `agencyservice`.`agency` a ON a.`id` = at.`agency_id`
+    WHERE at.`content_imprint` IS NOT NULL AND at.`content_imprint` <> '' AND at.`imprint_id` IS NULL
+) src;
+
+-- 4) link each department to its (possibly shared) imprint object
+UPDATE `agencyservice`.`agency_topic` at
+JOIN `agencyservice`.`agency` a ON a.`id` = at.`agency_id`
+JOIN `agencyservice`.`legal_text` lt
+    ON lt.`kind` = 'IMPRINT'
+    AND (lt.`tenant_id` <=> a.`tenant_id`)
+    AND lt.`content` = at.`content_imprint`
+    AND lt.`publication_status` = at.`publication_status_imprint`
+SET at.`imprint_id` = lt.`id`
+WHERE at.`content_imprint` IS NOT NULL AND at.`content_imprint` <> '' AND at.`imprint_id` IS NULL;

--- a/src/main/resources/db/changelog/changeset/0026_legal_text/createLegalText-rollback.sql
+++ b/src/main/resources/db/changelog/changeset/0026_legal_text/createLegalText-rollback.sql
@@ -1,0 +1,2 @@
+DROP SEQUENCE IF EXISTS `agencyservice`.`sequence_legal_text`;
+DROP TABLE IF EXISTS `agencyservice`.`legal_text`;

--- a/src/main/resources/db/changelog/changeset/0026_legal_text/createLegalText.sql
+++ b/src/main/resources/db/changelog/changeset/0026_legal_text/createLegalText.sql
@@ -1,0 +1,20 @@
+-- ADR-014: legal texts (DPP / Impressum) become first-class shared objects owned by a Träger.
+CREATE TABLE IF NOT EXISTS `agencyservice`.`legal_text` (
+    `id` bigint(21) NOT NULL,
+    `tenant_id` bigint(21) NULL,
+    `kind` varchar(20) NOT NULL,
+    `label` varchar(255) NOT NULL,
+    `content` longtext NULL,
+    `publication_status` varchar(20) NOT NULL DEFAULT 'DRAFT',
+    `create_date` datetime NOT NULL DEFAULT (UTC_TIMESTAMP),
+    `update_date` datetime NOT NULL DEFAULT (UTC_TIMESTAMP),
+    PRIMARY KEY (`id`),
+    KEY `idx_legal_text_tenant_kind` (`tenant_id`, `kind`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+
+CREATE SEQUENCE IF NOT EXISTS `agencyservice`.`sequence_legal_text`
+INCREMENT BY 1
+MINVALUE = 0
+NOMAXVALUE
+START WITH 0
+CACHE 10;

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/controller/AgencyAdminControllerDepartmentDppTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/controller/AgencyAdminControllerDepartmentDppTest.java
@@ -11,6 +11,7 @@ import de.caritas.cob.agencyservice.api.admin.service.agencypostcoderange.Agency
 import de.caritas.cob.agencyservice.api.admin.service.legal.DepartmentDataProtectionService;
 import de.caritas.cob.agencyservice.api.admin.service.legal.DepartmentDataProtectionView;
 import de.caritas.cob.agencyservice.api.admin.service.legal.DepartmentImprintService;
+import de.caritas.cob.agencyservice.api.admin.service.legal.LegalTextAdminService;
 import de.caritas.cob.agencyservice.api.admin.validation.AgencyValidator;
 import de.caritas.cob.agencyservice.api.model.DepartmentDataProtectionContentDTO;
 import de.caritas.cob.agencyservice.api.model.DepartmentDataProtectionDTO;
@@ -34,6 +35,7 @@ class AgencyAdminControllerDepartmentDppTest {
   @Mock private AgencyAdminControlsFacade agencyAdminControlsFacade;
   @Mock private DepartmentDataProtectionService departmentDataProtectionService;
   @Mock private DepartmentImprintService departmentImprintService;
+  @Mock private LegalTextAdminService legalTextAdminService;
 
   @InjectMocks private AgencyAdminController controller;
 

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/controller/AgencyAdminControllerDepartmentImprintTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/controller/AgencyAdminControllerDepartmentImprintTest.java
@@ -10,6 +10,7 @@ import de.caritas.cob.agencyservice.api.admin.service.agencyadmincontrol.AgencyA
 import de.caritas.cob.agencyservice.api.admin.service.agencypostcoderange.AgencyPostcodeRangeAdminService;
 import de.caritas.cob.agencyservice.api.admin.service.legal.DepartmentDataProtectionService;
 import de.caritas.cob.agencyservice.api.admin.service.legal.DepartmentImprintService;
+import de.caritas.cob.agencyservice.api.admin.service.legal.LegalTextAdminService;
 import de.caritas.cob.agencyservice.api.admin.service.legal.DepartmentImprintView;
 import de.caritas.cob.agencyservice.api.admin.validation.AgencyValidator;
 import de.caritas.cob.agencyservice.api.model.DepartmentImprintContentDTO;
@@ -34,6 +35,7 @@ class AgencyAdminControllerDepartmentImprintTest {
   @Mock private AgencyAdminControlsFacade agencyAdminControlsFacade;
   @Mock private DepartmentDataProtectionService departmentDataProtectionService;
   @Mock private DepartmentImprintService departmentImprintService;
+  @Mock private LegalTextAdminService legalTextAdminService;
 
   @InjectMocks private AgencyAdminController controller;
 

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/controller/AgencyAdminControllerLegalTextTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/controller/AgencyAdminControllerLegalTextTest.java
@@ -92,9 +92,10 @@ class AgencyAdminControllerLegalTextTest {
   }
 
   @Test
-  void updateLegalText_Should_delegate() {
+  void updateLegalText_Should_passNullPublish_ToPreserveCurrentStatus() {
+    // omitted publish flag = keep the current publication status (review regression)
     when(legalTextAdminService.updateLegalText(
-            eq(1L), eq("Umbenannt"), eq(Map.of("de", "<p>y</p>")), eq(false)))
+            eq(1L), eq("Umbenannt"), eq(Map.of("de", "<p>y</p>")), isNull()))
         .thenReturn(view(1L, 2L));
 
     var body =
@@ -103,6 +104,22 @@ class AgencyAdminControllerLegalTextTest {
 
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
     assertThat(response.getBody().getUsageCount()).isEqualTo(2L);
+  }
+
+  @Test
+  void updateLegalText_Should_passExplicitPublishFlag() {
+    when(legalTextAdminService.updateLegalText(
+            eq(1L), eq("Umbenannt"), eq(Map.of("de", "<p>y</p>")), eq(Boolean.TRUE)))
+        .thenReturn(view(1L, 2L));
+
+    var body =
+        new UpdateLegalTextDTO()
+            .label("Umbenannt")
+            .content(Map.of("de", "<p>y</p>"))
+            .publish(true);
+    var response = controller.updateLegalText(1L, body);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/controller/AgencyAdminControllerLegalTextTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/controller/AgencyAdminControllerLegalTextTest.java
@@ -1,0 +1,130 @@
+package de.caritas.cob.agencyservice.api.admin.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import de.caritas.cob.agencyservice.api.admin.service.AgencyAdminService;
+import de.caritas.cob.agencyservice.api.admin.service.agency.AgencyAdminSearchService;
+import de.caritas.cob.agencyservice.api.admin.service.agencyadmincontrol.AgencyAdminControlsFacade;
+import de.caritas.cob.agencyservice.api.admin.service.agencypostcoderange.AgencyPostcodeRangeAdminService;
+import de.caritas.cob.agencyservice.api.admin.service.legal.DepartmentDataProtectionService;
+import de.caritas.cob.agencyservice.api.admin.service.legal.DepartmentImprintService;
+import de.caritas.cob.agencyservice.api.admin.service.legal.LegalTextAdminService;
+import de.caritas.cob.agencyservice.api.admin.service.legal.LegalTextAdminView;
+import de.caritas.cob.agencyservice.api.admin.validation.AgencyValidator;
+import de.caritas.cob.agencyservice.api.model.CreateLegalTextDTO;
+import de.caritas.cob.agencyservice.api.model.LegalTextAdminDTO;
+import de.caritas.cob.agencyservice.api.model.LegalTextAssignmentDTO;
+import de.caritas.cob.agencyservice.api.model.UpdateLegalTextDTO;
+import de.caritas.cob.agencyservice.api.repository.agencytopic.PublicationStatus;
+import de.caritas.cob.agencyservice.api.repository.legaltext.LegalTextKind;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+
+/** ADR-014 legal-text library endpoints: delegation + DTO mapping. */
+@ExtendWith(MockitoExtension.class)
+class AgencyAdminControllerLegalTextTest {
+
+  @Mock private AgencyAdminSearchService agencyAdminSearchService;
+  @Mock private AgencyPostcodeRangeAdminService agencyPostcodeRangeAdminService;
+  @Mock private AgencyAdminService agencyAdminService;
+  @Mock private AgencyValidator agencyValidator;
+  @Mock private AgencyAdminControlsFacade agencyAdminControlsFacade;
+  @Mock private DepartmentDataProtectionService departmentDataProtectionService;
+  @Mock private DepartmentImprintService departmentImprintService;
+  @Mock private LegalTextAdminService legalTextAdminService;
+
+  @InjectMocks private AgencyAdminController controller;
+
+  private LegalTextAdminView view(long id, long usage) {
+    return new LegalTextAdminView(
+        id,
+        LegalTextKind.DPP,
+        "Standard-DSE",
+        "{\"de\":\"<p>x</p>\"}",
+        PublicationStatus.PUBLISHED,
+        usage);
+  }
+
+  @Test
+  void getLegalTexts_Should_delegate_andMapViewsWithUsageCount() {
+    when(legalTextAdminService.listLegalTexts(LegalTextKind.DPP))
+        .thenReturn(List.of(view(1L, 3L)));
+
+    var response = controller.getLegalTexts("DPP");
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody()).hasSize(1);
+    var dto = response.getBody().get(0);
+    assertThat(dto.getId()).isEqualTo(1L);
+    assertThat(dto.getKind()).isEqualTo(LegalTextAdminDTO.KindEnum.DPP);
+    assertThat(dto.getLabel()).isEqualTo("Standard-DSE");
+    assertThat(dto.getUsageCount()).isEqualTo(3L);
+    assertThat(dto.getPublicationStatus())
+        .isEqualTo(LegalTextAdminDTO.PublicationStatusEnum.PUBLISHED);
+  }
+
+  @Test
+  void createLegalText_Should_delegateWithPublishFlag() {
+    when(legalTextAdminService.createLegalText(
+            eq(LegalTextKind.DPP), eq("Neu"), eq(Map.of("de", "<p>x</p>")), eq(true)))
+        .thenReturn(view(2L, 0L));
+
+    var body =
+        new CreateLegalTextDTO()
+            .kind(CreateLegalTextDTO.KindEnum.DPP)
+            .label("Neu")
+            .content(Map.of("de", "<p>x</p>"))
+            .publish(true);
+    var response = controller.createLegalText(body);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody().getId()).isEqualTo(2L);
+  }
+
+  @Test
+  void updateLegalText_Should_delegate() {
+    when(legalTextAdminService.updateLegalText(
+            eq(1L), eq("Umbenannt"), eq(Map.of("de", "<p>y</p>")), eq(false)))
+        .thenReturn(view(1L, 2L));
+
+    var body =
+        new UpdateLegalTextDTO().label("Umbenannt").content(Map.of("de", "<p>y</p>"));
+    var response = controller.updateLegalText(1L, body);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody().getUsageCount()).isEqualTo(2L);
+  }
+
+  @Test
+  void assignDepartmentLegalText_Should_delegate_andReturn204() {
+    var body =
+        new LegalTextAssignmentDTO().kind(LegalTextAssignmentDTO.KindEnum.IMPRINT).legalTextId(9L);
+
+    var response = controller.assignDepartmentLegalText(7L, 42L, body);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+    verify(legalTextAdminService)
+        .assignDepartmentLegalText(7L, 42L, LegalTextKind.IMPRINT, 9L);
+  }
+
+  @Test
+  void assignDepartmentLegalText_Should_passNullId_ForUnassign() {
+    var body = new LegalTextAssignmentDTO().kind(LegalTextAssignmentDTO.KindEnum.DPP);
+
+    var response = controller.assignDepartmentLegalText(7L, 42L, body);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+    verify(legalTextAdminService)
+        .assignDepartmentLegalText(eq(7L), eq(42L), eq(LegalTextKind.DPP), isNull());
+  }
+}

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/controller/AgencyAdminControllerTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/controller/AgencyAdminControllerTest.java
@@ -170,6 +170,33 @@ public class AgencyAdminControllerTest {
   }
 
   @Test
+  public void searchAgencies_Should_bindUpperCasedSortFieldsSentByAdminFrontend()
+      throws Exception {
+    // The admin frontend upper-cases sort fields (field=POSTCODE, field=CREATEDATE),
+    // while the generated FieldEnum constants are POST_CODE and CREATE_DATE.
+    for (var fieldParam : java.util.List.of(
+        "POSTCODE", "CREATEDATE", "ID", "NAME", "CITY", "OFFLINE",
+        "postCode", "createDate")) {
+      this.mvc
+          .perform(get(AGENCY_SEARCH_PATH)
+              .param(PAGE_PARAM, "1").param(PER_PAGE_PARAM, "10")
+              .param("field", fieldParam).param("order", "ASC"))
+          .andExpect(status().isOk());
+    }
+
+    var sortCaptor = org.mockito.ArgumentCaptor.forClass(
+        de.caritas.cob.agencyservice.api.model.Sort.class);
+    Mockito.verify(this.agencyAdminFullResponseDTO, Mockito.times(8))
+        .searchAgencies(any(), eq(1), eq(10), sortCaptor.capture());
+    var boundFields = sortCaptor.getAllValues().stream()
+        .map(s -> s == null || s.getField() == null ? null : s.getField().name())
+        .toList();
+    org.assertj.core.api.Assertions.assertThat(boundFields).containsExactly(
+        "POST_CODE", "CREATE_DATE", "ID", "NAME", "CITY", "OFFLINE",
+        "POST_CODE", "CREATE_DATE");
+  }
+
+  @Test
   @WithMockUser(authorities = {"AUTHORIZATION_AGENCY_ADMIN"})
   public void createAgency_Should_returnCreated_When_AgencyDtoIsGiven() throws Exception {
 

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/service/agency/AgencyAdminSearchServiceIT.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/service/agency/AgencyAdminSearchServiceIT.java
@@ -69,7 +69,7 @@ class AgencyAdminSearchServiceIT {
   void searchAgency_Should_FindOnlyAgenciesManagedByTheAdmin_WhenUserIsAgencyAdmin() {
     // given
     when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(true);
-    when(authenticatedUser.getUserId()).thenReturn("userId");
+    when(authenticatedUser.requireUserId()).thenReturn("userId");
     when(securityHeaderSupplier.getKeycloakAndCsrfHttpHeaders()).thenReturn(new HttpHeaders());
     when(userAdminServiceApiControllerFactory.createControllerApi()).thenReturn(adminUserControllerApi);
     when(adminUserControllerApi.getAdminAgencies("userId")).thenReturn(Lists.newArrayList(2L, 3L));
@@ -86,7 +86,7 @@ class AgencyAdminSearchServiceIT {
   void searchAgency_Should_FindOnlyAgenciesManagedByTheAdmin_WhenUserIsAgencyAdmin_AndSortByPostcodeAscending() {
     // given
     when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(false);
-    when(authenticatedUser.getUserId()).thenReturn("userId");
+    when(authenticatedUser.requireUserId()).thenReturn("userId");
     when(securityHeaderSupplier.getKeycloakAndCsrfHttpHeaders()).thenReturn(new HttpHeaders());
     when(userAdminServiceApiControllerFactory.createControllerApi()).thenReturn(adminUserControllerApi);
     when(adminUserControllerApi.getAdminAgencies("userId")).thenReturn(Lists.newArrayList(2L, 3L));
@@ -105,7 +105,7 @@ class AgencyAdminSearchServiceIT {
   void searchAgency_Should_FindOnlyAgenciesManagedByTheAdmin_WhenUserIsAgencyAdmin_AndSortByOffline() {
     // given
     when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(false);
-    when(authenticatedUser.getUserId()).thenReturn("userId");
+    when(authenticatedUser.requireUserId()).thenReturn("userId");
     when(securityHeaderSupplier.getKeycloakAndCsrfHttpHeaders()).thenReturn(new HttpHeaders());
     when(userAdminServiceApiControllerFactory.createControllerApi()).thenReturn(adminUserControllerApi);
     when(adminUserControllerApi.getAdminAgencies("userId")).thenReturn(Lists.newArrayList(2L, 3L));
@@ -125,7 +125,7 @@ class AgencyAdminSearchServiceIT {
   void searchAgency_Should_FindOnlyAgenciesManagedByTheAdmin_WhenUserIsAgencyAdmin_AndSortByPostcodeDescending() {
     // given
     when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(false);
-    when(authenticatedUser.getUserId()).thenReturn("userId");
+    when(authenticatedUser.requireUserId()).thenReturn("userId");
     when(securityHeaderSupplier.getKeycloakAndCsrfHttpHeaders()).thenReturn(new HttpHeaders());
     when(userAdminServiceApiControllerFactory.createControllerApi()).thenReturn(adminUserControllerApi);
     when(adminUserControllerApi.getAdminAgencies("userId")).thenReturn(Lists.newArrayList(2L, 3L));
@@ -198,7 +198,7 @@ class AgencyAdminSearchServiceIT {
   void searchAgency_Should_NotFindAnyAgencies_WhenUserIsAgencyAdminButDoesntManageAnyAgencies() {
     // given
     when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(true);
-    when(authenticatedUser.getUserId()).thenReturn("userId");
+    when(authenticatedUser.requireUserId()).thenReturn("userId");
     when(securityHeaderSupplier.getKeycloakAndCsrfHttpHeaders()).thenReturn(new HttpHeaders());
     when(userAdminServiceApiControllerFactory.createControllerApi()).thenReturn(adminUserControllerApi);
     when(adminUserControllerApi.getAdminAgencies("userId")).thenReturn(Lists.newArrayList());

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/service/agency/AgencyAdminSearchServiceIT.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/service/agency/AgencyAdminSearchServiceIT.java
@@ -141,6 +141,60 @@ class AgencyAdminSearchServiceIT {
   }
 
   @Test
+  void searchAgency_Should_SortByIdAscending() {
+    // given, when
+    var agencySearchResult = agencyAdminSearchService.searchAgencies("", 1, 20,
+        new Sort().field(FieldEnum.ID).order(Sort.OrderEnum.ASC));
+
+    // then
+    assertThat(agencySearchResult.getEmbedded()).hasSize(20);
+    List<Long> collect = agencySearchResult.getEmbedded().stream()
+        .map(p -> p.getEmbedded().getId()).collect(Collectors.toList());
+    assertThat(collect).isSorted();
+  }
+
+  @Test
+  void searchAgency_Should_SortByIdDescending() {
+    // given, when
+    var agencySearchResult = agencyAdminSearchService.searchAgencies("", 1, 20,
+        new Sort().field(FieldEnum.ID).order(Sort.OrderEnum.DESC));
+
+    // then
+    assertThat(agencySearchResult.getEmbedded()).hasSize(20);
+    List<Long> collect = agencySearchResult.getEmbedded().stream()
+        .map(p -> p.getEmbedded().getId()).collect(Collectors.toList());
+    assertThat(collect).isSortedAccordingTo(Comparator.reverseOrder());
+  }
+
+  @Test
+  void searchAgency_Should_SortByCreateDateAscending() {
+    // given, when
+    var agencySearchResult = agencyAdminSearchService.searchAgencies("", 1, 20,
+        new Sort().field(FieldEnum.CREATE_DATE).order(Sort.OrderEnum.ASC));
+
+    // then
+    assertThat(agencySearchResult.getEmbedded()).hasSize(20);
+    List<String> collect = agencySearchResult.getEmbedded().stream()
+        .filter(result -> result.getEmbedded().getCreateDate() != null)
+        .map(p -> p.getEmbedded().getCreateDate()).collect(Collectors.toList());
+    assertThat(collect).isSorted();
+  }
+
+  @Test
+  void searchAgency_Should_SortByCreateDateDescending() {
+    // given, when
+    var agencySearchResult = agencyAdminSearchService.searchAgencies("", 1, 20,
+        new Sort().field(FieldEnum.CREATE_DATE).order(Sort.OrderEnum.DESC));
+
+    // then
+    assertThat(agencySearchResult.getEmbedded()).hasSize(20);
+    List<String> collect = agencySearchResult.getEmbedded().stream()
+        .filter(result -> result.getEmbedded().getCreateDate() != null)
+        .map(p -> p.getEmbedded().getCreateDate()).collect(Collectors.toList());
+    assertThat(collect).isSortedAccordingTo(Comparator.reverseOrder());
+  }
+
+  @Test
   void searchAgency_Should_NotFindAnyAgencies_WhenUserIsAgencyAdminButDoesntManageAnyAgencies() {
     // given
     when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(true);

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/service/agency/AgencyAdminSearchTenantSupportServiceTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/service/agency/AgencyAdminSearchTenantSupportServiceTest.java
@@ -157,7 +157,7 @@ class AgencyAdminSearchTenantSupportServiceTest {
     stubTenantIdPath();
     TenantContext.setCurrentTenant(1L);
     when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(true);
-    when(authenticatedUser.getUserId()).thenReturn(USER_ID);
+    when(authenticatedUser.requireUserId()).thenReturn(USER_ID);
     when(authenticatedUser.getTenantId()).thenReturn(null);
     when(userAdminService.getAdminUserAgencyIds(USER_ID)).thenReturn(List.of(100L));
 
@@ -185,7 +185,7 @@ class AgencyAdminSearchTenantSupportServiceTest {
     stubTenantIdPath();
     TenantContext.setCurrentTenant(1L);
     when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(true);
-    when(authenticatedUser.getUserId()).thenReturn(USER_ID);
+    when(authenticatedUser.requireUserId()).thenReturn(USER_ID);
     when(authenticatedUser.getTenantId()).thenReturn(1L);
     when(userAdminService.getAdminUserAgencyIds(USER_ID)).thenReturn(Collections.emptyList());
 

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/service/agency/AgencySettingsServiceTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/service/agency/AgencySettingsServiceTest.java
@@ -80,6 +80,68 @@ class AgencySettingsServiceTest {
   }
 
   @Test
+  void toSettings_Should_IgnoreUnknownProperties_When_StoredJsonContainsRetiredKeys() {
+    // Stored agency settings may still carry keys removed from the schema; a read must
+    // never fail because of them.
+    Settings result =
+        agencySettingsService.toSettings(
+            "{\"featureStatisticsEnabled\":true,\"someRetiredUnknownKey\":true}");
+
+    assertThat(result.getFeatureStatisticsEnabled()).isTrue();
+  }
+
+  @Test
+  void toSettings_Should_TranslateLegacyAttachmentUploadDisabled_ToMediaUploadOff() {
+    // ADR-015: legacy true = uploads were switched off -> whole upload family off.
+    Settings result =
+        agencySettingsService.toSettings("{\"featureAttachmentUploadDisabled\":true}");
+
+    assertThat(result.getFeatureMediaUploadEnabled()).isFalse();
+    assertThat(result.getFeatureMediaUploadAnonymousChatsEnabled()).isFalse();
+    assertThat(result.getFeatureMediaUploadOneOnOneChatsEnabled()).isFalse();
+    assertThat(result.getFeatureMediaUploadGroupChatsEnabled()).isFalse();
+    assertThat(result.getFeatureMediaUploadSupervisionChatsEnabled()).isFalse();
+    // other media families are not the legacy flag's concern
+    assertThat(result.getFeatureMediaInlineDisplayEnabled()).isNull();
+    assertThat(result.getFeatureMediaAiScanEnabled()).isNull();
+  }
+
+  @Test
+  void toSettings_Should_NotTouchMediaUpload_When_LegacyFlagIsFalseOrAbsent() {
+    Settings legacyFalse =
+        agencySettingsService.toSettings("{\"featureAttachmentUploadDisabled\":false}");
+    assertThat(legacyFalse.getFeatureMediaUploadEnabled()).isNull();
+
+    Settings legacyAbsent = agencySettingsService.toSettings("{}");
+    assertThat(legacyAbsent.getFeatureMediaUploadEnabled()).isNull();
+  }
+
+  @Test
+  void toSettings_Should_PreferExplicitMediaUploadValues_OverLegacyTranslation() {
+    Settings result =
+        agencySettingsService.toSettings(
+            "{\"featureAttachmentUploadDisabled\":true,"
+                + "\"featureMediaUploadEnabled\":true,"
+                + "\"featureMediaUploadGroupChatsEnabled\":false}");
+
+    assertThat(result.getFeatureMediaUploadEnabled()).isTrue();
+    assertThat(result.getFeatureMediaUploadGroupChatsEnabled()).isFalse();
+    // untouched variants still translate from the legacy flag
+    assertThat(result.getFeatureMediaUploadOneOnOneChatsEnabled()).isFalse();
+  }
+
+  @Test
+  void toSettingsJson_Should_NeverWriteTheRetiredLegacyKey() {
+    Settings settings =
+        agencySettingsService.toSettings("{\"featureAttachmentUploadDisabled\":true}");
+
+    String json = agencySettingsService.toSettingsJson(settings);
+
+    assertThat(json).doesNotContain("featureAttachmentUploadDisabled");
+    assertThat(json).contains("\"featureMediaUploadEnabled\":false");
+  }
+
+  @Test
   void toSettingsJson_Should_ReturnNull_When_SettingsIsNull() {
     assertThat(agencySettingsService.toSettingsJson(null)).isNull();
   }

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/service/legal/DepartmentDataProtectionServiceTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/service/legal/DepartmentDataProtectionServiceTest.java
@@ -173,7 +173,7 @@ class DepartmentDataProtectionServiceTest {
   @Test
   void publish_Should_allow_When_restrictedAdminOwnsTheAgency() {
     when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(true);
-    when(authenticatedUser.getUserId()).thenReturn("admin-1");
+    when(authenticatedUser.requireUserId()).thenReturn("admin-1");
     when(userAdminService.getAdminUserAgencyIds("admin-1")).thenReturn(List.of(7L, 9L));
     existingDepartment();
 
@@ -187,7 +187,7 @@ class DepartmentDataProtectionServiceTest {
   @Test
   void publish_Should_throwAccessDenied_When_restrictedAdminDoesNotOwnTheAgency() {
     when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(true);
-    when(authenticatedUser.getUserId()).thenReturn("admin-1");
+    when(authenticatedUser.requireUserId()).thenReturn("admin-1");
     when(userAdminService.getAdminUserAgencyIds("admin-1")).thenReturn(List.of(9L));
 
     assertThatExceptionOfType(AgencyAccessDeniedException.class)
@@ -228,7 +228,7 @@ class DepartmentDataProtectionServiceTest {
   @Test
   void getDepartmentDataPrivacy_Should_throwAccessDenied_When_restrictedAdminDoesNotOwnTheAgency() {
     when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(true);
-    when(authenticatedUser.getUserId()).thenReturn("admin-1");
+    when(authenticatedUser.requireUserId()).thenReturn("admin-1");
     when(userAdminService.getAdminUserAgencyIds("admin-1")).thenReturn(List.of(9L));
 
     assertThatExceptionOfType(AgencyAccessDeniedException.class)

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/service/legal/DepartmentDataProtectionServiceTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/service/legal/DepartmentDataProtectionServiceTest.java
@@ -16,6 +16,8 @@ import de.caritas.cob.agencyservice.api.repository.agency.Agency;
 import de.caritas.cob.agencyservice.api.repository.agencytopic.AgencyTopic;
 import de.caritas.cob.agencyservice.api.repository.agencytopic.AgencyTopicRepository;
 import de.caritas.cob.agencyservice.api.repository.agencytopic.PublicationStatus;
+import de.caritas.cob.agencyservice.api.repository.legaltext.LegalText;
+import de.caritas.cob.agencyservice.api.repository.legaltext.LegalTextKind;
 import de.caritas.cob.agencyservice.api.tenant.TenantContext;
 import de.caritas.cob.agencyservice.api.util.AuthenticatedUser;
 import de.caritas.cob.agencyservice.api.validation.InputSanitizer;
@@ -75,6 +77,57 @@ class DepartmentDataProtectionServiceTest {
     when(agencyTopicRepository.findByAgency_IdAndTopicId(7L, 42L))
         .thenReturn(Optional.of(department));
     return department;
+  }
+
+  @Test
+  void publish_Should_writeThroughToReferencedLegalText_When_departmentReferencesOne() {
+    // ADR-014: once a department references a shared legal-text object, that object is the truth.
+    // The legacy per-department publish endpoint must therefore update the referenced object —
+    // writing the inline column would be silently ignored by the read path.
+    when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(false);
+    var department = existingDepartment();
+    var referenced =
+        LegalText.builder()
+            .id(100L)
+            .kind(LegalTextKind.DPP)
+            .label("Geteilte DSE")
+            .content("{\"de\":\"<p>alt</p>\"}")
+            .publicationStatus(PublicationStatus.DRAFT)
+            .build();
+    department.setDpp(referenced);
+
+    var status =
+        service.publishDepartmentDataPrivacy(7L, 42L, Map.of("de", "<p>neu</p>"), true);
+
+    assertThat(status).isEqualTo(PublicationStatus.PUBLISHED);
+    assertThat(referenced.getContent()).contains("neu");
+    assertThat(referenced.getPublicationStatus()).isEqualTo(PublicationStatus.PUBLISHED);
+    assertThat(referenced.getUpdateDate()).isNotNull();
+    // the inline copy stays untouched — it is dead weight kept only for rollback
+    var saved = ArgumentCaptor.forClass(AgencyTopic.class);
+    verify(agencyTopicRepository).save(saved.capture());
+    assertThat(saved.getValue().getContentDpp()).isNull();
+  }
+
+  @Test
+  void read_Should_returnReferencedLegalText_When_departmentReferencesOne() {
+    when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(false);
+    var department = existingDepartment();
+    department.setContentDpp("{\"de\":\"<p>inline-alt</p>\"}");
+    department.setPublicationStatus(PublicationStatus.DRAFT);
+    department.setDpp(
+        LegalText.builder()
+            .id(100L)
+            .kind(LegalTextKind.DPP)
+            .label("Geteilte DSE")
+            .content("{\"de\":\"<p>geteilt</p>\"}")
+            .publicationStatus(PublicationStatus.PUBLISHED)
+            .build());
+
+    var view = service.getDepartmentDataPrivacy(7L, 42L);
+
+    assertThat(view.content()).isEqualTo("{\"de\":\"<p>geteilt</p>\"}");
+    assertThat(view.publicationStatus()).isEqualTo(PublicationStatus.PUBLISHED);
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/service/legal/DepartmentDataProtectionServiceTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/service/legal/DepartmentDataProtectionServiceTest.java
@@ -47,7 +47,10 @@ class DepartmentDataProtectionServiceTest {
     // real sanitizer so we actually verify markup stripping, not a mock
     service =
         new DepartmentDataProtectionService(
-            agencyTopicRepository, new InputSanitizer(), authenticatedUser, userAdminService);
+            agencyTopicRepository,
+            new LegalContentSanitizer(new InputSanitizer()),
+            authenticatedUser,
+            userAdminService);
   }
 
   @AfterEach

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/service/legal/DepartmentImprintServiceTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/service/legal/DepartmentImprintServiceTest.java
@@ -47,7 +47,10 @@ class DepartmentImprintServiceTest {
     // real sanitizer so we actually verify markup stripping, not a mock
     service =
         new DepartmentImprintService(
-            agencyTopicRepository, new InputSanitizer(), authenticatedUser, userAdminService);
+            agencyTopicRepository,
+            new LegalContentSanitizer(new InputSanitizer()),
+            authenticatedUser,
+            userAdminService);
   }
 
   @AfterEach
@@ -259,8 +262,9 @@ class DepartmentImprintServiceTest {
     when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(false);
     var department = existingDepartment();
     // translation-metadata convention: __meta-suffixed keys carry JSON, not HTML - sanitising
-    // them would destroy the payload, so they are passed through JSON-validated instead
-    var metaJson = "{\"source\":\"machine\",\"reviewed\":false}";
+    // them would destroy the payload; they pass through after the STRICT schema validation
+    // (shared LegalContentSanitizer — the former lenient parse-only check is gone)
+    var metaJson = "{\"mt\":true,\"src\":\"de\",\"at\":\"2026-07-16T10:00:00Z\"}";
 
     service.publishDepartmentImprint(
         7L, 42L, Map.of("de", "<p>Impressum</p>", "de__meta", metaJson), true);
@@ -268,7 +272,25 @@ class DepartmentImprintServiceTest {
     var stored = department.getContentImprint();
     assertThat(stored).contains("\"de__meta\":");
     // the JSON payload survives verbatim (an HTML sanitizer would have escaped the quotes away)
-    assertThat(stored).contains("machine").contains("reviewed");
+    assertThat(stored).contains("mt").contains("src");
+  }
+
+  @Test
+  void publish_Should_rejectMetaWithUnknownFields() {
+    // the imprint path used to accept arbitrary JSON behind the __meta suffix — with the shared
+    // strict validation, unknown fields are rejected like on the DPP path
+    when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(false);
+    existingDepartment();
+
+    assertThatExceptionOfType(BadRequestException.class)
+        .isThrownBy(
+            () ->
+                service.publishDepartmentImprint(
+                    7L,
+                    42L,
+                    Map.of("de__meta", "{\"source\":\"machine\",\"reviewed\":false}"),
+                    true));
+    verify(agencyTopicRepository, never()).save(any());
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/service/legal/DepartmentImprintServiceTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/service/legal/DepartmentImprintServiceTest.java
@@ -184,7 +184,7 @@ class DepartmentImprintServiceTest {
   @Test
   void publish_Should_allow_When_restrictedAdminOwnsTheAgency() {
     when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(true);
-    when(authenticatedUser.getUserId()).thenReturn("admin-1");
+    when(authenticatedUser.requireUserId()).thenReturn("admin-1");
     when(userAdminService.getAdminUserAgencyIds("admin-1")).thenReturn(List.of(7L, 9L));
     existingDepartment();
 
@@ -197,7 +197,7 @@ class DepartmentImprintServiceTest {
   @Test
   void publish_Should_throwAccessDenied_When_restrictedAdminDoesNotOwnTheAgency() {
     when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(true);
-    when(authenticatedUser.getUserId()).thenReturn("admin-1");
+    when(authenticatedUser.requireUserId()).thenReturn("admin-1");
     when(userAdminService.getAdminUserAgencyIds("admin-1")).thenReturn(List.of(9L));
 
     assertThatExceptionOfType(AgencyAccessDeniedException.class)
@@ -322,7 +322,7 @@ class DepartmentImprintServiceTest {
   @Test
   void getDepartmentImprint_Should_throwAccessDenied_When_restrictedAdminDoesNotOwnTheAgency() {
     when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(true);
-    when(authenticatedUser.getUserId()).thenReturn("admin-1");
+    when(authenticatedUser.requireUserId()).thenReturn("admin-1");
     when(userAdminService.getAdminUserAgencyIds("admin-1")).thenReturn(List.of(9L));
 
     assertThatExceptionOfType(AgencyAccessDeniedException.class)

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/service/legal/DepartmentImprintServiceTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/service/legal/DepartmentImprintServiceTest.java
@@ -16,6 +16,8 @@ import de.caritas.cob.agencyservice.api.repository.agency.Agency;
 import de.caritas.cob.agencyservice.api.repository.agencytopic.AgencyTopic;
 import de.caritas.cob.agencyservice.api.repository.agencytopic.AgencyTopicRepository;
 import de.caritas.cob.agencyservice.api.repository.agencytopic.PublicationStatus;
+import de.caritas.cob.agencyservice.api.repository.legaltext.LegalText;
+import de.caritas.cob.agencyservice.api.repository.legaltext.LegalTextKind;
 import de.caritas.cob.agencyservice.api.tenant.TenantContext;
 import de.caritas.cob.agencyservice.api.util.AuthenticatedUser;
 import de.caritas.cob.agencyservice.api.validation.InputSanitizer;
@@ -75,6 +77,53 @@ class DepartmentImprintServiceTest {
     when(agencyTopicRepository.findByAgency_IdAndTopicId(7L, 42L))
         .thenReturn(Optional.of(department));
     return department;
+  }
+
+  @Test
+  void publish_Should_writeThroughToReferencedLegalText_When_departmentReferencesOne() {
+    // ADR-014: the referenced shared Impressum object is the truth; the legacy per-department
+    // endpoint writes through to it instead of the ignored inline column.
+    when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(false);
+    var department = existingDepartment();
+    var referenced =
+        LegalText.builder()
+            .id(101L)
+            .kind(LegalTextKind.IMPRINT)
+            .label("Geteiltes Impressum")
+            .content("{\"de\":\"<p>alt</p>\"}")
+            .publicationStatus(PublicationStatus.DRAFT)
+            .build();
+    department.setImprint(referenced);
+
+    var status = service.publishDepartmentImprint(7L, 42L, Map.of("de", "<p>neu</p>"), true);
+
+    assertThat(status).isEqualTo(PublicationStatus.PUBLISHED);
+    assertThat(referenced.getContent()).contains("neu");
+    assertThat(referenced.getPublicationStatus()).isEqualTo(PublicationStatus.PUBLISHED);
+    var saved = ArgumentCaptor.forClass(AgencyTopic.class);
+    verify(agencyTopicRepository).save(saved.capture());
+    assertThat(saved.getValue().getContentImprint()).isNull();
+  }
+
+  @Test
+  void read_Should_returnReferencedLegalText_When_departmentReferencesOne() {
+    when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(false);
+    var department = existingDepartment();
+    department.setContentImprint("{\"de\":\"<p>inline-alt</p>\"}");
+    department.setPublicationStatusImprint(PublicationStatus.DRAFT);
+    department.setImprint(
+        LegalText.builder()
+            .id(101L)
+            .kind(LegalTextKind.IMPRINT)
+            .label("Geteiltes Impressum")
+            .content("{\"de\":\"<p>geteilt</p>\"}")
+            .publicationStatus(PublicationStatus.PUBLISHED)
+            .build());
+
+    var view = service.getDepartmentImprint(7L, 42L);
+
+    assertThat(view.content()).isEqualTo("{\"de\":\"<p>geteilt</p>\"}");
+    assertThat(view.publicationStatus()).isEqualTo(PublicationStatus.PUBLISHED);
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/service/legal/LegalContentSanitizerTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/service/legal/LegalContentSanitizerTest.java
@@ -1,0 +1,95 @@
+package de.caritas.cob.agencyservice.api.admin.service.legal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import de.caritas.cob.agencyservice.api.exception.httpresponses.BadRequestException;
+import de.caritas.cob.agencyservice.api.validation.InputSanitizer;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The one canonical sanitisation path for admin-authored legal content (DPP, Impressum, shared
+ * legal texts): every translation value is OWASP-sanitised, {@code __meta}-suffixed keys carry
+ * translation metadata as JSON and are validated against the strict schema (only {@code
+ * mt:boolean}, {@code src:string}, {@code at:string}, non-blank, no unknown fields) because they
+ * are stored verbatim and served publicly.
+ */
+class LegalContentSanitizerTest {
+
+  private LegalContentSanitizer sanitizer;
+
+  @BeforeEach
+  void setUp() {
+    sanitizer = new LegalContentSanitizer(new InputSanitizer());
+  }
+
+  @Test
+  void sanitizeToJson_Should_stripDangerousMarkup_andKeepText() {
+    var json =
+        sanitizer.sanitizeToJson(
+            Map.of("de", "<p onclick=\"steal()\">Impressum <script>bad()</script></p>"));
+
+    assertThat(json).startsWith("{").contains("\"de\":");
+    assertThat(json).contains("Impressum").doesNotContain("script").doesNotContain("onclick");
+  }
+
+  @Test
+  void sanitizeToJson_Should_returnEmptyJsonObject_When_contentNull() {
+    assertThat(sanitizer.sanitizeToJson(null)).isEqualTo("{}");
+  }
+
+  @Test
+  void sanitizeToJson_Should_passThroughValidStrictMeta_Unsanitised() {
+    var metaJson = "{\"mt\":true,\"src\":\"de\",\"at\":\"2026-07-16T10:00:00Z\"}";
+
+    var json = sanitizer.sanitizeToJson(Map.of("de", "<p>x</p>", "de__meta", metaJson));
+
+    assertThat(json).contains("\"de__meta\":");
+    // quotes survive as JSON, not HTML entities
+    assertThat(json).contains("mt");
+  }
+
+  @Test
+  void sanitizeToJson_Should_rejectMetaWithUnknownFields() {
+    // the formerly lenient imprint path accepted arbitrary JSON here — no longer
+    assertThatExceptionOfType(BadRequestException.class)
+        .isThrownBy(
+            () ->
+                sanitizer.sanitizeToJson(
+                    Map.of("de__meta", "{\"source\":\"machine\",\"reviewed\":false}")));
+  }
+
+  @Test
+  void sanitizeToJson_Should_rejectNonObjectMeta() {
+    assertThatExceptionOfType(BadRequestException.class)
+        .isThrownBy(() -> sanitizer.sanitizeToJson(Map.of("de__meta", "[\"de\",\"en\"]")));
+    assertThatExceptionOfType(BadRequestException.class)
+        .isThrownBy(() -> sanitizer.sanitizeToJson(Map.of("de__meta", "\"just-a-string\"")));
+    assertThatExceptionOfType(BadRequestException.class)
+        .isThrownBy(() -> sanitizer.sanitizeToJson(Map.of("de__meta", "not-json{")));
+    assertThatExceptionOfType(BadRequestException.class)
+        .isThrownBy(() -> sanitizer.sanitizeToJson(Map.of("de__meta", "")));
+  }
+
+  @Test
+  void sanitizeToJson_Should_rejectWrongMetaFieldTypes() {
+    assertThatExceptionOfType(BadRequestException.class)
+        .isThrownBy(() -> sanitizer.sanitizeToJson(Map.of("de__meta", "{\"mt\":\"true\"}")));
+    assertThatExceptionOfType(BadRequestException.class)
+        .isThrownBy(() -> sanitizer.sanitizeToJson(Map.of("de__meta", "{\"src\":\"   \"}")));
+  }
+
+  @Test
+  void sanitizeToJson_Should_treatNullValuesAsEmpty_andSkipNullKeys() {
+    var content = new java.util.HashMap<String, String>();
+    content.put("de", null);
+    content.put(null, "<p>ignored</p>");
+
+    var json = sanitizer.sanitizeToJson(content);
+
+    assertThat(json).contains("\"de\":\"\"");
+    assertThat(json).doesNotContain("ignored");
+  }
+}

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/service/legal/LegalTextAdminServiceTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/service/legal/LegalTextAdminServiceTest.java
@@ -316,7 +316,7 @@ class LegalTextAdminServiceTest {
   @Test
   void assign_Should_throwAccessDenied_When_restrictedAdminDoesNotOwnTheAgency() {
     when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(true);
-    when(authenticatedUser.getUserId()).thenReturn("admin-1");
+    when(authenticatedUser.requireUserId()).thenReturn("admin-1");
     when(userAdminService.getAdminUserAgencyIds("admin-1")).thenReturn(List.of(99L));
 
     assertThatExceptionOfType(AgencyAccessDeniedException.class)

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/service/legal/LegalTextAdminServiceTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/service/legal/LegalTextAdminServiceTest.java
@@ -299,6 +299,20 @@ class LegalTextAdminServiceTest {
   }
 
   @Test
+  void assign_Should_rejectNullTenantText_When_agencyIsTenantScoped() {
+    // review: a null-tenant (global/orphan) text must not bypass the cross-tenant guard and leak
+    // into a specific Träger's department in multi-tenant mode
+    when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(false);
+    departmentOfTenant(5L);
+    when(legalTextRepository.findById(4L))
+        .thenReturn(Optional.of(text(4L, null, LegalTextKind.DPP)));
+
+    assertThatExceptionOfType(BadRequestException.class)
+        .isThrownBy(() -> service.assignDepartmentLegalText(7L, 42L, LegalTextKind.DPP, 4L));
+    verify(agencyTopicRepository, never()).save(any());
+  }
+
+  @Test
   void assign_Should_throwAccessDenied_When_restrictedAdminDoesNotOwnTheAgency() {
     when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(true);
     when(authenticatedUser.getUserId()).thenReturn("admin-1");

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/service/legal/LegalTextAdminServiceTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/service/legal/LegalTextAdminServiceTest.java
@@ -1,0 +1,273 @@
+package de.caritas.cob.agencyservice.api.admin.service.legal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import de.caritas.cob.agencyservice.api.admin.service.UserAdminService;
+import de.caritas.cob.agencyservice.api.exception.httpresponses.AgencyAccessDeniedException;
+import de.caritas.cob.agencyservice.api.exception.httpresponses.BadRequestException;
+import de.caritas.cob.agencyservice.api.exception.httpresponses.NotFoundException;
+import de.caritas.cob.agencyservice.api.repository.agency.Agency;
+import de.caritas.cob.agencyservice.api.repository.agencytopic.AgencyTopic;
+import de.caritas.cob.agencyservice.api.repository.agencytopic.AgencyTopicRepository;
+import de.caritas.cob.agencyservice.api.repository.agencytopic.PublicationStatus;
+import de.caritas.cob.agencyservice.api.repository.legaltext.LegalText;
+import de.caritas.cob.agencyservice.api.repository.legaltext.LegalTextKind;
+import de.caritas.cob.agencyservice.api.repository.legaltext.LegalTextRepository;
+import de.caritas.cob.agencyservice.api.tenant.TenantContext;
+import de.caritas.cob.agencyservice.api.util.AuthenticatedUser;
+import de.caritas.cob.agencyservice.api.validation.InputSanitizer;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * ADR-014 legal-text library: tenant-scoped CRUD over shared legal-text objects plus the
+ * per-department assignment ("share this text" / "own text" / "unassign = tenant fallback").
+ */
+@ExtendWith(MockitoExtension.class)
+class LegalTextAdminServiceTest {
+
+  @Mock private LegalTextRepository legalTextRepository;
+  @Mock private AgencyTopicRepository agencyTopicRepository;
+  @Mock private AuthenticatedUser authenticatedUser;
+  @Mock private UserAdminService userAdminService;
+
+  private LegalTextAdminService service;
+
+  @BeforeEach
+  void setUp() {
+    TenantContext.clear();
+    service =
+        new LegalTextAdminService(
+            legalTextRepository,
+            agencyTopicRepository,
+            new InputSanitizer(),
+            authenticatedUser,
+            userAdminService);
+  }
+
+  @AfterEach
+  void tearDown() {
+    TenantContext.clear();
+  }
+
+  private LegalText text(Long id, Long tenantId, LegalTextKind kind) {
+    return LegalText.builder()
+        .id(id)
+        .tenantId(tenantId)
+        .kind(kind)
+        .label("Text " + id)
+        .content("{\"de\":\"<p>x</p>\"}")
+        .publicationStatus(PublicationStatus.PUBLISHED)
+        .build();
+  }
+
+  private AgencyTopic departmentOfTenant(Long agencyTenantId) {
+    var department =
+        AgencyTopic.builder()
+            .topicId(42L)
+            .agency(
+                Agency.builder()
+                    .id(7L)
+                    .name("Zentrum")
+                    .consultingTypeId(1)
+                    .tenantId(agencyTenantId)
+                    .build())
+            .build();
+    when(agencyTopicRepository.findByAgency_IdAndTopicId(7L, 42L))
+        .thenReturn(Optional.of(department));
+    return department;
+  }
+
+  // --- list ---
+
+  @Test
+  void list_Should_returnCallerTenantsTexts_withUsageCounts() {
+    when(authenticatedUser.getTenantId()).thenReturn(5L);
+    when(legalTextRepository.findByTenantIdAndKindOrderByLabelAsc(5L, LegalTextKind.DPP))
+        .thenReturn(List.of(text(1L, 5L, LegalTextKind.DPP)));
+    when(agencyTopicRepository.countByDpp_Id(1L)).thenReturn(3L);
+
+    var views = service.listLegalTexts(LegalTextKind.DPP);
+
+    assertThat(views).hasSize(1);
+    assertThat(views.get(0).id()).isEqualTo(1L);
+    assertThat(views.get(0).usageCount()).isEqualTo(3L);
+  }
+
+  @Test
+  void list_Should_countImprintUsage_ForImprintKind() {
+    when(authenticatedUser.getTenantId()).thenReturn(5L);
+    when(legalTextRepository.findByTenantIdAndKindOrderByLabelAsc(5L, LegalTextKind.IMPRINT))
+        .thenReturn(List.of(text(2L, 5L, LegalTextKind.IMPRINT)));
+    when(agencyTopicRepository.countByImprint_Id(2L)).thenReturn(1L);
+
+    var views = service.listLegalTexts(LegalTextKind.IMPRINT);
+
+    assertThat(views.get(0).usageCount()).isEqualTo(1L);
+  }
+
+  // --- create ---
+
+  @Test
+  void create_Should_sanitizeContent_stampCallerTenant_andStorePublished() {
+    when(authenticatedUser.getTenantId()).thenReturn(5L);
+    when(legalTextRepository.save(any(LegalText.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+
+    var view =
+        service.createLegalText(
+            LegalTextKind.DPP,
+            "Standard-DSE",
+            Map.of("de", "<p onclick=\"x()\">DSE <script>bad()</script></p>"),
+            true);
+
+    var saved = ArgumentCaptor.forClass(LegalText.class);
+    verify(legalTextRepository).save(saved.capture());
+    assertThat(saved.getValue().getTenantId()).isEqualTo(5L);
+    assertThat(saved.getValue().getKind()).isEqualTo(LegalTextKind.DPP);
+    assertThat(saved.getValue().getLabel()).isEqualTo("Standard-DSE");
+    assertThat(saved.getValue().getContent())
+        .contains("DSE")
+        .doesNotContain("script")
+        .doesNotContain("onclick");
+    assertThat(saved.getValue().getPublicationStatus()).isEqualTo(PublicationStatus.PUBLISHED);
+    assertThat(saved.getValue().getCreateDate()).isNotNull();
+    assertThat(view.usageCount()).isZero();
+  }
+
+  @Test
+  void create_Should_rejectBlankLabel() {
+    assertThatExceptionOfType(BadRequestException.class)
+        .isThrownBy(
+            () -> service.createLegalText(LegalTextKind.DPP, "  ", Map.of("de", "x"), false));
+    verify(legalTextRepository, never()).save(any());
+  }
+
+  // --- update ---
+
+  @Test
+  void update_Should_updateLabelContentAndStatus() {
+    when(authenticatedUser.getTenantId()).thenReturn(5L);
+    var existing = text(1L, 5L, LegalTextKind.DPP);
+    existing.setPublicationStatus(PublicationStatus.DRAFT);
+    when(legalTextRepository.findById(1L)).thenReturn(Optional.of(existing));
+    when(legalTextRepository.save(any(LegalText.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+    when(agencyTopicRepository.countByDpp_Id(1L)).thenReturn(2L);
+
+    var view = service.updateLegalText(1L, "Neu", Map.of("de", "<p>neu</p>"), true);
+
+    assertThat(existing.getLabel()).isEqualTo("Neu");
+    assertThat(existing.getContent()).contains("neu");
+    assertThat(existing.getPublicationStatus()).isEqualTo(PublicationStatus.PUBLISHED);
+    assertThat(existing.getUpdateDate()).isNotNull();
+    assertThat(view.usageCount()).isEqualTo(2L);
+  }
+
+  @Test
+  void update_Should_throwAccessDenied_When_textBelongsToAnotherTenant() {
+    when(authenticatedUser.getTenantId()).thenReturn(5L);
+    when(legalTextRepository.findById(1L))
+        .thenReturn(Optional.of(text(1L, 9L, LegalTextKind.DPP)));
+
+    assertThatExceptionOfType(AgencyAccessDeniedException.class)
+        .isThrownBy(() -> service.updateLegalText(1L, "x", Map.of("de", "x"), false));
+    verify(legalTextRepository, never()).save(any());
+  }
+
+  @Test
+  void update_Should_throwNotFound_When_textMissing() {
+    when(legalTextRepository.findById(99L)).thenReturn(Optional.empty());
+
+    assertThatExceptionOfType(NotFoundException.class)
+        .isThrownBy(() -> service.updateLegalText(99L, "x", Map.of("de", "x"), false));
+  }
+
+  // --- assignment ---
+
+  @Test
+  void assign_Should_setDppReference_When_kindAndTenantMatch() {
+    when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(false);
+    var department = departmentOfTenant(5L);
+    when(legalTextRepository.findById(1L))
+        .thenReturn(Optional.of(text(1L, 5L, LegalTextKind.DPP)));
+
+    service.assignDepartmentLegalText(7L, 42L, LegalTextKind.DPP, 1L);
+
+    assertThat(department.getDpp()).isNotNull();
+    assertThat(department.getDpp().getId()).isEqualTo(1L);
+    verify(agencyTopicRepository).save(department);
+  }
+
+  @Test
+  void assign_Should_clearReference_When_legalTextIdIsNull() {
+    when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(false);
+    var department = departmentOfTenant(5L);
+    department.setImprint(text(2L, 5L, LegalTextKind.IMPRINT));
+
+    service.assignDepartmentLegalText(7L, 42L, LegalTextKind.IMPRINT, null);
+
+    assertThat(department.getImprint()).isNull();
+    verify(agencyTopicRepository).save(department);
+  }
+
+  @Test
+  void assign_Should_rejectKindMismatch() {
+    // an IMPRINT object must never end up in the DPP slot — the consent screen would show the
+    // wrong document kind
+    when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(false);
+    departmentOfTenant(5L);
+    when(legalTextRepository.findById(2L))
+        .thenReturn(Optional.of(text(2L, 5L, LegalTextKind.IMPRINT)));
+
+    assertThatExceptionOfType(BadRequestException.class)
+        .isThrownBy(() -> service.assignDepartmentLegalText(7L, 42L, LegalTextKind.DPP, 2L));
+    verify(agencyTopicRepository, never()).save(any());
+  }
+
+  @Test
+  void assign_Should_rejectTextOfAnotherTenant() {
+    when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(false);
+    departmentOfTenant(5L);
+    when(legalTextRepository.findById(3L))
+        .thenReturn(Optional.of(text(3L, 9L, LegalTextKind.DPP)));
+
+    assertThatExceptionOfType(BadRequestException.class)
+        .isThrownBy(() -> service.assignDepartmentLegalText(7L, 42L, LegalTextKind.DPP, 3L));
+    verify(agencyTopicRepository, never()).save(any());
+  }
+
+  @Test
+  void assign_Should_throwAccessDenied_When_restrictedAdminDoesNotOwnTheAgency() {
+    when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(true);
+    when(authenticatedUser.getUserId()).thenReturn("admin-1");
+    when(userAdminService.getAdminUserAgencyIds("admin-1")).thenReturn(List.of(99L));
+
+    assertThatExceptionOfType(AgencyAccessDeniedException.class)
+        .isThrownBy(() -> service.assignDepartmentLegalText(7L, 42L, LegalTextKind.DPP, 1L));
+    verify(agencyTopicRepository, never()).save(any());
+  }
+
+  @Test
+  void assign_Should_throwNotFound_When_assignedTextMissing() {
+    when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(false);
+    departmentOfTenant(5L);
+    when(legalTextRepository.findById(99L)).thenReturn(Optional.empty());
+
+    assertThatExceptionOfType(NotFoundException.class)
+        .isThrownBy(() -> service.assignDepartmentLegalText(7L, 42L, LegalTextKind.DPP, 99L));
+  }
+}

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/service/legal/LegalTextAdminServiceTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/service/legal/LegalTextAdminServiceTest.java
@@ -34,7 +34,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 /**
  * ADR-014 legal-text library: tenant-scoped CRUD over shared legal-text objects plus the
- * per-department assignment ("share this text" / "own text" / "unassign = tenant fallback").
+ * per-department assignment ("share this text" / "own text" / "unassign = inline content
+ * fallback").
  */
 @ExtendWith(MockitoExtension.class)
 class LegalTextAdminServiceTest {

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/service/legal/LegalTextAdminServiceTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/service/legal/LegalTextAdminServiceTest.java
@@ -196,6 +196,54 @@ class LegalTextAdminServiceTest {
         .isThrownBy(() -> service.updateLegalText(99L, "x", Map.of("de", "x"), false));
   }
 
+  // --- library CRUD is full-admin only (review: a restricted admin must not be able to change
+  // tenant-wide shared texts that agencies outside their scope reference) ---
+
+  @Test
+  void list_Should_throwAccessDenied_When_restrictedAgencyAdmin() {
+    when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(true);
+
+    assertThatExceptionOfType(AgencyAccessDeniedException.class)
+        .isThrownBy(() -> service.listLegalTexts(LegalTextKind.DPP));
+  }
+
+  @Test
+  void create_Should_throwAccessDenied_When_restrictedAgencyAdmin() {
+    when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(true);
+
+    assertThatExceptionOfType(AgencyAccessDeniedException.class)
+        .isThrownBy(
+            () -> service.createLegalText(LegalTextKind.DPP, "x", Map.of("de", "x"), false));
+    verify(legalTextRepository, never()).save(any());
+  }
+
+  @Test
+  void update_Should_throwAccessDenied_When_restrictedAgencyAdmin() {
+    when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(true);
+
+    assertThatExceptionOfType(AgencyAccessDeniedException.class)
+        .isThrownBy(() -> service.updateLegalText(1L, "x", Map.of("de", "x"), false));
+    verify(legalTextRepository, never()).save(any());
+  }
+
+  // --- publish semantics on update ---
+
+  @Test
+  void update_Should_preservePublicationStatus_When_publishOmitted() {
+    // review: a label/content-only update must not silently unpublish a published text
+    when(authenticatedUser.getTenantId()).thenReturn(5L);
+    var existing = text(1L, 5L, LegalTextKind.DPP);
+    existing.setPublicationStatus(PublicationStatus.PUBLISHED);
+    when(legalTextRepository.findById(1L)).thenReturn(Optional.of(existing));
+    when(legalTextRepository.save(any(LegalText.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+    when(agencyTopicRepository.countByDpp_Id(1L)).thenReturn(1L);
+
+    service.updateLegalText(1L, "Nur Label", Map.of("de", "<p>x</p>"), null);
+
+    assertThat(existing.getPublicationStatus()).isEqualTo(PublicationStatus.PUBLISHED);
+  }
+
   // --- assignment ---
 
   @Test

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/service/legal/LegalTextAdminServiceTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/service/legal/LegalTextAdminServiceTest.java
@@ -53,7 +53,7 @@ class LegalTextAdminServiceTest {
         new LegalTextAdminService(
             legalTextRepository,
             agencyTopicRepository,
-            new InputSanitizer(),
+            new LegalContentSanitizer(new InputSanitizer()),
             authenticatedUser,
             userAdminService);
   }

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/validation/validators/AgencyUpdatePermissionValidatorTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/validation/validators/AgencyUpdatePermissionValidatorTest.java
@@ -46,12 +46,12 @@ class AgencyUpdatePermissionValidatorTest {
     // given
     when(validateAgencyDto.getId()).thenReturn(AGENCY_ID);
     when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(true);
-    when(authenticatedUser.getUserId()).thenReturn("userId");
-    when(userAdminService.getAdminUserAgencyIds(authenticatedUser.getUserId())).thenReturn(Lists.newArrayList(AGENCY_ID, 2L));
+    when(authenticatedUser.requireUserId()).thenReturn("userId");
+    when(userAdminService.getAdminUserAgencyIds("userId")).thenReturn(Lists.newArrayList(AGENCY_ID, 2L));
     // when
     agencyUpdatePermissionValidator.validate(validateAgencyDto);
     // then
-    Mockito.verify(userAdminService).getAdminUserAgencyIds(authenticatedUser.getUserId());
+    Mockito.verify(userAdminService).getAdminUserAgencyIds("userId");
   }
 
   @Test
@@ -59,8 +59,8 @@ class AgencyUpdatePermissionValidatorTest {
     // given
     when(validateAgencyDto.getId()).thenReturn(AGENCY_ID);
     when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(true);
-    when(authenticatedUser.getUserId()).thenReturn("userId");
-    when(userAdminService.getAdminUserAgencyIds(authenticatedUser.getUserId())).thenReturn(Lists.newArrayList(2L, 3L));
+    when(authenticatedUser.requireUserId()).thenReturn("userId");
+    when(userAdminService.getAdminUserAgencyIds("userId")).thenReturn(Lists.newArrayList(2L, 3L));
     // when, then
     assertThrows(AgencyAccessDeniedException.class, () -> agencyUpdatePermissionValidator.validate(validateAgencyDto));
   }

--- a/src/test/java/de/caritas/cob/agencyservice/api/controller/AgencyAdminControllerIT.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/controller/AgencyAdminControllerIT.java
@@ -446,7 +446,8 @@ class AgencyAdminControllerIT {
     var extendedConsultingTypeResponseDTO = new ExtendedConsultingTypeResponseDTO();
     when(consultingTypeManager.getConsultingTypeSettings(anyInt()))
         .thenReturn(extendedConsultingTypeResponseDTO);
-    when(userAdminService.getAdminUserAgencyIds(authenticatedUser.getUserId())).thenReturn(
+    when(authenticatedUser.requireUserId()).thenReturn("userId");
+    when(userAdminService.getAdminUserAgencyIds("userId")).thenReturn(
         Lists.newArrayList(1L));
 
     UpdateAgencyDTO agencyDTO = new UpdateAgencyDTO()
@@ -489,7 +490,8 @@ class AgencyAdminControllerIT {
     when(consultingTypeManager.getConsultingTypeSettings(anyInt()))
         .thenReturn(extendedConsultingTypeResponseDTO);
     when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(true);
-    when(userAdminService.getAdminUserAgencyIds(authenticatedUser.getUserId())).thenReturn(
+    when(authenticatedUser.requireUserId()).thenReturn("userId");
+    when(userAdminService.getAdminUserAgencyIds("userId")).thenReturn(
         Lists.newArrayList(2L, 3L));
 
     UpdateAgencyDTO agencyDTO = new UpdateAgencyDTO()

--- a/src/test/java/de/caritas/cob/agencyservice/api/repository/legaltext/LegalTextRepositoryTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/repository/legaltext/LegalTextRepositoryTest.java
@@ -1,0 +1,167 @@
+package de.caritas.cob.agencyservice.api.repository.legaltext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import de.caritas.cob.agencyservice.api.repository.agency.Agency;
+import de.caritas.cob.agencyservice.api.repository.agency.DataProtectionResponsibleEntity;
+import de.caritas.cob.agencyservice.api.repository.agencytopic.AgencyTopic;
+import de.caritas.cob.agencyservice.api.repository.agencytopic.AgencyTopicRepository;
+import de.caritas.cob.agencyservice.api.repository.agencytopic.PublicationStatus;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.boot.jpa.test.autoconfigure.TestEntityManager;
+import org.springframework.boot.liquibase.autoconfigure.LiquibaseAutoConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+/**
+ * ADR-014 persistence model: legal texts (DPP / Impressum) are first-class shared objects owned by
+ * a Träger (tenant); a department (Fachbereich = agency × topic) references one per kind, and
+ * several departments may share the same text instead of maintaining N inline copies.
+ */
+@TestPropertySource(properties = {"spring.profiles.active=testing"})
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.ANY)
+@ExtendWith(SpringExtension.class)
+@DataJpaTest(excludeAutoConfiguration = LiquibaseAutoConfiguration.class)
+class LegalTextRepositoryTest {
+
+  @Autowired private TestEntityManager em;
+  @Autowired private LegalTextRepository legalTextRepository;
+  @Autowired private AgencyTopicRepository agencyTopicRepository;
+
+  private Agency persistAgency(String name) {
+    var now = LocalDateTime.now();
+    return em.persistFlushFind(
+        Agency.builder()
+            .name(name)
+            .consultingTypeId(1)
+            .dataProtectionResponsibleEntity(DataProtectionResponsibleEntity.AGENCY_RESPONSIBLE)
+            .dataProtectionOfficerContactData("officer")
+            .dataProtectionAlternativeContactData("alternative")
+            .dataProtectionAgencyResponsibleContactData("agency")
+            .createDate(now)
+            .updateDate(now)
+            .build());
+  }
+
+  private AgencyTopic persistDepartment(Agency agency, long topicId) {
+    var now = LocalDateTime.now();
+    return em.persistFlushFind(
+        AgencyTopic.builder().agency(agency).topicId(topicId).createDate(now).updateDate(now)
+            .build());
+  }
+
+  @Test
+  void persist_Should_storeLegalTextWithKindLabelContentAndStatus() {
+    var now = LocalDateTime.now();
+    LegalText text =
+        LegalText.builder()
+            .tenantId(1L)
+            .kind(LegalTextKind.DPP)
+            .label("Standard-DSE Träger")
+            .content("{\"de\":\"<p>DSE</p>\"}")
+            .publicationStatus(PublicationStatus.PUBLISHED)
+            .createDate(now)
+            .updateDate(now)
+            .build();
+
+    Long id = em.persistFlushFind(text).getId();
+    em.clear();
+
+    LegalText reloaded = em.find(LegalText.class, id);
+    assertThat(reloaded.getTenantId()).isEqualTo(1L);
+    assertThat(reloaded.getKind()).isEqualTo(LegalTextKind.DPP);
+    assertThat(reloaded.getLabel()).isEqualTo("Standard-DSE Träger");
+    assertThat(reloaded.getContent()).isEqualTo("{\"de\":\"<p>DSE</p>\"}");
+    assertThat(reloaded.getPublicationStatus()).isEqualTo(PublicationStatus.PUBLISHED);
+  }
+
+  @Test
+  void publicationStatus_Should_defaultToDraft_When_notSet() {
+    var now = LocalDateTime.now();
+    LegalText text =
+        LegalText.builder()
+            .tenantId(1L)
+            .kind(LegalTextKind.IMPRINT)
+            .label("Impressum")
+            .content("{\"de\":\"<p>Impressum</p>\"}")
+            .createDate(now)
+            .updateDate(now)
+            .build();
+
+    Long id = em.persistFlushFind(text).getId();
+    em.clear();
+
+    assertThat(em.find(LegalText.class, id).getPublicationStatus())
+        .isEqualTo(PublicationStatus.DRAFT);
+  }
+
+  @Test
+  void twoDepartments_Should_shareOneLegalText_And_usageCountReflectsIt() {
+    // given one shared DSE referenced by two Fachbereiche of the same agency
+    var now = LocalDateTime.now();
+    Agency agency = persistAgency("Beratungszentrum Süd");
+    LegalText sharedDpp =
+        em.persistFlushFind(
+            LegalText.builder()
+                .tenantId(1L)
+                .kind(LegalTextKind.DPP)
+                .label("Gemeinsame DSE")
+                .content("{\"de\":\"<p>geteilt</p>\"}")
+                .publicationStatus(PublicationStatus.PUBLISHED)
+                .createDate(now)
+                .updateDate(now)
+                .build());
+
+    AgencyTopic debtCounselling = persistDepartment(agency, 10L);
+    AgencyTopic pregnancy = persistDepartment(agency, 20L);
+    debtCounselling.setDpp(sharedDpp);
+    pregnancy.setDpp(sharedDpp);
+    em.persistAndFlush(debtCounselling);
+    em.persistAndFlush(pregnancy);
+    em.clear();
+
+    // then both departments resolve to the same text and the usage count is 2
+    AgencyTopic reloaded =
+        agencyTopicRepository.findByAgency_IdAndTopicId(agency.getId(), 10L).orElseThrow();
+    assertThat(reloaded.getDpp().getId()).isEqualTo(sharedDpp.getId());
+    assertThat(reloaded.getDpp().getContent()).isEqualTo("{\"de\":\"<p>geteilt</p>\"}");
+    assertThat(agencyTopicRepository.countByDpp_Id(sharedDpp.getId())).isEqualTo(2);
+    assertThat(agencyTopicRepository.countByImprint_Id(sharedDpp.getId())).isZero();
+  }
+
+  @Test
+  void findByTenantIdAndKind_Should_listOnlyThatTenantsTextsOfThatKind() {
+    var now = LocalDateTime.now();
+    em.persist(
+        LegalText.builder().tenantId(1L).kind(LegalTextKind.DPP).label("t1 dpp")
+            .content("{}").createDate(now).updateDate(now).build());
+    em.persist(
+        LegalText.builder().tenantId(1L).kind(LegalTextKind.IMPRINT).label("t1 imprint")
+            .content("{}").createDate(now).updateDate(now).build());
+    em.persist(
+        LegalText.builder().tenantId(2L).kind(LegalTextKind.DPP).label("t2 dpp")
+            .content("{}").createDate(now).updateDate(now).build());
+    em.flush();
+    em.clear();
+
+    assertThat(legalTextRepository.findByTenantIdAndKindOrderByLabelAsc(1L, LegalTextKind.DPP))
+        .extracting(LegalText::getLabel)
+        .containsExactly("t1 dpp");
+  }
+
+  @Test
+  void departmentWithoutReferences_Should_loadWithNullDppAndImprint() {
+    Agency agency = persistAgency("Zentrum ohne Texte");
+    AgencyTopic department = persistDepartment(agency, 30L);
+    em.clear();
+
+    AgencyTopic reloaded = em.find(AgencyTopic.class, department.getId());
+    assertThat(reloaded.getDpp()).isNull();
+    assertThat(reloaded.getImprint()).isNull();
+  }
+}

--- a/src/test/java/de/caritas/cob/agencyservice/api/repository/legaltext/LegalTextRepositoryTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/repository/legaltext/LegalTextRepositoryTest.java
@@ -270,6 +270,33 @@ class LegalTextRepositoryTest {
   }
 
   @Test
+  void persist_Should_rejectNullTenantText_When_agencyIsTenantScoped() {
+    // defense-in-depth mirror of the service guard: a null-tenant (global/orphan) text must not
+    // slip into a tenant-scoped agency's department through some future write path either
+    var now = LocalDateTime.now();
+    Agency agency = persistAgency("Zentrum Null-Tenant-Guard");
+    agency.setTenantId(5L);
+    em.persistAndFlush(agency);
+    LegalText orphanText =
+        em.persistFlushFind(
+            LegalText.builder()
+                .tenantId(null)
+                .kind(LegalTextKind.DPP)
+                .label("Verwaiste DSE")
+                .content("{}")
+                .createDate(now)
+                .updateDate(now)
+                .build());
+    AgencyTopic department =
+        AgencyTopic.builder().agency(agency).topicId(53L).createDate(now).updateDate(now).build();
+    department.setDpp(orphanText);
+
+    assertThatExceptionOfType(RuntimeException.class)
+        .isThrownBy(() -> em.persistAndFlush(department))
+        .withStackTraceContaining("tenant");
+  }
+
+  @Test
   void departmentWithoutReferences_Should_loadWithNullDppAndImprint() {
     Agency agency = persistAgency("Zentrum ohne Texte");
     AgencyTopic department = persistDepartment(agency, 30L);

--- a/src/test/java/de/caritas/cob/agencyservice/api/repository/legaltext/LegalTextRepositoryTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/repository/legaltext/LegalTextRepositoryTest.java
@@ -1,6 +1,7 @@
 package de.caritas.cob.agencyservice.api.repository.legaltext;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import de.caritas.cob.agencyservice.api.repository.agency.Agency;
 import de.caritas.cob.agencyservice.api.repository.agency.DataProtectionResponsibleEntity;
@@ -152,6 +153,120 @@ class LegalTextRepositoryTest {
     assertThat(legalTextRepository.findByTenantIdAndKindOrderByLabelAsc(1L, LegalTextKind.DPP))
         .extracting(LegalText::getLabel)
         .containsExactly("t1 dpp");
+  }
+
+  @Test
+  void persist_Should_applyCreateAndUpdateDate_When_notSet() {
+    // the DB columns are NOT NULL; the entity must survive saves where no caller set the dates
+    LegalText text =
+        LegalText.builder()
+            .tenantId(1L)
+            .kind(LegalTextKind.DPP)
+            .label("Ohne Datum")
+            .content("{}")
+            .build();
+
+    Long id = em.persistFlushFind(text).getId();
+    em.clear();
+
+    LegalText reloaded = em.find(LegalText.class, id);
+    assertThat(reloaded.getCreateDate()).isNotNull();
+    assertThat(reloaded.getUpdateDate()).isNotNull();
+  }
+
+  @Test
+  void update_Should_refreshUpdateDate() {
+    var past = LocalDateTime.now().minusDays(3);
+    LegalText text =
+        em.persistFlushFind(
+            LegalText.builder()
+                .tenantId(1L)
+                .kind(LegalTextKind.DPP)
+                .label("Alt")
+                .content("{}")
+                .createDate(past)
+                .updateDate(past)
+                .build());
+
+    text.setLabel("Neu");
+    em.persistAndFlush(text);
+    em.clear();
+
+    assertThat(em.find(LegalText.class, text.getId()).getUpdateDate()).isAfter(past);
+  }
+
+  @Test
+  void persist_Should_rejectDppReferenceOfWrongKind() {
+    // a department's DPP slot must never point at an IMPRINT object — the consent screen would
+    // render the wrong document kind
+    Agency agency = persistAgency("Zentrum Guard");
+    var now = LocalDateTime.now();
+    LegalText imprintText =
+        em.persistFlushFind(
+            LegalText.builder()
+                .tenantId(null)
+                .kind(LegalTextKind.IMPRINT)
+                .label("Impressum")
+                .content("{}")
+                .createDate(now)
+                .updateDate(now)
+                .build());
+    AgencyTopic department =
+        AgencyTopic.builder().agency(agency).topicId(50L).createDate(now).updateDate(now).build();
+    department.setDpp(imprintText);
+
+    assertThatExceptionOfType(RuntimeException.class)
+        .isThrownBy(() -> em.persistAndFlush(department))
+        .withStackTraceContaining("kind");
+  }
+
+  @Test
+  void persist_Should_rejectImprintReferenceOfWrongKind() {
+    Agency agency = persistAgency("Zentrum Guard 2");
+    var now = LocalDateTime.now();
+    LegalText dppText =
+        em.persistFlushFind(
+            LegalText.builder()
+                .tenantId(null)
+                .kind(LegalTextKind.DPP)
+                .label("DSE")
+                .content("{}")
+                .createDate(now)
+                .updateDate(now)
+                .build());
+    AgencyTopic department =
+        AgencyTopic.builder().agency(agency).topicId(51L).createDate(now).updateDate(now).build();
+    department.setImprint(dppText);
+
+    assertThatExceptionOfType(RuntimeException.class)
+        .isThrownBy(() -> em.persistAndFlush(department))
+        .withStackTraceContaining("kind");
+  }
+
+  @Test
+  void persist_Should_rejectReferenceToAnotherTenantsText() {
+    // a department must never reference another Träger's legal document
+    var now = LocalDateTime.now();
+    Agency agency = persistAgency("Zentrum Tenant-Guard");
+    agency.setTenantId(5L);
+    em.persistAndFlush(agency);
+    LegalText foreignText =
+        em.persistFlushFind(
+            LegalText.builder()
+                .tenantId(9L)
+                .kind(LegalTextKind.DPP)
+                .label("Fremde DSE")
+                .content("{}")
+                .createDate(now)
+                .updateDate(now)
+                .build());
+    AgencyTopic department =
+        AgencyTopic.builder().agency(agency).topicId(52L).createDate(now).updateDate(now).build();
+    department.setDpp(foreignText);
+
+    assertThatExceptionOfType(RuntimeException.class)
+        .isThrownBy(() -> em.persistAndFlush(department))
+        .withStackTraceContaining("tenant");
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/agencyservice/api/service/AgencyServiceTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/service/AgencyServiceTest.java
@@ -46,6 +46,8 @@ import de.caritas.cob.agencyservice.api.repository.agency.Agency;
 import de.caritas.cob.agencyservice.api.repository.agency.AgencyRepository;
 import de.caritas.cob.agencyservice.api.repository.agencytopic.AgencyTopic;
 import de.caritas.cob.agencyservice.api.repository.agencytopic.PublicationStatus;
+import de.caritas.cob.agencyservice.api.repository.legaltext.LegalText;
+import de.caritas.cob.agencyservice.api.repository.legaltext.LegalTextKind;
 import de.caritas.cob.agencyservice.api.service.matrix.AgencyMatrixPasswordCipher;
 import de.caritas.cob.agencyservice.api.service.matrix.MatrixProvisioningService;
 import de.caritas.cob.agencyservice.api.tenant.TenantContext;
@@ -248,6 +250,52 @@ public class AgencyServiceTest {
     assertEquals(Boolean.FALSE, byTopicId.get(2L).getHasPublishedImprint());
     // the existing topicIds contract is untouched
     assertEquals(List.of(1L, 2L), result.get(0).getTopicIds());
+  }
+
+  @Test
+  public void getListOfAgencies_Should_DeriveLegalPublicationFlagsFromReferencedLegalText_WhenDepartmentReferencesOne()
+      throws MissingConsultingTypeException {
+
+    // ADR-014 write-through only updates the referenced legal_text object; the inline columns are
+    // intentionally kept stale. The search flags must therefore resolve reference-first, exactly
+    // like DepartmentLegalService — otherwise a publish/draft-save would not show up here.
+    Agency agency = Agency.builder().id(100L).name("Zentrum").consultingTypeId(CONSULTING_TYPE_SUCHT)
+        .build();
+    // referenced DPP is PUBLISHED while the stale inline copy says DRAFT → flag must be true
+    AgencyTopic publishedViaReference = AgencyTopic.builder().agency(agency).topicId(1L)
+        .contentDpp("{\"de\":\"<p>stale inline</p>\"}").publicationStatus(PublicationStatus.DRAFT)
+        .dpp(LegalText.builder().id(500L).kind(LegalTextKind.DPP).label("Geteilte DSE")
+            .content("{\"de\":\"<p>geteilt</p>\"}")
+            .publicationStatus(PublicationStatus.PUBLISHED).build())
+        .build();
+    // referenced imprint is DRAFT while the stale inline copy says PUBLISHED → flag must be false
+    AgencyTopic draftViaReference = AgencyTopic.builder().agency(agency).topicId(2L)
+        .contentImprint("{\"de\":\"<p>stale inline</p>\"}")
+        .publicationStatusImprint(PublicationStatus.PUBLISHED)
+        .imprint(LegalText.builder().id(501L).kind(LegalTextKind.IMPRINT)
+            .label("Geteiltes Impressum").content("{\"de\":\"<p>Entwurf</p>\"}")
+            .publicationStatus(PublicationStatus.DRAFT).build())
+        .build();
+    ReflectionTestUtils.setField(agency, "agencyTopics",
+        List.of(publishedViaReference, draftViaReference));
+
+    when(agencyRepository.searchWithoutTopic(VALID_POSTCODE, VALID_POSTCODE_LENGTH,
+        CONSULTING_TYPE_SUCHT, AGE, GENDER, COUNSELLING_RELATION, TENANT_ID))
+        .thenReturn(List.of(agency));
+    when(consultingTypeManager.getConsultingTypeSettings(Mockito.anyInt()))
+        .thenReturn(CONSULTING_TYPE_SETTINGS_WITH_WHITESPOT_AGENCY);
+
+    var result =
+        agencyService.getAgencies(Optional.of(VALID_POSTCODE), CONSULTING_TYPE_SUCHT,
+            Optional.empty());
+
+    assertEquals(1, result.size());
+    var byTopicId = result.get(0).getDepartments().stream()
+        .collect(java.util.stream.Collectors.toMap(d -> d.getTopicId(), d -> d));
+    assertTrue(byTopicId.get(1L).getHasPublishedDpp());
+    assertEquals(Boolean.FALSE, byTopicId.get(1L).getHasPublishedImprint());
+    assertEquals(Boolean.FALSE, byTopicId.get(2L).getHasPublishedDpp());
+    assertEquals(Boolean.FALSE, byTopicId.get(2L).getHasPublishedImprint());
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/agencyservice/api/service/DepartmentLegalServiceTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/service/DepartmentLegalServiceTest.java
@@ -9,6 +9,8 @@ import de.caritas.cob.agencyservice.api.repository.agency.Agency;
 import de.caritas.cob.agencyservice.api.repository.agencytopic.AgencyTopic;
 import de.caritas.cob.agencyservice.api.repository.agencytopic.AgencyTopicRepository;
 import de.caritas.cob.agencyservice.api.repository.agencytopic.PublicationStatus;
+import de.caritas.cob.agencyservice.api.repository.legaltext.LegalText;
+import de.caritas.cob.agencyservice.api.repository.legaltext.LegalTextKind;
 import java.time.LocalDateTime;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
@@ -101,6 +103,73 @@ class DepartmentLegalServiceTest {
 
     assertThat(view.dppContent()).isNull();
     assertThat(view.imprintContent()).isNull();
+  }
+
+  @Test
+  void getPublishedDepartmentLegal_Should_preferReferencedLegalText_OverInlineContent() {
+    // ADR-014: when the department references a shared legal-text object, that object is the
+    // truth — the leftover inline copy must be ignored entirely.
+    var department =
+        department(
+            "{\"de\":\"<p>alte Inline-DSE</p>\"}",
+            PublicationStatus.PUBLISHED,
+            null,
+            PublicationStatus.DRAFT);
+    department.setDpp(
+        LegalText.builder()
+            .id(100L)
+            .kind(LegalTextKind.DPP)
+            .label("Geteilte DSE")
+            .content("{\"de\":\"<p>geteilte DSE</p>\"}")
+            .publicationStatus(PublicationStatus.PUBLISHED)
+            .build());
+
+    var view = service.getPublishedDepartmentLegal(7L, 42L);
+
+    assertThat(view.dppContent()).isEqualTo("{\"de\":\"<p>geteilte DSE</p>\"}");
+  }
+
+  @Test
+  void getPublishedDepartmentLegal_Should_returnNull_When_referencedTextIsDraft() {
+    // a DRAFT shared object must not fall back to a published inline leftover — the reference,
+    // once set, fully replaces the inline column
+    var department =
+        department(
+            "{\"de\":\"<p>alte Inline-DSE</p>\"}",
+            PublicationStatus.PUBLISHED,
+            null,
+            PublicationStatus.DRAFT);
+    department.setDpp(
+        LegalText.builder()
+            .id(100L)
+            .kind(LegalTextKind.DPP)
+            .label("Entwurf")
+            .content("{\"de\":\"<p>Entwurf</p>\"}")
+            .publicationStatus(PublicationStatus.DRAFT)
+            .build());
+
+    var view = service.getPublishedDepartmentLegal(7L, 42L);
+
+    assertThat(view.dppContent()).isNull();
+  }
+
+  @Test
+  void getPublishedDepartmentLegal_Should_resolveImprintReferenceIndependently() {
+    var department =
+        department(null, PublicationStatus.DRAFT, null, PublicationStatus.DRAFT);
+    department.setImprint(
+        LegalText.builder()
+            .id(101L)
+            .kind(LegalTextKind.IMPRINT)
+            .label("Geteiltes Impressum")
+            .content("{\"de\":\"<p>Impressum</p>\"}")
+            .publicationStatus(PublicationStatus.PUBLISHED)
+            .build());
+
+    var view = service.getPublishedDepartmentLegal(7L, 42L);
+
+    assertThat(view.dppContent()).isNull();
+    assertThat(view.imprintContent()).isEqualTo("{\"de\":\"<p>Impressum</p>\"}");
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/agencyservice/api/util/AuthenticatedUserTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/util/AuthenticatedUserTest.java
@@ -1,8 +1,12 @@
 package de.caritas.cob.agencyservice.api.util;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.security.access.AccessDeniedException;
 
 @RunWith(MockitoJUnitRunner.class)
 public class AuthenticatedUserTest {
@@ -12,15 +16,34 @@ public class AuthenticatedUserTest {
     new AuthenticatedUser(null, null, null, null, null);
   }
 
-  @Test(expected = NullPointerException.class)
-  public void AuthenticatedUser_Should_ThrowNullPointerExceptionWhenUserIdIsNull() {
+  @Test
+  public void AuthenticatedUser_Should_AllowUserIdToBeNull() {
     AuthenticatedUser authenticatedUser = new AuthenticatedUser();
     authenticatedUser.setUserId(null);
+
+    assertThat(authenticatedUser.getUserId()).isNull();
   }
 
   @Test(expected = NullPointerException.class)
   public void AuthenticatedUser_Should_ThrowNullPointerExceptionWhenUsernameIsNull() {
     AuthenticatedUser authenticatedUser = new AuthenticatedUser();
     authenticatedUser.setUsername(null);
+  }
+
+  @Test
+  public void requireUserId_Should_ReturnDomainUserId_WhenPresent() {
+    AuthenticatedUser authenticatedUser = new AuthenticatedUser();
+    authenticatedUser.setUserId("domain-user-id");
+
+    assertThat(authenticatedUser.requireUserId()).isEqualTo("domain-user-id");
+  }
+
+  @Test
+  public void requireUserId_Should_ThrowAccessDeniedException_WhenMissing() {
+    AuthenticatedUser authenticatedUser = new AuthenticatedUser();
+
+    assertThatExceptionOfType(AccessDeniedException.class)
+        .isThrownBy(authenticatedUser::requireUserId)
+        .withMessage("Domain user id is required for this operation");
   }
 }

--- a/src/test/java/de/caritas/cob/agencyservice/config/AuthenticatedUserConfigTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/config/AuthenticatedUserConfigTest.java
@@ -1,0 +1,41 @@
+package de.caritas.cob.agencyservice.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+import org.junit.After;
+import org.junit.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+public class AuthenticatedUserConfigTest {
+
+  private final AuthenticatedUserConfig authenticatedUserConfig = new AuthenticatedUserConfig();
+
+  @After
+  public void resetRequestContext() {
+    RequestContextHolder.resetRequestAttributes();
+  }
+
+  @Test
+  public void getAuthenticatedUser_Should_AllowAgencyAdminWithoutDomainUserId() {
+    var jwt = Jwt.withTokenValue("test-token")
+        .header("alg", "none")
+        .claim("username", "platform-admin")
+        .claim("realm_access", Map.of("roles", List.of("agency-admin")))
+        .build();
+    var request = new MockHttpServletRequest();
+    request.setUserPrincipal(new JwtAuthenticationToken(jwt));
+    RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+
+    var authenticatedUser = authenticatedUserConfig.getAuthenticatedUser();
+
+    assertThat(authenticatedUser.getUserId()).isNull();
+    assertThat(authenticatedUser.getUsername()).isEqualTo("platform-admin");
+    assertThat(authenticatedUser.isAgencyAdmin()).isTrue();
+  }
+}


### PR DESCRIPTION
Syncs `dev` with the current `pre-dev`: **31 commits** (~10 PRs).

Pre-merge audit (run across all repos before opening):
- ✅ Merge predicted **clean** — no conflicting changes
- ✅ Liquibase changesets all registered in the master changelog (the previously-orphaned `0067_consultant_public_slug` was fixed in UserService #548)
- ✅ Service config contract checked against ORISO-Helm; the missing `DPA_SIGN_FRONTEND_BASE_URL` was fixed in Helm #121

Deploy-time notes (not merge blockers):
- Required Helm secrets are still `changeme` placeholders and must be supplied in the secrets overlay, or the Helm render fails.
- `magicLinkFrontendBaseUrl` / `passwordResetFrontendBaseUrl` / `passwordResetAdminFrontendBaseUrl` remain unset, so those emails fail closed until the real frontend/admin domains are configured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)