### PR TITLE
test(postcode): close the last open assertion from #66

### DIFF
--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/service/agencypostcoderange/AgencyPostcodeRangeAdminServiceTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/service/agencypostcoderange/AgencyPostcodeRangeAdminServiceTest.java
@@ -10,6 +10,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.util.ReflectionTestUtils.setField;
 
@@ -66,6 +67,10 @@ class AgencyPostcodeRangeAdminServiceTest {
     this.agencyPostcodeRangeAdminService.deleteAgencyPostcodeRange(1L);
 
     verify(this.agencyPostcodeRangeRepository, times(1)).deleteAllByAgencyId(1L);
+    // The offline status is controlled explicitly via agency update, so deleting the
+    // last postcode range must not reach the agency at all (#66). Without this the
+    // test name promised an assertion it never made.
+    verifyNoInteractions(this.agencyAdminService);
   }
 
   @Test


### PR DESCRIPTION
## Why

Refs OpenResilienceInitiative/ORISO-AgencyService#66
Refs OpenResilienceInitiative/ORISO-AgencyService#185

While reconciling the #185 quarantine against reality, all four AS-TEST-FIX issues turned out to be already fixed in code — with one exception.

`deleteAgencyPostcodeRange_Should_NotSetAgencyOffline_When_givenPostcodeRangeIsTheLast` verifies only the repository delete. It never asserts the thing its name promises, so it would stay green if the removed auto-offline behaviour came back. #66's acceptance criterion explicitly asked for the `never()`-style assertion.

`deleteAgencyPostcodeRange` now touches only `AgencyPostcodeRangeRepository`, so the honest assertion is that `AgencyAdminService` is not reached at all.

## Verification

`./mvnw test -Dtest=AgencyPostcodeRangeAdminServiceTest` — `Tests run: 7, Failures: 0, Errors: 0` (Java 21, `openjdk 21.0.11`).

Test-only change, one file, five lines. No production code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)