### PR TITLE
fix(security): require SSL for Keycloak tokens in prod and staging (AS-H05)

### DIFF
--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -100,4 +100,4 @@ cache.applicationsettings.configuration.maxEntriesLocalHeap=100
 cache.applicationsettings.configuration.eternal=false
 cache.applicationsettings.configuration.timeToIdleSeconds=300
 cache.applicationsettings.configuration.timeToLiveSeconds=600
-keycloak.ssl-required=none
+keycloak.ssl-required=external

--- a/src/main/resources/application-staging.properties
+++ b/src/main/resources/application-staging.properties
@@ -99,4 +99,4 @@ cache.applicationsettings.configuration.maxEntriesLocalHeap=100
 cache.applicationsettings.configuration.eternal=false
 cache.applicationsettings.configuration.timeToIdleSeconds=300
 cache.applicationsettings.configuration.timeToLiveSeconds=600
-keycloak.ssl-required=none
+keycloak.ssl-required=external

--- a/src/test/java/de/caritas/cob/agencyservice/config/ProductionProfilePropertiesTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/config/ProductionProfilePropertiesTest.java
@@ -1,0 +1,61 @@
+package de.caritas.cob.agencyservice.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Guards the security-relevant settings of the internet-facing profiles (AS-H05).
+ *
+ * <p>The audit finding was that dev, staging and prod were byte-identical, which is how {@code
+ * keycloak.ssl-required=none} ended up accepting plaintext HTTP tokens in production. These
+ * assertions fail as soon as a profile drifts back.
+ */
+class ProductionProfilePropertiesTest {
+
+  private static final String SSL_REQUIRED = "keycloak.ssl-required";
+
+  @Test
+  void prodProfile_Should_RequireSslForKeycloakTokens() throws IOException {
+    assertEquals("external", loadProfile("prod").getProperty(SSL_REQUIRED));
+  }
+
+  @Test
+  void stagingProfile_Should_RequireSslForKeycloakTokens() throws IOException {
+    assertEquals("external", loadProfile("staging").getProperty(SSL_REQUIRED));
+  }
+
+  @Test
+  void prodProfile_Should_NotEnableSqlLogging() throws IOException {
+    var prod = loadProfile("prod");
+
+    assertEquals("false", prod.getProperty("spring.jpa.show-sql"));
+    assertNotEquals("DEBUG", prod.getProperty("logging.level.root"));
+  }
+
+  @Test
+  void prodProfile_Should_DifferFromDevProfile() throws IOException {
+    var prod = loadProfile("prod");
+    var dev = loadProfile("dev");
+
+    assertNotEquals(
+        dev.getProperty(SSL_REQUIRED),
+        prod.getProperty(SSL_REQUIRED),
+        "prod must not reuse the dev Keycloak SSL setting");
+  }
+
+  private Properties loadProfile(String profile) throws IOException {
+    var properties = new Properties();
+    try (InputStream stream =
+        getClass().getClassLoader().getResourceAsStream("application-" + profile + ".properties")) {
+      assertNotNull(stream, "application-" + profile + ".properties must exist");
+      properties.load(stream);
+    }
+    return properties;
+  }
+}


### PR DESCRIPTION
## Why

`application-prod.properties` and `application-staging.properties` both shipped `keycloak.ssl-required=none`, so the resource server accepted Keycloak tokens over plaintext HTTP in production. ConsultingTypeService fixed the identical finding in its #18; AgencyService was the last service still carrying it.

Found during the security-audit reconciliation pass (OpenResilienceInitiative/ORISO-Docs#72), which re-verified all ~20 audit findings against the current `pre-dev`. The other halves of AS-H05 — DEBUG logging and `show-sql` in production — were already fixed and are asserted here to keep them that way.

## What changed

- `keycloak.ssl-required` is now `external` in `prod` and `staging`; `dev` and `testing` keep `none` for local HTTP work
- New `ProductionProfilePropertiesTest` guards the setting, that prod has no SQL/DEBUG logging, and that prod does not simply mirror the dev profile — profile drift is what produced this finding

## Verification

Red first, then green:

```
Tests run: 4, Failures: 3   <- before the config change
Tests run: 4, Failures: 0   <- after
```

Run with `mvn test -Dtest=ProductionProfilePropertiesTest` (Java 21 via Docker; no local JDK on this machine).

Refs OpenResilienceInitiative/ORISO-AgencyService#19

🤖 Generated with [Claude Code](https://claude.com/claude-code)