### PR TITLE
fix(security): resolve fixable HIGH/CRITICAL image vulnerabilities behind the new Trivy gate

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,5 +3,8 @@ VOLUME ["/tmp","/log"]
 EXPOSE 8084
 ARG JAR_FILE
 ENV JAVA_UPPER_VERSION=eclipse-temurin:21-jre@sha256:273396ed5998598ed1091e8d72711c2d36980a0e65103859c55a4e977a41ffd3
+# The Ubuntu-based Temurin image ships Canonical's pebble service manager,
+# which is unused here and carries fixable Go CVEs; drop it from the image.
+RUN rm -f /usr/bin/pebble
 COPY ./target/AgencyService.jar app.jar
 ENTRYPOINT ["java","-Djava.security.egd=file:/dev/./urandom","-Dtomcat.util.http.parser.HttpParser.requestTargetAllow=|{}","-XX:MaxRAMPercentage=75","-jar","/app.jar"]

--- a/api/agencyadminservice.yaml
+++ b/api/agencyadminservice.yaml
@@ -26,7 +26,7 @@ paths:
       tags:
         - admin-agency-controller
       summary: 'Returns the list of agencies by search query parameter. [Authorization: Role:
-      agency-admin]'
+        agency-admin]'
       operationId: searchAgencies
       parameters:
         - name: q
@@ -229,9 +229,9 @@ paths:
       tags:
         - admin-agency-controller
       summary: 'Change an agency from team-agency to default and vice-versa and switch the
-      associated consultant accounts to team consultant or default consultant. Ongoing team
-      counselings change to 1:1 when converting agency to default status. 1:1 counselings remain
-      single counselings when swapping the agency to team-agency. [Authorization: Role: user-admin]'
+        associated consultant accounts to team consultant or default consultant. Ongoing team
+        counselings change to 1:1 when converting agency to default status. 1:1 counselings remain
+        single counselings when swapping the agency to team-agency. [Authorization: Role: user-admin]'
       operationId: changeAgencyType
       parameters:
         - name: agencyId
@@ -263,8 +263,8 @@ paths:
       tags:
         - admin-agency-controller
       summary: 'Read a department''s (Fachbereich = agency x topic) own data privacy policy (DSE) to
-      prefill the editor. [Authorization: Role: agency-admin or restricted-agency-admin scoped to
-      its own agencies]'
+        prefill the editor. [Authorization: Role: agency-admin or restricted-agency-admin scoped to
+        its own agencies]'
       operationId: getDepartmentDataProtection
       parameters:
         - name: agencyId
@@ -302,8 +302,8 @@ paths:
       tags:
         - admin-agency-controller
       summary: 'Publish or draft-save a department''s (Fachbereich = agency x topic) own data
-      privacy policy (DSE). [Authorization: Role: agency-admin or restricted-agency-admin scoped to
-      its own agencies]'
+        privacy policy (DSE). [Authorization: Role: agency-admin or restricted-agency-admin scoped to
+        its own agencies]'
       operationId: publishDepartmentDataProtection
       parameters:
         - name: agencyId
@@ -349,8 +349,8 @@ paths:
       tags:
         - admin-agency-controller
       summary: 'List the caller tenant''s shared legal texts of one kind, each with its department
-      usage count ("used by N departments", ADR-014). Library CRUD is full-admin only: a shared
-      text applies tenant-wide. [Authorization: Role: agency-admin]'
+        usage count ("used by N departments", ADR-014). Library CRUD is full-admin only: a shared
+        text applies tenant-wide. [Authorization: Role: agency-admin]'
       operationId: getLegalTexts
       parameters:
         - name: kind
@@ -379,7 +379,7 @@ paths:
       tags:
         - admin-agency-controller
       summary: 'Create a shared legal text owned by the caller''s tenant (ADR-014).
-      [Authorization: Role: agency-admin — full admins only, see GET]'
+        [Authorization: Role: agency-admin — full admins only, see GET]'
       operationId: createLegalText
       requestBody:
         content:
@@ -408,9 +408,9 @@ paths:
       tags:
         - admin-agency-controller
       summary: 'Update a shared legal text (label, multilingual content, optionally publication
-      status — omitted publish keeps the current status). Changes apply to every department
-      referencing the text. [Authorization: Role: agency-admin — full admins only, scoped to the
-      owning tenant]'
+        status — omitted publish keeps the current status). Changes apply to every department
+        referencing the text. [Authorization: Role: agency-admin — full admins only, scoped to the
+        owning tenant]'
       operationId: updateLegalText
       parameters:
         - name: legalTextId
@@ -449,10 +449,10 @@ paths:
       tags:
         - admin-agency-controller
       summary: 'Assign a shared legal text to a department''s DPP or imprint slot, or clear the
-      slot (null = department falls back to its own inline content, content_dpp/content_imprint;
-      tenant-level fallback is future work, ADR-014 / #136). The text''s kind must match the
-      slot and the text must belong to the agency''s tenant. [Authorization: Role: agency-admin or
-      restricted-agency-admin scoped to its own agencies]'
+        slot (null = department falls back to its own inline content, content_dpp/content_imprint;
+        tenant-level fallback is future work, ADR-014 / #136). The text''s kind must match the
+        slot and the text must belong to the agency''s tenant. [Authorization: Role: agency-admin or
+        restricted-agency-admin scoped to its own agencies]'
       operationId: assignDepartmentLegalText
       parameters:
         - name: agencyId
@@ -494,8 +494,8 @@ paths:
       tags:
         - admin-agency-controller
       summary: 'Read a department''s (Fachbereich = agency x topic) own imprint (Impressum) to
-      prefill the editor. [Authorization: Role: agency-admin or restricted-agency-admin scoped to
-      its own agencies]'
+        prefill the editor. [Authorization: Role: agency-admin or restricted-agency-admin scoped to
+        its own agencies]'
       operationId: getDepartmentImprint
       parameters:
         - name: agencyId
@@ -533,8 +533,8 @@ paths:
       tags:
         - admin-agency-controller
       summary: 'Publish or draft-save a department''s (Fachbereich = agency x topic) own imprint
-      (Impressum). [Authorization: Role: agency-admin or restricted-agency-admin scoped to its own
-      agencies]'
+        (Impressum). [Authorization: Role: agency-admin or restricted-agency-admin scoped to its own
+        agencies]'
       operationId: publishDepartmentImprint
       parameters:
         - name: agencyId

--- a/pom.xml
+++ b/pom.xml
@@ -16,20 +16,17 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>4.0.1</version>
+    <version>4.0.7</version>
     <relativePath/> <!-- lookup parent from repository -->
   </parent>
 
   <properties> <!-- upper version is used to add the new features with the new versions of Java and spring boot, basic code changes are already made and as new features arrive they will use the upper version -->
     <java.upper.version>21</java.upper.version>
-    <springboot.upper.version>4.0.1</springboot.upper.version>
+    <springboot.upper.version>4.0.7</springboot.upper.version>
     <spring.upper.version>6.2.0</spring.upper.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <java.version>21</java.version>
-    <keycloak.version>17.0.0</keycloak.version>
-    <!-- force at least version 2.16 due to https://logging.apache.org/log4j/2.x/security.html -->
-    <log4j.version>2.17.1</log4j.version>
     <openapi.generator.maven.version>7.17.0</openapi.generator.maven.version>
     <jackson-databind-nullable.version>0.2.3</jackson-databind-nullable.version>
     <jakarta.ws.rs-api.version>3.1.0</jakarta.ws.rs-api.version>
@@ -38,10 +35,9 @@
     <h2.version>1.4.200</h2.version>
     <powermock-module-junit4.version>2.0.9</powermock-module-junit4.version>
     <easy-random-core.version>5.0.0</easy-random-core.version>
-    <spring-boot-autoconfigure.version>4.0.1</spring-boot-autoconfigure.version>
+    <spring-boot-autoconfigure.version>4.0.7</spring-boot-autoconfigure.version>
     <liquibase-core.version>4.23.2</liquibase-core.version>
     <springfox-boot-starter.version>3.0.0</springfox-boot-starter.version>
-    <spring-security.version>7.0.1</spring-security.version>
     <springfox.version>2.9.2</springfox.version>
     <springfox-swagger-ui.version>2.10.0</springfox-swagger-ui.version>
     <spring-security-oauth2-test-webmvc-addons.version>3.0.1</spring-security-oauth2-test-webmvc-addons.version>
@@ -52,6 +48,17 @@
     <springfox.boot.starter.version>3.0.0</springfox.boot.starter.version>
     <owasp.java.html.sanitizer>20211018.1</owasp.java.html.sanitizer>
   </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <!-- swagger-parser drags in commons-io 2.11.0 (CVE-2024-47554); force a fixed release. -->
+      <dependency>
+        <groupId>commons-io</groupId>
+        <artifactId>commons-io</artifactId>
+        <version>2.22.0</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 
   <dependencies>
     <!-- OWASP HTML sanitizer for user-supplied legal/DPP HTML (mirrors ORISO-TenantService) -->
@@ -110,17 +117,14 @@
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-web</artifactId>
-      <version>${spring-security.version}</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-config</artifactId>
-      <version>${spring-security.version}</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-core</artifactId>
-      <version>${spring-security.version}</version>
     </dependency>
     <!-- Spring actuator  -->
     <dependency>
@@ -175,7 +179,7 @@
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-utils</artifactId>
-      <version>3.3.0</version>
+      <version>3.6.1</version>
     </dependency>
     <!-- SpringFox: generate YAML file from POJOs and generate documentation -->
     <dependency>
@@ -217,26 +221,18 @@
       </exclusions>
     </dependency>
 
-    <!-- Keycloak dependencies -->
-    <dependency>
-      <groupId>org.keycloak</groupId>
-      <artifactId>keycloak-spring-security-adapter</artifactId>
-      <version>${keycloak.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.keycloak</groupId>
-      <artifactId>keycloak-spring-boot-starter</artifactId>
-      <version>${keycloak.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.keycloak</groupId>
-      <artifactId>keycloak-admin-client</artifactId>
-      <version>${keycloak.version}</version>
-    </dependency>
     <dependency>
       <groupId>jakarta.ws.rs</groupId>
       <artifactId>jakarta.ws.rs-api</artifactId>
       <version>${jakarta.ws.rs-api.version}</version>
+    </dependency>
+    <!-- Generated OpenAPI clients reference javax.annotation.Generated (source retention);
+         formerly a Keycloak adapter transitive, now declared explicitly for compilation only. -->
+    <dependency>
+      <groupId>javax.annotation</groupId>
+      <artifactId>javax.annotation-api</artifactId>
+      <version>1.3.2</version>
+      <scope>provided</scope>
     </dependency>
 
     <!-- Lombok dependencies -->
@@ -256,7 +252,7 @@
     <dependency>
       <groupId>com.github.jknack</groupId>
       <artifactId>handlebars</artifactId>
-      <version>4.3.1</version>
+      <version>4.5.2</version>
     </dependency>
 
     <!-- Liquibase -->
@@ -297,20 +293,18 @@
       <artifactId>mariadb-java-client</artifactId>
     </dependency>
 
+    <!-- Versions managed by the Spring Boot parent BOM (Log4Shell-era 2.17.1 pin removed). -->
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
-      <version>${log4j.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-api</artifactId>
-      <version>${log4j.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-to-slf4j</artifactId>
-      <version>${log4j.version}</version>
     </dependency>
 
 

--- a/src/main/java/de/caritas/cob/agencyservice/config/SecurityConfig.java
+++ b/src/main/java/de/caritas/cob/agencyservice/config/SecurityConfig.java
@@ -9,10 +9,10 @@ import de.caritas.cob.agencyservice.filter.HttpTenantFilter;
 import de.caritas.cob.agencyservice.filter.StatelessCsrfFilter;
 import jakarta.annotation.Nullable;
 import lombok.RequiredArgsConstructor;
-import org.keycloak.adapters.springsecurity.KeycloakConfiguration;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
@@ -27,7 +27,7 @@ import org.springframework.security.web.csrf.CsrfFilter;
 /**
  * Provides the Keycloak/Spring Security configuration.
  */
-@KeycloakConfiguration
+@Configuration
 @EnableMethodSecurity(
     prePostEnabled = true)
 @EnableWebSecurity

--- a/src/test/java/de/caritas/cob/agencyservice/api/tenant/TechnicalUserTenantResolverTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/tenant/TechnicalUserTenantResolverTest.java
@@ -13,10 +13,6 @@ import jakarta.servlet.http.HttpServletRequest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.keycloak.adapters.springsecurity.token.KeycloakAuthenticationToken;
-import org.keycloak.representations.AccessToken;
-import org.keycloak.representations.AccessToken.Access;
-import org.mockito.Answers;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -30,15 +26,6 @@ class TechnicalUserTenantResolverTest {
   public static final long TECHNICAL_CONTEXT = 0L;
   @Mock
   HttpServletRequest authenticatedRequest;
-
-  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
-  KeycloakAuthenticationToken token;
-
-  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
-  AccessToken accessToken;
-
-  @Mock
-  Access access;
 
   @Mock
   SecurityContext mockSecurityContext;

--- a/src/test/java/de/caritas/cob/agencyservice/api/tenant/TenantResolverServiceTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/tenant/TenantResolverServiceTest.java
@@ -12,8 +12,6 @@ import jakarta.servlet.http.HttpServletRequest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.keycloak.adapters.springsecurity.token.KeycloakAuthenticationToken;
-import org.mockito.Answers;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -38,9 +36,6 @@ class TenantResolverServiceTest {
 
   @Mock
   HttpServletRequest nonAuthenticatedRequest;
-
-  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
-  KeycloakAuthenticationToken token;
 
   @InjectMocks
   TenantResolverService tenantResolverService;


### PR DESCRIPTION
## Summary

The `AgencyService Build and Publish` run on `pre-dev` fails at **Reject fixable high or critical image vulnerabilities** with 27 jar findings (22 HIGH, 5 CRITICAL) plus 5 HIGH in `/usr/bin/pebble`: https://github.com/OpenResilienceInitiative/ORISO-AgencyService/actions/runs/30258798117

This is Task 2b of the Element Call Matryoshka recovery plan (2026-07-27).

### Root cause

PR #191 introduced the Trivy gate itself — the last green publish (2026-07-21) never scanned the image. The findings are **pre-existing stale dependencies** (Spring Boot parent pinned at 4.0.1, Keycloak 17 adapter jars, old direct pins), not something #191's code changes added. Several of the CVEs were also published after 07-21, so the first gated run collected them all at once.

### Changes

| Finding | Fix |
| --- | --- |
| `spring-boot` 4.0.1 (CVE-2026-40976 CRITICAL, CVE-2026-40973) | Parent bump 4.0.1 → **4.0.7** |
| `tomcat-embed-core` 11.0.15 (CVE-2026-41293 CRITICAL + 6 more) | → **11.0.22** via Boot BOM |
| `spring-security-web/-config` 7.0.1 (CVE-2026-22732 CRITICAL, CVE-2026-22753, CVE-2026-22754) | dropped the `spring-security.version=7.0.1` pin; BOM manages **7.0.6** |
| `tools.jackson` 3.0.3 (CVE-2026-29062, CVE-2026-54512/54513) | → **3.1.4** via Boot BOM |
| `com.fasterxml.jackson` 2.20.1 (CVE-2026-54512/54513, GHSA-r7wm-3cxj-wff9) | → **2.21.4** via Boot BOM (jackson-2-bom) |
| `keycloak-core` 17.0.0 (CVE-2023-6841, CVE-2024-10039) | **removed** Keycloak adapter/starter/admin-client entirely — the service authenticates via Spring Security's OAuth2 resource server; the adapter only supplied `@KeycloakConfiguration` (an alias for `@Configuration`) and two unused test mocks. No fixed adapter version exists (adapters were discontinued upstream). |
| `handlebars` 4.3.1 (CVE-2026-55760) | → **4.5.2** (same bump UserService took in US#542) |
| `plexus-utils` 3.3.0 (CVE-2025-67030) | → **3.6.1** |
| `commons-io` 2.11.0 (CVE-2024-47554, via swagger-parser) | managed to **2.22.0** |
| `/usr/bin/pebble` (golang.org/x/net CVE-2026-25681 + 4 more) | removed from the runtime image — Canonical's service manager ships in the Ubuntu-based Temurin base and is unused by the Spring Boot entrypoint |

Supporting changes:
- Removed the obsolete Log4Shell-era `log4j 2.17.1` pin (broke `LogManager` init under Boot 4.0.7; BOM manages current 2.x)
- Declared `javax.annotation-api` (provided scope) — the generated OpenAPI clients reference `javax.annotation.Generated` at compile time and previously got it transitively from Keycloak

### Also in this PR: OpenAPI spec YAML fix (unblocks UserService)

`api/agencyadminservice.yaml` contained multi-line quoted `summary` scalars whose continuation lines sat at the same indentation as the key (first instance at line 29 col 7). Strict parsers (Redocly) reject this as deficient indentation, which fails the cross-repo **OpenAPI Contracts** workflow in ORISO-UserService at "Verify AgencyService admin consumer compatibility" (that workflow bundles AgencyService@pre-dev on push events). The continuation lines are now indented two spaces deeper than the key — the same pattern already used in `api/agencyservice.yaml` and applied to the UserService specs in US #811 (commit d9ba1da6). Merging this PR unblocks the UserService OpenAPI Contracts workflow on pre-dev.

Validated mirroring that workflow locally: `redocly@2.40.0 bundle` succeeds for both specs, and `oasdiff v1.17.0 breaking --fail-on WARN` against the UserService consumer contracts (`services/agencyadminservice.yaml`, `services/agencyservice.yaml` at pre-dev) passes.

### Validation

- `mvn package` green locally: **519 tests, 0 failures, 0 errors**
- Rebuilt jar verified to bundle only fixed versions (tomcat 11.0.22, spring-security 7.0.6, jackson 2.21.4/3.1.4, no org.keycloak jars)
- Local image scan mirroring the workflow flags (`trivy image --severity HIGH,CRITICAL --ignore-unfixed`): **0 findings**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
