### PR TITLE
fix(legal): publishing a department text must break the shared link, not rewrite it for every sibling

### DIFF
--- a/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/DepartmentDataProtectionService.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/DepartmentDataProtectionService.java
@@ -76,20 +76,18 @@ public class DepartmentDataProtectionService {
 
     var sanitizedJson = legalContentSanitizer.sanitizeToJson(content);
     var status = publish ? PublicationStatus.PUBLISHED : PublicationStatus.DRAFT;
-    var now = LocalDateTime.now();
 
-    LegalText referenced = department.getDpp();
-    if (referenced != null) {
-      // ADR-014: the referenced shared object is the truth — write through to it; the inline
-      // column stays untouched (the read path ignores it once a reference exists).
-      referenced.setContent(sanitizedJson);
-      referenced.setPublicationStatus(status);
-      referenced.setUpdateDate(now);
-    } else {
-      department.setContentDpp(sanitizedJson);
-      department.setPublicationStatus(status);
+    // ADR-014 amendment 2026-07-28: never write through to the referenced shared object. The 0026
+    // backfill merged byte-identical departments onto one row, so writing through would silently
+    // republish every sibling Fachbereich. Publishing means "this department leaves the shared
+    // text": the reference is dropped and the text becomes the department's own. A draft keeps the
+    // reference, so the public still resolves the inherited text until the admin publishes.
+    if (publish) {
+      department.setDpp(null);
     }
-    department.setUpdateDate(now);
+    department.setContentDpp(sanitizedJson);
+    department.setPublicationStatus(status);
+    department.setUpdateDate(LocalDateTime.now());
     agencyTopicRepository.save(department);
 
     return status;
@@ -112,12 +110,29 @@ public class DepartmentDataProtectionService {
     assertCallerTenantMatches(department.getAgency());
 
     LegalText referenced = department.getDpp();
-    if (referenced != null) {
+    if (referenced != null && !hasPendingDraft(department, referenced)) {
       return new DepartmentDataProtectionView(
           referenced.getContent(), referenced.getPublicationStatus());
     }
     return new DepartmentDataProtectionView(
         department.getContentDpp(), department.getPublicationStatus());
+  }
+
+  /**
+   * Tells an admin's unpublished draft apart from a {@code 0026} backfill leftover, both of which
+   * appear as inline content next to a live reference.
+   *
+   * <p>The backfill copied the inline text into the shared object <em>verbatim</em> and left the
+   * column as a rollback anchor, so a leftover is byte-identical to what it references and must
+   * keep resolving through the reference. A draft is inline content that differs from the
+   * referenced text and is still {@code DRAFT} — the editor has to show the admin their own
+   * unfinished work, while the public keeps seeing the inherited text.
+   */
+  private boolean hasPendingDraft(AgencyTopic department, LegalText referenced) {
+    var draft = department.getContentDpp();
+    return draft != null
+        && department.getPublicationStatus() == PublicationStatus.DRAFT
+        && !draft.equals(referenced.getContent());
   }
 
   /**

--- a/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/DepartmentImprintService.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/DepartmentImprintService.java
@@ -69,20 +69,18 @@ public class DepartmentImprintService {
 
     var sanitizedJson = legalContentSanitizer.sanitizeToJson(content);
     var status = publish ? PublicationStatus.PUBLISHED : PublicationStatus.DRAFT;
-    var now = LocalDateTime.now();
 
-    LegalText referenced = department.getImprint();
-    if (referenced != null) {
-      // ADR-014: the referenced shared object is the truth — write through to it; the inline
-      // column stays untouched (the read path ignores it once a reference exists).
-      referenced.setContent(sanitizedJson);
-      referenced.setPublicationStatus(status);
-      referenced.setUpdateDate(now);
-    } else {
-      department.setContentImprint(sanitizedJson);
-      department.setPublicationStatusImprint(status);
+    // ADR-014 amendment 2026-07-28: never write through to the referenced shared object. The 0026
+    // backfill merged byte-identical departments onto one row, so writing through would silently
+    // republish every sibling Fachbereich. Publishing means "this department leaves the shared
+    // text": the reference is dropped and the text becomes the department's own. A draft keeps the
+    // reference, so the public still resolves the inherited text until the admin publishes.
+    if (publish) {
+      department.setImprint(null);
     }
-    department.setUpdateDate(now);
+    department.setContentImprint(sanitizedJson);
+    department.setPublicationStatusImprint(status);
+    department.setUpdateDate(LocalDateTime.now());
     agencyTopicRepository.save(department);
 
     return status;
@@ -105,12 +103,25 @@ public class DepartmentImprintService {
     assertCallerTenantMatches(department.getAgency());
 
     LegalText referenced = department.getImprint();
-    if (referenced != null) {
+    if (referenced != null && !hasPendingDraft(department, referenced)) {
       return new DepartmentImprintView(
           referenced.getContent(), referenced.getPublicationStatus());
     }
     return new DepartmentImprintView(
         department.getContentImprint(), department.getPublicationStatusImprint());
+  }
+
+  /**
+   * Tells an admin's unpublished draft apart from a {@code 0026} backfill leftover, both of which
+   * appear as inline content next to a live reference. Mirrors {@code
+   * DepartmentDataProtectionService#hasPendingDraft}: the backfill copied the text verbatim, so a
+   * leftover is byte-identical to what it references and keeps resolving through the reference.
+   */
+  private boolean hasPendingDraft(AgencyTopic department, LegalText referenced) {
+    var draft = department.getContentImprint();
+    return draft != null
+        && department.getPublicationStatusImprint() == PublicationStatus.DRAFT
+        && !draft.equals(referenced.getContent());
   }
 
   /**

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/service/legal/DepartmentDataProtectionServiceTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/service/legal/DepartmentDataProtectionServiceTest.java
@@ -82,42 +82,69 @@ class DepartmentDataProtectionServiceTest {
     return department;
   }
 
+  private LegalText sharedDpp() {
+    return LegalText.builder()
+        .id(100L)
+        .kind(LegalTextKind.DPP)
+        .label("Geteilte DSE")
+        .content("{\"de\":\"<p>alt</p>\"}")
+        .publicationStatus(PublicationStatus.PUBLISHED)
+        .build();
+  }
+
   @Test
-  void publish_Should_writeThroughToReferencedLegalText_When_departmentReferencesOne() {
-    // ADR-014: once a department references a shared legal-text object, that object is the truth.
-    // The legacy per-department publish endpoint must therefore update the referenced object —
-    // writing the inline column would be silently ignored by the read path.
+  void publish_Should_breakSharedLink_And_storeOwnText_When_departmentReferencesOne() {
+    // ADR-014 amendment 2026-07-28: publishing under one Fachbereich must NOT rewrite the shared
+    // object — the 0026 backfill merged byte-identical departments onto one row, so writing through
+    // would silently republish every sibling department. Publishing means "this department leaves
+    // the shared text": clear the reference, store the text on the department itself.
     when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(false);
     var department = existingDepartment();
-    var referenced =
-        LegalText.builder()
-            .id(100L)
-            .kind(LegalTextKind.DPP)
-            .label("Geteilte DSE")
-            .content("{\"de\":\"<p>alt</p>\"}")
-            .publicationStatus(PublicationStatus.DRAFT)
-            .build();
+    var referenced = sharedDpp();
     department.setDpp(referenced);
 
     var status =
         service.publishDepartmentDataPrivacy(7L, 42L, Map.of("de", "<p>neu</p>"), true);
 
     assertThat(status).isEqualTo(PublicationStatus.PUBLISHED);
-    assertThat(referenced.getContent()).contains("neu");
-    assertThat(referenced.getPublicationStatus()).isEqualTo(PublicationStatus.PUBLISHED);
-    assertThat(referenced.getUpdateDate()).isNotNull();
-    // the inline copy stays untouched — it is dead weight kept only for rollback
+
     var saved = ArgumentCaptor.forClass(AgencyTopic.class);
     verify(agencyTopicRepository).save(saved.capture());
-    assertThat(saved.getValue().getContentDpp()).isNull();
+    assertThat(saved.getValue().getDpp()).as("shared link must be broken").isNull();
+    assertThat(saved.getValue().getContentDpp()).contains("neu");
+    assertThat(saved.getValue().getPublicationStatus()).isEqualTo(PublicationStatus.PUBLISHED);
+
+    // the sibling departments still pointing at this row must be byte-identical afterwards
+    assertThat(referenced.getContent()).isEqualTo("{\"de\":\"<p>alt</p>\"}");
+    assertThat(referenced.getPublicationStatus()).isEqualTo(PublicationStatus.PUBLISHED);
   }
 
   @Test
-  void read_Should_returnReferencedLegalText_When_departmentReferencesOne() {
+  void draftSave_Should_keepSharedLink_And_parkDraftInline_When_departmentReferencesOne() {
+    // A draft must not change what the public sees: the reference stays, so the read path keeps
+    // resolving the inherited text while the draft waits in the otherwise-unused inline column.
     when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(false);
     var department = existingDepartment();
-    department.setContentDpp("{\"de\":\"<p>inline-alt</p>\"}");
-    department.setPublicationStatus(PublicationStatus.DRAFT);
+    var referenced = sharedDpp();
+    department.setDpp(referenced);
+
+    var status =
+        service.publishDepartmentDataPrivacy(7L, 42L, Map.of("de", "<p>entwurf</p>"), false);
+
+    assertThat(status).isEqualTo(PublicationStatus.DRAFT);
+
+    var saved = ArgumentCaptor.forClass(AgencyTopic.class);
+    verify(agencyTopicRepository).save(saved.capture());
+    assertThat(saved.getValue().getDpp()).as("draft must not unshare").isSameAs(referenced);
+    assertThat(saved.getValue().getContentDpp()).contains("entwurf");
+    assertThat(saved.getValue().getPublicationStatus()).isEqualTo(PublicationStatus.DRAFT);
+    assertThat(referenced.getContent()).isEqualTo("{\"de\":\"<p>alt</p>\"}");
+  }
+
+  @Test
+  void read_Should_returnReferencedLegalText_When_departmentReferencesOne_AndHasNoPendingDraft() {
+    when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(false);
+    var department = existingDepartment();
     department.setDpp(
         LegalText.builder()
             .id(100L)
@@ -131,6 +158,29 @@ class DepartmentDataProtectionServiceTest {
 
     assertThat(view.content()).isEqualTo("{\"de\":\"<p>geteilt</p>\"}");
     assertThat(view.publicationStatus()).isEqualTo(PublicationStatus.PUBLISHED);
+  }
+
+  @Test
+  void read_Should_returnPendingDraft_When_departmentHasDraftAlongsideReference() {
+    // The editor must show the admin their own unfinished work, not the inherited text they are
+    // about to replace — while the public still resolves the reference.
+    when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(false);
+    var department = existingDepartment();
+    department.setContentDpp("{\"de\":\"<p>entwurf</p>\"}");
+    department.setPublicationStatus(PublicationStatus.DRAFT);
+    department.setDpp(
+        LegalText.builder()
+            .id(100L)
+            .kind(LegalTextKind.DPP)
+            .label("Geteilte DSE")
+            .content("{\"de\":\"<p>geteilt</p>\"}")
+            .publicationStatus(PublicationStatus.PUBLISHED)
+            .build());
+
+    var view = service.getDepartmentDataPrivacy(7L, 42L);
+
+    assertThat(view.content()).isEqualTo("{\"de\":\"<p>entwurf</p>\"}");
+    assertThat(view.publicationStatus()).isEqualTo(PublicationStatus.DRAFT);
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/service/legal/DepartmentImprintServiceTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/service/legal/DepartmentImprintServiceTest.java
@@ -82,38 +82,63 @@ class DepartmentImprintServiceTest {
     return department;
   }
 
+  private LegalText sharedImprint() {
+    return LegalText.builder()
+        .id(101L)
+        .kind(LegalTextKind.IMPRINT)
+        .label("Geteiltes Impressum")
+        .content("{\"de\":\"<p>alt</p>\"}")
+        .publicationStatus(PublicationStatus.PUBLISHED)
+        .build();
+  }
+
   @Test
-  void publish_Should_writeThroughToReferencedLegalText_When_departmentReferencesOne() {
-    // ADR-014: the referenced shared Impressum object is the truth; the legacy per-department
-    // endpoint writes through to it instead of the ignored inline column.
+  void publish_Should_breakSharedLink_And_storeOwnText_When_departmentReferencesOne() {
+    // ADR-014 amendment 2026-07-28: publishing under one Fachbereich leaves the shared Impressum
+    // rather than rewriting it for every sibling department that the 0026 backfill merged onto the
+    // same row.
     when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(false);
     var department = existingDepartment();
-    var referenced =
-        LegalText.builder()
-            .id(101L)
-            .kind(LegalTextKind.IMPRINT)
-            .label("Geteiltes Impressum")
-            .content("{\"de\":\"<p>alt</p>\"}")
-            .publicationStatus(PublicationStatus.DRAFT)
-            .build();
+    var referenced = sharedImprint();
     department.setImprint(referenced);
 
     var status = service.publishDepartmentImprint(7L, 42L, Map.of("de", "<p>neu</p>"), true);
 
     assertThat(status).isEqualTo(PublicationStatus.PUBLISHED);
-    assertThat(referenced.getContent()).contains("neu");
-    assertThat(referenced.getPublicationStatus()).isEqualTo(PublicationStatus.PUBLISHED);
+
     var saved = ArgumentCaptor.forClass(AgencyTopic.class);
     verify(agencyTopicRepository).save(saved.capture());
-    assertThat(saved.getValue().getContentImprint()).isNull();
+    assertThat(saved.getValue().getImprint()).as("shared link must be broken").isNull();
+    assertThat(saved.getValue().getContentImprint()).contains("neu");
+    assertThat(saved.getValue().getPublicationStatusImprint())
+        .isEqualTo(PublicationStatus.PUBLISHED);
+    assertThat(referenced.getContent()).isEqualTo("{\"de\":\"<p>alt</p>\"}");
+    assertThat(referenced.getPublicationStatus()).isEqualTo(PublicationStatus.PUBLISHED);
   }
 
   @Test
-  void read_Should_returnReferencedLegalText_When_departmentReferencesOne() {
+  void draftSave_Should_keepSharedLink_And_parkDraftInline_When_departmentReferencesOne() {
     when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(false);
     var department = existingDepartment();
-    department.setContentImprint("{\"de\":\"<p>inline-alt</p>\"}");
-    department.setPublicationStatusImprint(PublicationStatus.DRAFT);
+    var referenced = sharedImprint();
+    department.setImprint(referenced);
+
+    var status = service.publishDepartmentImprint(7L, 42L, Map.of("de", "<p>entwurf</p>"), false);
+
+    assertThat(status).isEqualTo(PublicationStatus.DRAFT);
+
+    var saved = ArgumentCaptor.forClass(AgencyTopic.class);
+    verify(agencyTopicRepository).save(saved.capture());
+    assertThat(saved.getValue().getImprint()).as("draft must not unshare").isSameAs(referenced);
+    assertThat(saved.getValue().getContentImprint()).contains("entwurf");
+    assertThat(saved.getValue().getPublicationStatusImprint()).isEqualTo(PublicationStatus.DRAFT);
+    assertThat(referenced.getContent()).isEqualTo("{\"de\":\"<p>alt</p>\"}");
+  }
+
+  @Test
+  void read_Should_returnReferencedLegalText_When_departmentReferencesOne_AndHasNoPendingDraft() {
+    when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(false);
+    var department = existingDepartment();
     department.setImprint(
         LegalText.builder()
             .id(101L)
@@ -127,6 +152,27 @@ class DepartmentImprintServiceTest {
 
     assertThat(view.content()).isEqualTo("{\"de\":\"<p>geteilt</p>\"}");
     assertThat(view.publicationStatus()).isEqualTo(PublicationStatus.PUBLISHED);
+  }
+
+  @Test
+  void read_Should_returnPendingDraft_When_departmentHasDraftAlongsideReference() {
+    when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(false);
+    var department = existingDepartment();
+    department.setContentImprint("{\"de\":\"<p>entwurf</p>\"}");
+    department.setPublicationStatusImprint(PublicationStatus.DRAFT);
+    department.setImprint(
+        LegalText.builder()
+            .id(101L)
+            .kind(LegalTextKind.IMPRINT)
+            .label("Geteiltes Impressum")
+            .content("{\"de\":\"<p>geteilt</p>\"}")
+            .publicationStatus(PublicationStatus.PUBLISHED)
+            .build());
+
+    var view = service.getDepartmentImprint(7L, 42L);
+
+    assertThat(view.content()).isEqualTo("{\"de\":\"<p>entwurf</p>\"}");
+    assertThat(view.publicationStatus()).isEqualTo(PublicationStatus.DRAFT);
   }
 
   @Test


### PR DESCRIPTION
## What

Publishing a Fachbereich's Datenschutzerklärung or Impressum wrote **through** to the referenced
shared `LegalText` whenever `dpp_id` / `imprint_id` was set — the code called the shared object
"the truth". The `0026_legal_text` backfill deliberately merges byte-identical department texts
onto **one** shared row, so on every migrated environment departments already share rows today, and
publishing for one department silently republished all of its siblings.

The department selector agreed in the ADR-014 amendment (2026-07-28) makes this reachable from the
admin UI on every save, which is why it is now treated as a defect rather than a design choice.

## How

- **Publish** clears the reference and stores the sanitised text on the department itself — a
  department *leaves* the shared text instead of rewriting it for everyone.
- **Draft-save** keeps the reference and parks the draft in the otherwise-unused inline column, so
  the public read path keeps resolving the inherited text until the admin publishes.
- The read path distinguishes a pending draft from a `0026` backfill leftover: the backfill copied
  content verbatim, so a leftover is byte-identical to what it references, while a real draft
  differs and is still `DRAFT`.

No schema change — the inline columns are unused whenever a reference is set.

## Tests

Red-green. The two tests that previously asserted the write-through
(`publish_Should_writeThroughToReferencedLegalText_When_departmentReferencesOne`, one per service)
are replaced by tests that assert the sibling rows stay byte-identical, plus new coverage for
draft-keeps-link and read-returns-pending-draft.

```
Tests run: 523, Failures: 0, Errors: 0, Skipped: 0 — BUILD SUCCESS
You have 0 Checkstyle violations.
```

## Note for reviewers

This changes what "publish" means for a department that inherits a shared text: it is now a
one-way un-share, by design and with no revert (ADR-014 amendment, decision 3). The admin-side
counterpart is OpenResilienceInitiative/ORISO-Admin#555, which is blocked on this PR.

Refs OpenResilienceInitiative/ORISO-AgencyService#193
Part of epic OpenResilienceInitiative/ORISO-Frontend#86

🤖 Generated with [Claude Code](https://claude.com/claude-code)
