### PR TITLE
test(agency-admin): give the admin service ITs the fixture they assume

### DIFF
--- a/src/main/java/de/caritas/cob/agencyservice/api/repository/agency/Agency.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/repository/agency/Agency.java
@@ -151,7 +151,11 @@ public class Agency implements TenantAware {
   @Column(name = "update_date", nullable = false)
   private LocalDateTime updateDate;
 
-  @Column(name = "data_protection_responsible_entity", nullable = false)
+  // Changeset 0016 declares this column NULL. nullable=false here contradicted the migration
+  // and only ever became real DDL on the create-drop test schema, where it rejected inserts
+  // production accepts. Same reasoning as the neighbouring DPO contact field below — that one
+  // was corrected, this one was missed (#204).
+  @Column(name = "data_protection_responsible_entity")
   @Enumerated(EnumType.STRING)
   private DataProtectionResponsibleEntity dataProtectionResponsibleEntity;
 

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/service/AgencyAdminServiceIT.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/service/AgencyAdminServiceIT.java
@@ -1,6 +1,7 @@
 package de.caritas.cob.agencyservice.api.admin.service;
 
 import de.caritas.cob.agencyservice.AgencyServiceApplication;
+import de.caritas.cob.agencyservice.api.service.TopicService;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
@@ -9,6 +10,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,7 +22,15 @@ import org.springframework.transaction.annotation.Transactional;
 @DirtiesContext(classMode = ClassMode.BEFORE_CLASS)
 @Transactional
 @TestPropertySource(properties = "multitenancy.enabled=false")
+@Sql(scripts = "/database/AgencyDatabase.sql")
 public class AgencyAdminServiceIT extends AgencyAdminServiceITBase {
+
+  /**
+   * Without this the suite calls the real ConsultingTypeService on localhost:8083 during
+   * createAgency and fails with 401 (#204). Mirrors AgencyAdminServiceTenantAwareIT.
+   */
+  @MockitoBean
+  private TopicService topicService;
 
   @Test
   public void saveAgency_Should_PersistsAgency() {

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/service/AgencyAdminServiceITBase.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/service/AgencyAdminServiceITBase.java
@@ -6,6 +6,8 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
 
 import com.google.common.collect.Lists;
 import de.caritas.cob.agencyservice.api.model.AgencyAdminFullResponseDTO;
@@ -18,14 +20,28 @@ import de.caritas.cob.agencyservice.api.tenant.TenantContext;
 import de.caritas.cob.agencyservice.api.util.AuthenticatedUser;
 import jakarta.persistence.EntityManager;
 import java.util.Optional;
+import org.junit.Before;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 public class AgencyAdminServiceITBase {
 
+  /**
+   * A real admin request carries a tenantId claim, which {@code AuthenticatedUserConfig} copies
+   * onto {@link AuthenticatedUser}. The mock returns null unless told otherwise, and
+   * {@code AgencyAdminService.setTenantIdOnCreate} then fails every create with
+   * "The validated object is null" — a fixture artifact, not the behaviour under test (#204).
+   */
+  protected static final Long AUTHENTICATED_TENANT_ID = 1L;
+
   @Autowired protected AgencyAdminService agencyAdminService;
   @Autowired protected AgencyRepository agencyRepository;
   @MockitoBean protected AuthenticatedUser authenticatedUser;
+
+  @Before
+  public void givenAuthenticatedUserHasTenant() {
+    lenient().when(authenticatedUser.getTenantId()).thenReturn(AUTHENTICATED_TENANT_ID);
+  }
 
   public void saveAgency_Should_PersistsAgency() {
 

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/service/AgencyAdminServiceTenantAwareIT.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/service/AgencyAdminServiceTenantAwareIT.java
@@ -41,6 +41,9 @@ import org.springframework.transaction.annotation.Transactional;
 @TestPropertySource(properties = "multitenancy.enabled=true")
 @TestPropertySource(properties = "feature.topics.enabled=true")
 @Transactional
+// AgencyDatabase.sql first: setTenants.sql only UPDATEs agency rows, so without the seed it
+// silently updated nothing and every lookup in the base fixture failed (#204).
+@Sql(value = "/database/AgencyDatabase.sql", executionPhase = ExecutionPhase.BEFORE_TEST_METHOD)
 @Sql(value = "/setTenants.sql", executionPhase = ExecutionPhase.BEFORE_TEST_METHOD)
 public class AgencyAdminServiceTenantAwareIT extends AgencyAdminServiceITBase {
 


### PR DESCRIPTION
## Why

Closes OpenResilienceInitiative/ORISO-AgencyService#204
Refs OpenResilienceInitiative/ORISO-AgencyService#185
Refs OpenResilienceInitiative/ORISO-AgencyService#217

Stacked on #199 — it needs the ADR-014 columns in `AgencyDatabase.sql`, which this PR starts loading. Retarget to `pre-dev` once #199 merges.

`AgencyAdminServiceIT` (6 errors) and `AgencyAdminServiceTenantAwareIT` (9 errors) share `AgencyAdminServiceITBase`. Four distinct causes, none of them about the behaviour the tests claim to cover.

### 1. No seed data at all

Neither suite carried `@Sql(scripts = "/database/AgencyDatabase.sql")`, unlike every other IT in the repo that reads agencies. The database was empty, so `findById(0L)` in `createUpdateAgencyDtoFromExistingAgency` threw `RuntimeException` and `findAgencyById` threw `NotFoundException`.

The tenant-aware suite did have `@Sql("/setTenants.sql")` — but that script only runs `UPDATE AGENCY SET TENANT_ID = '1'`. With no rows it updated nothing and reported success, which is why the suite looked configured while having no data.

### 2. Mocked tenant was null

`@MockitoBean AuthenticatedUser` returns null for `getTenantId()`. With `multitenancy.enabled=false` the `HttpTenantFilter` bean does not exist either, so `TenantContext` is empty and `AgencyAdminService.setTenantIdOnCreate` failed every create with `NullPointerException: The validated object is null`.

A real admin request carries a `tenantId` claim, which `AuthenticatedUserConfig` copies onto `AuthenticatedUser` — the null was a mock artifact, so the base now stubs it.

**What happens when a token genuinely has no claim is a separate question, and this PR does not answer it.** Filed as #217: in that case creation dies on a bare `Validate.notNull` with no message, even though `AGENCY.TENANT_ID` is nullable and the seed rows have `TENANT_ID = null`.

### 3. An entity annotation contradicting its own migration

```java
@Column(name = "data_protection_responsible_entity", nullable = false)
```

Changeset `0016_add_data_protection_attributes` declares that column `NULL`. The annotation only becomes real DDL on the `create-drop` test schema, where it rejected an insert that production accepts:

```
DataIntegrityViolationException: NULL not allowed for column "DATA_PROTECTION_RESPONSIBLE_ENTITY"
```

The field directly below it carries a comment explaining exactly this trap and was corrected for that reason; this neighbour was missed. This is the one production-code line in the PR.

### 4. A live call to ConsultingTypeService

`AgencyAdminServiceIT.saveAgency_Should_PersistsAgency` reached `http://localhost:8083/topic` during `createAgency` and got `401 UNAUTHORIZED`. `TopicService` is now mocked, mirroring the tenant-aware sibling that already did this.

## Verification

Java 21 (`openjdk 21.0.11`).

| Suite | before | after |
| --- | --- | --- |
| `AgencyAdminServiceIT` | 6 tests, 6 errors | 6 tests, 0 failures, 0 errors |
| `AgencyAdminServiceTenantAwareIT` | 9 tests, 9 errors | 9 tests, 0 failures, 0 errors |

Full `./mvnw -B -fae verify` on this branch, to confirm the entity change regressed nothing:

| | tests | failures | errors | red suites |
| --- | --- | --- | --- | --- |
| `pre-dev` | 716 | 29 | 51 | 16 |
| this branch (incl. #199) | 716 | 14 | 18 | 7 |

`ResponseEntityExceptionHandlerIT` is still red here — that is #203 / #216, a separate branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)