### PR TITLE
refactor(deletion): drop the redundant agency_topic delete

### DIFF
--- a/src/main/java/de/caritas/cob/agencyservice/api/workflow/AgencyPurgeTransaction.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/workflow/AgencyPurgeTransaction.java
@@ -3,7 +3,6 @@ package de.caritas.cob.agencyservice.api.workflow;
 import de.caritas.cob.agencyservice.api.repository.agency.Agency;
 import de.caritas.cob.agencyservice.api.repository.agency.AgencyRepository;
 import de.caritas.cob.agencyservice.api.repository.agencypostcoderange.AgencyPostcodeRangeRepository;
-import de.caritas.cob.agencyservice.api.repository.agencytopic.AgencyTopicRepository;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -11,18 +10,24 @@ import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
- * Purges one agency and its restricting dependencies inside its own transaction.
+ * Purges one agency inside its own transaction.
  *
- * <p>This lives in a separate bean on purpose. The purge previously ran for the whole batch inside
- * one class-level transaction, so {@code agencyRepository.delete(...)} only queued the delete and
- * Hibernate flushed it at commit — outside the caller's {@code try/catch} and outside the method. A
- * constraint violation therefore produced no per-agency log line at all and took the entire batch
- * down with it.
+ * <p>The transaction boundary is the entire point of this class. The purge previously ran for the
+ * whole batch inside one class-level transaction on {@link DeleteAgencyService}, so {@code
+ * agencyRepository.delete(...)} only queued the delete and Hibernate flushed it at commit — outside
+ * the caller's {@code try/catch} and outside the method. A failure therefore produced no per-agency
+ * log line and took the whole batch down with it.
  *
  * <p>With {@code REQUIRES_NEW} the commit happens when this method returns, so the flush is inside
  * the transaction the caller can observe: a failing agency raises an exception the caller catches
  * and logs, and the agencies already purged stay purged. A self-invocation would bypass the proxy
  * and silently restore the old behaviour, which is why this is not a private method on the service.
+ *
+ * <p>Departments ({@code agency_topic}) are deliberately <em>not</em> deleted here. {@code
+ * Agency.agencyTopics} is mapped {@code cascade = ALL, orphanRemoval = true}, so Hibernate removes
+ * them before the parent on its own. An earlier revision added an explicit delete believing the
+ * {@code RESTRICT} constraint blocked the purge; a before/after test on PreDev proved it never did.
+ * Postcode ranges carry no such cascade and do need the explicit call.
  */
 @Component
 @RequiredArgsConstructor
@@ -30,17 +35,14 @@ public class AgencyPurgeTransaction {
 
   private final @NonNull AgencyRepository agencyRepository;
   private final @NonNull AgencyPostcodeRangeRepository agencyPostcodeRangeRepository;
-  private final @NonNull AgencyTopicRepository agencyTopicRepository;
 
   /**
-   * Deletes the agency together with every row holding a restricting foreign key on it.
+   * Deletes the agency together with the dependencies that JPA does not cascade.
    *
    * @param agency the {@link Agency} to purge
    */
   @Transactional(propagation = Propagation.REQUIRES_NEW)
   public void purge(Agency agency) {
-    var agencyTopics = agencyTopicRepository.findAllByAgencyId(agency.getId());
-    agencyTopicRepository.deleteAll(agencyTopics);
     agencyPostcodeRangeRepository.deleteAllByAgencyId(agency.getId());
     agencyRepository.delete(agency);
   }

--- a/src/test/java/de/caritas/cob/agencyservice/api/workflow/AgencyPurgeTransactionTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/workflow/AgencyPurgeTransactionTest.java
@@ -1,15 +1,10 @@
 package de.caritas.cob.agencyservice.api.workflow;
 
 import static org.mockito.Mockito.inOrder;
-import static org.mockito.Mockito.when;
 
-import com.google.common.collect.Lists;
 import de.caritas.cob.agencyservice.api.repository.agency.Agency;
 import de.caritas.cob.agencyservice.api.repository.agency.AgencyRepository;
 import de.caritas.cob.agencyservice.api.repository.agencypostcoderange.AgencyPostcodeRangeRepository;
-import de.caritas.cob.agencyservice.api.repository.agencytopic.AgencyTopic;
-import de.caritas.cob.agencyservice.api.repository.agencytopic.AgencyTopicRepository;
-import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -23,26 +18,25 @@ class AgencyPurgeTransactionTest {
 
   @Mock AgencyPostcodeRangeRepository agencyPostcodeRangeRepository;
 
-  @Mock AgencyTopicRepository agencyTopicRepository;
-
   @InjectMocks AgencyPurgeTransaction agencyPurgeTransaction;
 
+  /**
+   * Postcode ranges hold a RESTRICT foreign key on agency and are not cascaded by JPA, so they have
+   * to be removed first. Departments are not asserted here: they are removed by the {@code cascade =
+   * ALL, orphanRemoval = true} mapping on {@code Agency.agencyTopics}, which a mock-based unit test
+   * cannot observe — that ordering is Hibernate's, not this class's.
+   */
   @Test
-  void purge_Should_deleteAgencyTopicsAndPostcodeRangesBeforeTheAgency() {
-    // given — agency_topic holds a RESTRICT foreign key on agency and was never deleted
+  void purge_Should_deletePostcodeRangesBeforeTheAgency() {
+    // given
     var agency = new Agency();
     agency.setId(268L);
-    var agencyTopic = new AgencyTopic();
-    when(agencyTopicRepository.findAllByAgencyId(268L))
-        .thenReturn(Lists.newArrayList(agencyTopic));
 
     // when
     agencyPurgeTransaction.purge(agency);
 
     // then
-    var inOrder =
-        inOrder(agencyTopicRepository, agencyPostcodeRangeRepository, agencyRepository);
-    inOrder.verify(agencyTopicRepository).deleteAll(List.of(agencyTopic));
+    var inOrder = inOrder(agencyPostcodeRangeRepository, agencyRepository);
     inOrder.verify(agencyPostcodeRangeRepository).deleteAllByAgencyId(268L);
     inOrder.verify(agencyRepository).delete(agency);
   }


### PR DESCRIPTION
Follow-up to #207, removing something I added there on a false premise.

## Why

#207 added an explicit `agency_topic` deletion to `AgencyPurgeTransaction`, documented as closing a `RESTRICT` foreign key that blocked the agency purge. **It never blocked anything.**

`Agency.agencyTopics` is mapped `@OneToMany(..., cascade = CascadeType.ALL, orphanRemoval = true)`, so Hibernate already deletes the department rows before the parent.

Measured on PreDev against the **pre-#207** image (`sha256:33825b34…`) with a disposable agency that had a department row:

```
agency_999002_still_there   0
its_topics                  0
exceptions in log           0
```

I derived the gap from `information_schema` plus the service code and did not read the entity mapping. The FK topology showed a `RESTRICT` constraint with no matching delete step, which looked conclusive and was not.

## What changes

The redundant query on its own would be tolerable. The problem is that its javadoc and commit message assert a constraint problem that does not exist — the next reader takes that for a real finding and reasons from it.

- Explicit `agency_topic` deletion and the now-unused `AgencyTopicRepository` dependency removed.
- Javadoc rewritten to state the class's real purpose — the per-agency `REQUIRES_NEW` boundary, so the flush happens inside a transaction the caller can observe and attribute — and to name the JPA cascade as what handles departments, so the explicit call does not get re-added later.
- The unit test drops the department-ordering assertion (a mock-based test cannot observe Hibernate's cascade ordering anyway) and keeps postcode-ranges-before-agency, which genuinely is this class's responsibility.

## What #207 still delivers

Unchanged and verified live on PreDev at 20:56/20:58 UTC:

```
Agency deletion workflow started, 1 agencies marked for deletion.
agency with id 999001 has been deleted.
Agency deletion workflow started, 0 agencies marked for deletion.
```

Per-agency transaction isolation and the run/match-count logging are real. The latter satisfies the third acceptance criterion of #138.

## Verification

| | Result |
| --- | --- |
| Full unit suite | 529 tests, 0 failures, 0 errors |
| Checkstyle | clean |
| PreDev behaviour | agency with departments purges either way — proven on both images |

Closes OpenResilienceInitiative/ORISO-AgencyService#220
Refs OpenResilienceInitiative/ORISO-AgencyService#207

🤖 Generated with [Claude Code](https://claude.com/claude-code)