### PR TITLE
test(exception-handler): supply the controller's missing collaborators

### DIFF
--- a/src/test/java/de/caritas/cob/agencyservice/api/ResponseEntityExceptionHandlerIT.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/ResponseEntityExceptionHandlerIT.java
@@ -21,7 +21,9 @@ import de.caritas.cob.agencyservice.api.exception.httpresponses.InternalServerEr
 import de.caritas.cob.agencyservice.api.exception.httpresponses.InvalidPostcodeException;
 import de.caritas.cob.agencyservice.api.exception.httpresponses.NotFoundException;
 import de.caritas.cob.agencyservice.api.service.AgencyService;
+import de.caritas.cob.agencyservice.api.service.DepartmentLegalService;
 import de.caritas.cob.agencyservice.api.service.LogService;
+import de.caritas.cob.agencyservice.api.service.TopicEnrichmentService;
 import de.caritas.cob.agencyservice.config.security.AuthorisationService;
 import de.caritas.cob.agencyservice.config.security.JwtAuthConverter;
 import de.caritas.cob.agencyservice.config.security.JwtAuthConverterProperties;
@@ -54,6 +56,15 @@ public class ResponseEntityExceptionHandlerIT {
 
   @MockitoBean
   private AgencyService agencyService;
+
+  // AgencyController takes three @NonNull collaborators. Without these two the context
+  // never loads, every test here errors, and the exception-to-status assertions below
+  // are never reached (#203).
+  @MockitoBean
+  private TopicEnrichmentService topicEnrichmentService;
+
+  @MockitoBean
+  private DepartmentLegalService departmentLegalService;
 
   @MockitoBean
   private LinkDiscoverers linkDiscoverers;


### PR DESCRIPTION
## Why

Closes OpenResilienceInitiative/ORISO-AgencyService#203
Refs OpenResilienceInitiative/ORISO-AgencyService#185

`AgencyController` takes three `@NonNull` collaborators. `ResponseEntityExceptionHandlerIT` mocked only `AgencyService`, so the context never loaded:

```
UnsatisfiedDependencyException: Error creating bean with name 'agencyController'
Caused by: NoSuchBeanDefinitionException: No qualifying bean of type
  'de.caritas.cob.agencyservice.api.service.TopicEnrichmentService' available
```

The first test errored on the context load; the other eight on `ApplicationContext failure threshold (1) exceeded`, because Spring refuses to retry a context that already failed. Not one of the nine exception-to-status assertions was ever reached — the suite has been reporting nine errors while testing nothing.

## What this changes

Two `@MockitoBean` declarations and their imports. `TopicEnrichmentService` and `DepartmentLegalService`. Nothing else — the assertions are untouched and now actually execute.

## Verification

`./mvnw verify -Dtest=ResponseEntityExceptionHandlerIT`, Java 21 (`openjdk 21.0.11`):

| | tests | failures | errors |
| --- | --- | --- | --- |
| before | 9 | 0 | 9 |
| after | 9 | 0 | 0 |

The suite logs stack traces while running — that is the tests deliberately throwing into the handler, not a failure.

Test-only change. No production code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)