### PR TITLE
fix(deletion): purge agency topics and isolate per-agency failures

### DIFF
--- a/src/main/java/de/caritas/cob/agencyservice/api/workflow/AgencyPurgeTransaction.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/workflow/AgencyPurgeTransaction.java
@@ -1,0 +1,47 @@
+package de.caritas.cob.agencyservice.api.workflow;
+
+import de.caritas.cob.agencyservice.api.repository.agency.Agency;
+import de.caritas.cob.agencyservice.api.repository.agency.AgencyRepository;
+import de.caritas.cob.agencyservice.api.repository.agencypostcoderange.AgencyPostcodeRangeRepository;
+import de.caritas.cob.agencyservice.api.repository.agencytopic.AgencyTopicRepository;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Purges one agency and its restricting dependencies inside its own transaction.
+ *
+ * <p>This lives in a separate bean on purpose. The purge previously ran for the whole batch inside
+ * one class-level transaction, so {@code agencyRepository.delete(...)} only queued the delete and
+ * Hibernate flushed it at commit — outside the caller's {@code try/catch} and outside the method. A
+ * constraint violation therefore produced no per-agency log line at all and took the entire batch
+ * down with it.
+ *
+ * <p>With {@code REQUIRES_NEW} the commit happens when this method returns, so the flush is inside
+ * the transaction the caller can observe: a failing agency raises an exception the caller catches
+ * and logs, and the agencies already purged stay purged. A self-invocation would bypass the proxy
+ * and silently restore the old behaviour, which is why this is not a private method on the service.
+ */
+@Component
+@RequiredArgsConstructor
+public class AgencyPurgeTransaction {
+
+  private final @NonNull AgencyRepository agencyRepository;
+  private final @NonNull AgencyPostcodeRangeRepository agencyPostcodeRangeRepository;
+  private final @NonNull AgencyTopicRepository agencyTopicRepository;
+
+  /**
+   * Deletes the agency together with every row holding a restricting foreign key on it.
+   *
+   * @param agency the {@link Agency} to purge
+   */
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
+  public void purge(Agency agency) {
+    var agencyTopics = agencyTopicRepository.findAllByAgencyId(agency.getId());
+    agencyTopicRepository.deleteAll(agencyTopics);
+    agencyPostcodeRangeRepository.deleteAllByAgencyId(agency.getId());
+    agencyRepository.delete(agency);
+  }
+}

--- a/src/main/java/de/caritas/cob/agencyservice/api/workflow/DeleteAgencyService.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/workflow/DeleteAgencyService.java
@@ -3,34 +3,43 @@ package de.caritas.cob.agencyservice.api.workflow;
 import de.caritas.cob.agencyservice.api.repository.agency.Agency;
 import de.caritas.cob.agencyservice.api.repository.agency.AgencyRepository;
 import java.util.List;
-
-import de.caritas.cob.agencyservice.api.repository.agencypostcoderange.AgencyPostcodeRangeRepository;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
-import jakarta.transaction.Transactional;
-
 @Component
 @RequiredArgsConstructor
 @Slf4j
-@Transactional
 public class DeleteAgencyService {
 
   private final @NonNull AgencyRepository agencyRepository;
 
-  private final @NonNull AgencyPostcodeRangeRepository agencyPostcodeRangeRepository;
+  private final @NonNull AgencyPurgeTransaction agencyPurgeTransaction;
 
+  /**
+   * Purges every agency marked for deletion.
+   *
+   * <p>Deliberately not transactional. The class previously carried {@code @Transactional}, which
+   * meant the whole batch shared one transaction and the deletes were only flushed at commit —
+   * outside the per-agency {@code try/catch}. Each agency is now purged in its own transaction by
+   * {@link AgencyPurgeTransaction}, so a failure is attributable, logged, and confined to that
+   * agency.
+   *
+   * <p>The run is logged with its match count because a silent job and an empty job used to look
+   * identical in the logs.
+   */
   public void deleteAgenciesMarkedForDeletion() {
-    List<Agency> allByDeleteDateNotNull = agencyRepository.findAllByDeleteDateNotNull();
-    allByDeleteDateNotNull.stream().forEach(this::deleteAgency);
+    List<Agency> agenciesMarkedForDeletion = agencyRepository.findAllByDeleteDateNotNull();
+    log.info(
+        "Agency deletion workflow started, {} agencies marked for deletion.",
+        agenciesMarkedForDeletion.size());
+    agenciesMarkedForDeletion.forEach(this::deleteAgency);
   }
 
   private void deleteAgency(Agency agency) {
     try {
-      agencyPostcodeRangeRepository.deleteAllByAgencyId(agency.getId());
-      agencyRepository.delete(agency);
+      agencyPurgeTransaction.purge(agency);
       log.info("agency with id {} has been deleted.", agency.getId());
     } catch (Exception ex) {
       log.error("Error while deleting agency with id {}", agency.getId(), ex);

--- a/src/test/java/de/caritas/cob/agencyservice/api/workflow/AgencyPurgeTransactionTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/workflow/AgencyPurgeTransactionTest.java
@@ -1,0 +1,49 @@
+package de.caritas.cob.agencyservice.api.workflow;
+
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.Lists;
+import de.caritas.cob.agencyservice.api.repository.agency.Agency;
+import de.caritas.cob.agencyservice.api.repository.agency.AgencyRepository;
+import de.caritas.cob.agencyservice.api.repository.agencypostcoderange.AgencyPostcodeRangeRepository;
+import de.caritas.cob.agencyservice.api.repository.agencytopic.AgencyTopic;
+import de.caritas.cob.agencyservice.api.repository.agencytopic.AgencyTopicRepository;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AgencyPurgeTransactionTest {
+
+  @Mock AgencyRepository agencyRepository;
+
+  @Mock AgencyPostcodeRangeRepository agencyPostcodeRangeRepository;
+
+  @Mock AgencyTopicRepository agencyTopicRepository;
+
+  @InjectMocks AgencyPurgeTransaction agencyPurgeTransaction;
+
+  @Test
+  void purge_Should_deleteAgencyTopicsAndPostcodeRangesBeforeTheAgency() {
+    // given — agency_topic holds a RESTRICT foreign key on agency and was never deleted
+    var agency = new Agency();
+    agency.setId(268L);
+    var agencyTopic = new AgencyTopic();
+    when(agencyTopicRepository.findAllByAgencyId(268L))
+        .thenReturn(Lists.newArrayList(agencyTopic));
+
+    // when
+    agencyPurgeTransaction.purge(agency);
+
+    // then
+    var inOrder =
+        inOrder(agencyTopicRepository, agencyPostcodeRangeRepository, agencyRepository);
+    inOrder.verify(agencyTopicRepository).deleteAll(List.of(agencyTopic));
+    inOrder.verify(agencyPostcodeRangeRepository).deleteAllByAgencyId(268L);
+    inOrder.verify(agencyRepository).delete(agency);
+  }
+}

--- a/src/test/java/de/caritas/cob/agencyservice/api/workflow/DeleteAgencyServiceTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/workflow/DeleteAgencyServiceTest.java
@@ -1,64 +1,111 @@
 package de.caritas.cob.agencyservice.api.workflow;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import com.google.common.collect.Lists;
 import de.caritas.cob.agencyservice.api.repository.agency.Agency;
 import de.caritas.cob.agencyservice.api.repository.agency.AgencyRepository;
-
-import de.caritas.cob.agencyservice.api.repository.agencypostcoderange.AgencyPostcodeRangeRepository;
 import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.LoggerFactory;
 
 @ExtendWith(MockitoExtension.class)
 class DeleteAgencyServiceTest {
 
-  @Mock
-  AgencyRepository agencyRepository;
+  @Mock AgencyRepository agencyRepository;
 
-  @Mock
-  AgencyPostcodeRangeRepository agencyPostcodeRangeRepository;
+  @Mock AgencyPurgeTransaction agencyPurgeTransaction;
 
-  @InjectMocks
-  DeleteAgencyService deleteAgencyService;
+  @InjectMocks DeleteAgencyService deleteAgencyService;
 
-  @Test
-  void deleteAgenciesMarkedForDeletion_Should_callRepositoryToDeleteAllAgenciesMarkedForDeletion() {
-    // given
-    Agency agency1 = new Agency();
-    agency1.setId(1L);
-    Agency agency2 = new Agency();
-    agency2.setId(2L);
-    Mockito.when(agencyRepository.findAllByDeleteDateNotNull()).thenReturn(Lists.newArrayList(
-        agency1, agency2));
-    // when
-    deleteAgencyService.deleteAgenciesMarkedForDeletion();
-    // then
-    Mockito.verify(agencyPostcodeRangeRepository).deleteAllByAgencyId(agency1.getId());
-    Mockito.verify(agencyRepository).delete(agency1);
-    Mockito.verify(agencyPostcodeRangeRepository).deleteAllByAgencyId(agency2.getId());
-    Mockito.verify(agencyRepository).delete(agency2);
+  private final ch.qos.logback.classic.Logger logger =
+      (ch.qos.logback.classic.Logger) LoggerFactory.getLogger(DeleteAgencyService.class);
+  private final ListAppender<ILoggingEvent> logAppender = new ListAppender<>();
+
+  @BeforeEach
+  void setup() {
+    logAppender.start();
+    logger.addAppender(logAppender);
+  }
+
+  @AfterEach
+  void tearDown() {
+    logger.detachAppender(logAppender);
   }
 
   @Test
-  void deleteAgenciesMarkedForDeletion_Should_continueWithOtherAgencies_When_OneAgencyDeletionFails() {
+  void deleteAgenciesMarkedForDeletion_Should_purgeEveryAgencyMarkedForDeletion() {
     // given
     Agency agency1 = new Agency();
     agency1.setId(1L);
     Agency agency2 = new Agency();
     agency2.setId(2L);
-    Mockito.when(agencyRepository.findAllByDeleteDateNotNull()).thenReturn(List.of(agency1, agency2));
-    Mockito.doThrow(new RuntimeException("DB error"))
-        .when(agencyPostcodeRangeRepository).deleteAllByAgencyId(agency1.getId());
+    Mockito.when(agencyRepository.findAllByDeleteDateNotNull())
+        .thenReturn(Lists.newArrayList(agency1, agency2));
+
     // when
     deleteAgencyService.deleteAgenciesMarkedForDeletion();
+
     // then
-    Mockito.verify(agencyPostcodeRangeRepository).deleteAllByAgencyId(agency1.getId());
-    Mockito.verify(agencyRepository, Mockito.never()).delete(agency1);
-    Mockito.verify(agencyPostcodeRangeRepository).deleteAllByAgencyId(agency2.getId());
-    Mockito.verify(agencyRepository).delete(agency2);
+    Mockito.verify(agencyPurgeTransaction).purge(agency1);
+    Mockito.verify(agencyPurgeTransaction).purge(agency2);
+  }
+
+  @Test
+  void deleteAgenciesMarkedForDeletion_Should_continueWithOtherAgencies_When_OnePurgeFails() {
+    // given
+    Agency agency1 = new Agency();
+    agency1.setId(1L);
+    Agency agency2 = new Agency();
+    agency2.setId(2L);
+    Mockito.when(agencyRepository.findAllByDeleteDateNotNull())
+        .thenReturn(List.of(agency1, agency2));
+    Mockito.doThrow(new RuntimeException("constraint violation"))
+        .when(agencyPurgeTransaction)
+        .purge(agency1);
+
+    // when
+    deleteAgencyService.deleteAgenciesMarkedForDeletion();
+
+    // then - the failure is attributed and logged, and it does not stop the batch
+    Mockito.verify(agencyPurgeTransaction).purge(agency2);
+    assertThat(
+        logAppender.list.stream()
+            .anyMatch(
+                event ->
+                    event.getLevel() == Level.ERROR
+                        && event.getFormattedMessage().contains("Error while deleting agency")),
+        is(true));
+  }
+
+  @Test
+  void deleteAgenciesMarkedForDeletion_Should_logRunWithMatchCount_When_nothingMatches() {
+    // given - a silent job and an empty job used to look identical in the logs
+    Mockito.when(agencyRepository.findAllByDeleteDateNotNull()).thenReturn(List.of());
+
+    // when
+    deleteAgencyService.deleteAgenciesMarkedForDeletion();
+
+    // then
+    assertThat(
+        logAppender.list.stream()
+            .anyMatch(
+                event ->
+                    event
+                        .getFormattedMessage()
+                        .equals(
+                            "Agency deletion workflow started, 0 agencies marked for deletion.")),
+        is(true));
   }
 }


### PR DESCRIPTION
## Two defects, and the second is why the first stayed invisible

**1. `agency_topic` was never deleted.** It holds a `RESTRICT` foreign key on `agency`; only `agency_postcode_range` was removed. Any agency with assigned topics could not be purged. 57 such rows on PreDev.

**2. The per-agency `try/catch` could not catch it.** `DeleteAgencyService` carried a class-level `@Transactional`, so the whole batch shared one transaction and `agencyRepository.delete()` only *queued* the delete. Hibernate flushed at commit — outside the `try/catch` and outside the method. A constraint violation therefore produced **neither** `"agency with id {} has been deleted."` **nor** `"Error while deleting agency with id {}"`, and it aborted the entire batch instead of one agency.

That is exactly the silence reported in #138: 96 hours of logs with marked agencies present and zero purge lines, neither success nor error.

## Approach

Each agency is now purged by a new `AgencyPurgeTransaction` in its own `REQUIRES_NEW` transaction, so the commit — and therefore the flush — happens where the caller can observe it. A failing agency raises an exception the caller catches, attributes and logs; the agencies already purged stay purged.

`AgencyPurgeTransaction` is a **separate bean on purpose**. A private method with `@Transactional` on the same class would be a self-invocation, bypass the proxy, and silently restore the old behaviour. That is noted in the class javadoc so it is not "simplified" back later.

The run now also logs its match count, so a job that never fires and a job that matches nothing stop looking identical — an explicit acceptance criterion of #138.

## A note on the test that was already there

`deleteAgenciesMarkedForDeletion_Should_continueWithOtherAgencies_When_OneAgencyDeletionFails` passed against the old code, because its mock threw **synchronously inside the try**. The real failure arrived at commit and never reached that block. The test asserted a resilience the production code did not have. It has been rewritten to assert the error is actually logged.

## Verification

| | Result |
| --- | --- |
| `AgencyPurgeTransactionTest` with the topic deletion removed | **FAIL** — `Wanted but not invoked` |
| Same test, with the fix | **PASS** |
| Full unit suite | 521 tests, 0 failures, 0 errors |
| Checkstyle | 0 violations |

## Scope

Closes one of the six constraints inventoried in OpenResilienceInitiative/ORISO-UserService#866. The UserService-side constraints are OpenResilienceInitiative/ORISO-UserService#871 and OpenResilienceInitiative/ORISO-UserService#873.

Closes OpenResilienceInitiative/ORISO-AgencyService#202
Refs OpenResilienceInitiative/ORISO-AgencyService#138

🤖 Generated with [Claude Code](https://claude.com/claude-code)