### PR TITLE
test(schema): align the H2 test schema with ADR-014 legal texts

### DIFF
--- a/src/test/resources/database/AgencyDatabase.sql
+++ b/src/test/resources/database/AgencyDatabase.sql
@@ -1,11 +1,13 @@
 DROP TABLE IF EXISTS AGENCY_POSTCODE_RANGE;
 DROP TABLE IF EXISTS AGENCY_TOPIC;
+DROP TABLE IF EXISTS LEGAL_TEXT;
 DROP TABLE IF EXISTS AGENCY;
 DROP TABLE IF EXISTS AGENCY_ADMIN_CONTROL;
 DROP TABLE IF EXISTS DIOCESE;
 
 DROP SEQUENCE IF EXISTS SEQUENCE_AGENCY_POSTCODE_RANGE;
 DROP SEQUENCE IF EXISTS SEQUENCE_AGENCY_TOPIC;
+DROP SEQUENCE IF EXISTS SEQUENCE_LEGAL_TEXT;
 DROP SEQUENCE IF EXISTS SEQUENCE_AGENCY;
 DROP SEQUENCE IF EXISTS SEQUENCE_AGENCY_ADMIN_CONTROL;
 
@@ -67,6 +69,24 @@ CREATE SEQUENCE SEQUENCE_AGENCY_POSTCODE_RANGE
     START WITH 100000
     INCREMENT BY 1;
 
+-- ADR-014 (Liquibase changeset 0026_legal_text): legal texts are first-class shared
+-- objects owned by a Träger, referenced by departments instead of being inlined.
+create table LEGAL_TEXT
+(
+    ID                 bigint      not null,
+    TENANT_ID          bigint      null,
+    KIND               varchar(20) not null,
+    LABEL              varchar(255) not null,
+    CONTENT            longtext    null,
+    PUBLICATION_STATUS varchar(20) not null default 'DRAFT',
+    CREATE_DATE        timestamp,
+    UPDATE_DATE        timestamp,
+    primary key (ID)
+);
+CREATE SEQUENCE SEQUENCE_LEGAL_TEXT
+    START WITH 100000
+    INCREMENT BY 1;
+
 create table AGENCY_TOPIC
 (
     ID            bigint     not null,
@@ -78,8 +98,12 @@ create table AGENCY_TOPIC
     PUBLICATION_STATUS varchar(20) not null default 'DRAFT',
     CONTENT_IMPRINT longtext null,
     PUBLICATION_STATUS_IMPRINT varchar(20) not null default 'DRAFT',
+    DPP_ID        bigint     null,
+    IMPRINT_ID    bigint     null,
     primary key (ID),
-    foreign key (AGENCY_ID) references AGENCY (ID)
+    foreign key (AGENCY_ID) references AGENCY (ID),
+    foreign key (DPP_ID) references LEGAL_TEXT (ID),
+    foreign key (IMPRINT_ID) references LEGAL_TEXT (ID)
 );
 CREATE SEQUENCE SEQUENCE_AGENCY_TOPIC
     START WITH 100000


### PR DESCRIPTION
## Why

Refs OpenResilienceInitiative/ORISO-AgencyService#185

The #185 quarantine describes the remaining red as four clusters — "stale controller expectations, database/context setup, tenant-aware fixtures, and persistence behavior". Measuring it instead of reading it shows most of that is one defect with a wide blast radius.

Liquibase changeset `0026_legal_text` (ADR-014) created the `legal_text` table and added `agency_topic.dpp_id` / `imprint_id`. `src/test/resources/database/AgencyDatabase.sql` — the H2 schema every AgencyService integration test runs against — was never updated.

`AgencyTenantUnawareRepository` fetches `{"agencyTopics", "agencyTopics.dpp", "agencyTopics.imprint"}` via `@EntityGraph`, so every test that loads an agency with its topics failed with:

```
org.hibernate.exception.SQLGrammarException: Could not prepare statement
  [Column "AT1_0.DPP_ID" not found; ...]
```

18 direct hits, which then cascaded into `Status expected:<200> but was:<500>` and `ApplicationContext failure threshold (1) exceeded` in suites that have nothing to do with legal texts.

## What this changes

`AgencyDatabase.sql` only. Adds the `LEGAL_TEXT` table, `SEQUENCE_LEGAL_TEXT`, and the two nullable foreign keys on `AGENCY_TOPIC`, mirroring the production DDL in `db/changelog/changeset/0026_legal_text/createLegalText.sql` and `addAgencyTopicLegalTextReferences.sql`. No production code, no Java test code.

## Measured effect

Full `./mvnw -B -fae verify` on the same worktree, Java 21 (`openjdk 21.0.11`), before and after the one-file change:

| | tests | failures | errors | failing classes |
| --- | --- | --- | --- | --- |
| before | 716 | 29 | 51 | 16 |
| after | 716 | 14 | 33 | 9 |

Seven suites go fully green: `AgencyRepositoryIT`, `AgencyRepositoryTenantAwareIT`, `AgencyAdminSearchServiceIT`, `AgencyAdminControllerWithTopicsIT`, `AgencyAdminControllerWithDemographicsIT`, `AgencyControllerWithDemographicsIT`, `AgencyControllerWithSingleDomainMultitenancyIT`. `AgencyAdminControllerIT` drops from 8 failures to 1.

That is 41% of the quarantine, from a schema file.

## What is still red

Nine suites, 47 results. The remaining top causes are no longer schema drift:

| Count | Cause |
| --- | --- |
| 8 | `ApplicationContext failure threshold (1) exceeded` — context setup |
| 7 | bare `RuntimeException` |
| 5 | `NullPointerException: The validated object is null` |
| 4+3+2 | empty-collection assertions — missing or changed seed data |
| 3 | `NotFoundException` |

These are genuine per-suite defects and belong in follow-up slices under #185, not in this PR.

## Note for #185's exit criteria

This does not close #185. It does mean the "database/context setup" cluster was mostly a single missing migration in the test fixture rather than a broad infrastructure problem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)