### PR TITLE
fix(agency): only report topics a help-seeker can actually reach

### DIFF
--- a/src/main/java/de/caritas/cob/agencyservice/api/repository/agency/AgencyRepository.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/repository/agency/AgencyRepository.java
@@ -48,8 +48,14 @@ public interface AgencyRepository extends JpaRepository<Agency, Long> {
       + "AND ((:gender IS NULL) OR (a.genders LIKE CONCAT('%,',:gender,'%') OR a.genders LIKE CONCAT(:gender,'%'))) "
       + "AND a.delete_date IS NULL ";
 
+  // Only topics a help-seeker can actually reach. Without the reachability filter this reports
+  // topics whose every agency is offline or soft-deleted, and registration offers them as valid
+  // choices that dead-end on "Keine Online-Beratungsstelle gefunden" (ORISO-Frontend#245).
+  // The WHERE also gives AgencyTenantAwareRepository's `AND a.tenant_id = :tenantId` a real
+  // predicate to attach to instead of widening the INNER JOIN condition.
   String SELECT_ALL_AGENCIES_TOPICS = "SELECT distinct(at.topic_id) FROM agency_topic at "
-      + "INNER JOIN agency a ON a.id = at.agency_id ";
+      + "INNER JOIN agency a ON a.id = at.agency_id "
+      + "WHERE a.is_offline = false AND a.delete_date IS NULL ";
 
   String GROUP_BY_ORDER_BY = "GROUP BY a.id "
       + "ORDER BY a.postcode DESC";

--- a/src/test/java/de/caritas/cob/agencyservice/api/repository/agency/AgencyTopicReachabilityRepositoryTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/repository/agency/AgencyTopicReachabilityRepositoryTest.java
@@ -1,0 +1,93 @@
+package de.caritas.cob.agencyservice.api.repository.agency;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import de.caritas.cob.agencyservice.api.repository.agencytopic.AgencyTopic;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
+import org.springframework.boot.jpa.test.autoconfigure.TestEntityManager;
+import org.springframework.boot.liquibase.autoconfigure.LiquibaseAutoConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+/**
+ * {@code findAllAgenciesTopics} answers "which topics actually have agencies?" and drives what
+ * registration offers a help-seeker. A topic whose only agencies are offline or soft-deleted is a
+ * guaranteed dead end — the help-seeker picks it and lands on "Keine Online-Beratungsstelle
+ * gefunden" with no explanation (ORISO-Frontend#245).
+ */
+@TestPropertySource(properties = {"spring.profiles.active=testing"})
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.ANY)
+@ExtendWith(SpringExtension.class)
+@DataJpaTest(excludeAutoConfiguration = LiquibaseAutoConfiguration.class)
+class AgencyTopicReachabilityRepositoryTest {
+
+  @Autowired private TestEntityManager em;
+  @Autowired private AgencyRepository agencyRepository;
+
+  private Agency persistAgency(String name, boolean offline, LocalDateTime deleteDate) {
+    var now = LocalDateTime.now();
+    return em.persistFlushFind(
+        Agency.builder()
+            .name(name)
+            .consultingTypeId(1)
+            .offline(offline)
+            .deleteDate(deleteDate)
+            .dataProtectionResponsibleEntity(DataProtectionResponsibleEntity.AGENCY_RESPONSIBLE)
+            .dataProtectionOfficerContactData("officer")
+            .dataProtectionAlternativeContactData("alternative")
+            .dataProtectionAgencyResponsibleContactData("agency")
+            .createDate(now)
+            .updateDate(now)
+            .build());
+  }
+
+  private void persistDepartment(Agency agency, long topicId) {
+    var now = LocalDateTime.now();
+    em.persistFlushFind(
+        AgencyTopic.builder()
+            .agency(agency)
+            .topicId(topicId)
+            .createDate(now)
+            .updateDate(now)
+            .build());
+  }
+
+  @Test
+  void findAllAgenciesTopics_Should_reportTopic_When_itHasAReachableAgency() {
+    persistDepartment(persistAgency("Reachable", false, null), 4711L);
+    em.clear();
+
+    assertThat(agencyRepository.findAllAgenciesTopics(null)).contains(4711);
+  }
+
+  @Test
+  void findAllAgenciesTopics_Should_omitTopic_When_itsOnlyAgencyIsOffline() {
+    persistDepartment(persistAgency("Offline only", true, null), 4712L);
+    em.clear();
+
+    assertThat(agencyRepository.findAllAgenciesTopics(null)).doesNotContain(4712);
+  }
+
+  @Test
+  void findAllAgenciesTopics_Should_omitTopic_When_itsOnlyAgencyIsSoftDeleted() {
+    persistDepartment(persistAgency("Deleted only", false, LocalDateTime.now()), 4713L);
+    em.clear();
+
+    assertThat(agencyRepository.findAllAgenciesTopics(null)).doesNotContain(4713);
+  }
+
+  @Test
+  void findAllAgenciesTopics_Should_reportTopic_When_atLeastOneOfItsAgenciesIsReachable() {
+    // A topic stays offerable as long as one agency behind it can actually take the help-seeker.
+    persistDepartment(persistAgency("Offline sibling", true, null), 4714L);
+    persistDepartment(persistAgency("Reachable sibling", false, null), 4714L);
+    em.clear();
+
+    assertThat(agencyRepository.findAllAgenciesTopics(null)).contains(4714);
+  }
+}


### PR DESCRIPTION
## Problem

`findAllAgenciesTopics` answers "which topics actually have agencies?" and drives what registration
offers a help-seeker. It joined `agency` without any filter, so a topic whose every agency is
offline or soft-deleted was still reported — registration offered it and dead-ended the help-seeker
on "Keine Online-Beratungsstelle gefunden" with no explanation. Measured on production 2026-06-23:
13 of 16 active topics had zero reachable agencies.

## What changed

- `SELECT_ALL_AGENCIES_TOPICS` filters `a.is_offline = false AND a.delete_date IS NULL`.
- The added `WHERE` also gives `AgencyTenantAwareRepository`'s `AND a.tenant_id = :tenantId` a real
  predicate to attach to, instead of widening the `INNER JOIN` condition.
- New `AgencyTopicReachabilityRepositoryTest`: reachable topic reported; offline-only and
  deleted-only topics omitted; a topic with one offline **and** one reachable agency still reported.

## Scope correction — please read

The issue also claimed the forced `offline(true)` on agency create is a backend defect. That did
not survive review and is **not** changed here:

- `offline(true)` on create is correct — a new agency has no postcode ranges yet, so
  `AgencyOfflineStatusValidator` could never pass.
- The validator does throw `InvalidOfflineStatusException`, which
  `ApiResponseEntityExceptionHandler` maps to 400 with a reason. The rejection is **not** silent
  server-side; what swallows it is the admin UI. That part belongs in ORISO-Admin.

The issue text has been updated to match.

## Also worth knowing

`AgencyServiceIT` is **already red on `pre-dev`** (3 failures, 2 errors) before this change — every
collection assertion comes back empty. I did not touch it, and did not use it as the harness for
this fix; the new coverage is a repository test instead. Consistent with the 2026-07-26 pre-dev lane
review finding about dead tests with no required checks. Worth its own ticket.

## Verification

```
Tests run: 523, Failures: 0, Errors: 0, Skipped: 0 — BUILD SUCCESS
You have 0 Checkstyle violations.
```

Refs OpenResilienceInitiative/ORISO-AgencyService#194
Part of epic OpenResilienceInitiative/ORISO-Frontend#86

🤖 Generated with [Claude Code](https://claude.com/claude-code)
