### PR TITLE
feat(legal): give the agency the legal texts the inheritance chain assumed

### DIFF
--- a/api/agencyadminservice.yaml
+++ b/api/agencyadminservice.yaml
@@ -926,12 +926,38 @@ components:
         dataProtection:
           type: object
           $ref: '#/components/schemas/DataProtectionDTO'
+        content:
+          $ref: '#/components/schemas/AgencyLegalContentDTO'
         agencyLogo:
           type: string
           example: "base64 encoded image"
         settings:
           $ref: '#/components/schemas/Settings'
           description: Agency settings including platform-level agencyAdminControls
+
+    AgencyLegalContentDTO:
+      type: object
+      description: >
+        ADR-014 middle level of the chain tenant -> agency -> department. The Beratungsstelle's own
+        legal texts, each a language -> HTML map. Every Fachbereich inherits these until it
+        publishes its own. There is no draft state here: what is stored is what is in force.
+
+        On update, omitting this object — or sending either member as an empty map — keeps the
+        stored text, so an update about something else can never wipe a legal document. To empty a
+        text, send the language key with empty content (`{"de": ""}`).
+      properties:
+        privacy:
+          type: object
+          description: Data privacy policy per language code.
+          additionalProperties:
+            type: string
+          example: { "de": "<p>Datenschutzerklärung</p>" }
+        impressum:
+          type: object
+          description: Imprint per language code.
+          additionalProperties:
+            type: string
+          example: { "de": "<p>Impressum</p>" }
 
     DataProtectionDTO:
         type: object
@@ -1165,6 +1191,8 @@ components:
         dataProtection:
           type: object
           $ref: '#/components/schemas/DataProtectionDTO'
+        content:
+          $ref: '#/components/schemas/AgencyLegalContentDTO'
         agencyLogo:
           type: string
           example: "base64 encoded image"

--- a/src/main/java/de/caritas/cob/agencyservice/api/admin/service/AgencyAdminService.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/admin/service/AgencyAdminService.java
@@ -19,6 +19,8 @@ import de.caritas.cob.agencyservice.api.exception.httpresponses.NotFoundExceptio
 import de.caritas.cob.agencyservice.api.model.AgencyAdminFullResponseDTO;
 import de.caritas.cob.agencyservice.api.model.AgencyDTO;
 import de.caritas.cob.agencyservice.api.model.AgencyTypeRequestDTO;
+import de.caritas.cob.agencyservice.api.admin.service.legal.LegalContentSanitizer;
+import de.caritas.cob.agencyservice.api.model.AgencyLegalContentDTO;
 import de.caritas.cob.agencyservice.api.model.UpdateAgencyDTO;
 import de.caritas.cob.agencyservice.api.repository.agency.Agency;
 import de.caritas.cob.agencyservice.api.repository.agency.AgencyRepository;
@@ -32,6 +34,8 @@ import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
 
 import de.caritas.cob.agencyservice.api.util.AuthenticatedUser;
 import lombok.NonNull;
@@ -63,6 +67,7 @@ public class AgencyAdminService {
   private final @NonNull DataProtectionConverter dataProtectionConverter;
   private final @NonNull AgencyAdminControlsService agencyAdminControlsService;
   private final @NonNull AgencySettingsService agencySettingsService;
+  private final @NonNull LegalContentSanitizer legalContentSanitizer;
 
   @Autowired(required = false)
   private AgencyTopicEnrichmentService agencyTopicEnrichmentService;
@@ -252,6 +257,31 @@ public class AgencyAdminService {
     }
   }
 
+  private Map<String, String> legalContent(
+      UpdateAgencyDTO updateAgencyDTO,
+      Function<AgencyLegalContentDTO, Map<String, String>> kind) {
+    var content = updateAgencyDTO.getContent();
+    return content == null ? null : kind.apply(content);
+  }
+
+  /**
+   * Absent means untouched — the same rule {@link AgencyTopicMergeService} applies to topics, and
+   * for the same reason: an update about a phone number must not be able to wipe a legally
+   * required document.
+   *
+   * <p>An <em>empty</em> map counts as absent, not as "clear it". The generated request model
+   * initialises both maps to empty ones, so a client that sends only the imprint is
+   * indistinguishable from one that sends an empty privacy policy — treating empty as a deletion
+   * would hand exactly the silent-wipe defect this epic removes back to every partial update.
+   * Emptying a text is therefore expressed by sending the language key with empty content
+   * ({@code {"de": ""}}), which is what an emptied editor produces anyway.
+   */
+  private String resolveLegalTextForUpdate(String storedContent, Map<String, String> sentContent) {
+    return sentContent == null || sentContent.isEmpty()
+        ? storedContent
+        : legalContentSanitizer.sanitizeToJson(sentContent);
+  }
+
   private String resolveSettingsForUpdate(Agency agency, UpdateAgencyDTO updateAgencyDTO) {
     if (updateAgencyDTO.getSettings() != null) {
       return agencySettingsService.toSettingsJson(updateAgencyDTO.getSettings());
@@ -285,7 +315,14 @@ public class AgencyAdminService {
         .agencyLogo(updateAgencyDTO.getAgencyLogo())
         .matrixUserId(agency.getMatrixUserId())
         .matrixPassword(agency.getMatrixPassword())
-        .settings(resolveSettingsForUpdate(agency, updateAgencyDTO));
+        .settings(resolveSettingsForUpdate(agency, updateAgencyDTO))
+        .contentDpp(
+            resolveLegalTextForUpdate(
+                agency.getContentDpp(), legalContent(updateAgencyDTO, AgencyLegalContentDTO::getPrivacy)))
+        .contentImprint(
+            resolveLegalTextForUpdate(
+                agency.getContentImprint(),
+                legalContent(updateAgencyDTO, AgencyLegalContentDTO::getImpressum)));
 
     dataProtectionConverter.convertToEntity(updateAgencyDTO.getDataProtection(), agencyBuilder);
 

--- a/src/main/java/de/caritas/cob/agencyservice/api/admin/service/agency/AgencyAdminFullResponseDTOBuilder.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/admin/service/agency/AgencyAdminFullResponseDTOBuilder.java
@@ -1,26 +1,37 @@
 package de.caritas.cob.agencyservice.api.admin.service.agency;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
 import com.google.common.base.Splitter;
 import com.google.common.collect.Lists;
 import de.caritas.cob.agencyservice.api.admin.hallink.AgencyLinksBuilder;
 import de.caritas.cob.agencyservice.api.model.AgencyAdminFullResponseDTO;
 import de.caritas.cob.agencyservice.api.model.AgencyAdminResponseDTO;
+import de.caritas.cob.agencyservice.api.model.AgencyLegalContentDTO;
 import de.caritas.cob.agencyservice.api.model.AgencyLinks;
 import de.caritas.cob.agencyservice.api.model.DemographicsDTO;
 import de.caritas.cob.agencyservice.api.model.TopicDTO;
 import de.caritas.cob.agencyservice.api.repository.agency.Agency;
 import de.caritas.cob.agencyservice.api.repository.agencytopic.AgencyTopic;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * Builder to build an {@link AgencyAdminFullResponseDTO()} from an {@link Agency} instance.
  */
 @RequiredArgsConstructor
+@Slf4j
 public class AgencyAdminFullResponseDTOBuilder {
+
+  private static final ObjectReader CONTENT_READER =
+      new ObjectMapper().readerFor(new TypeReference<Map<String, String>>() {});
 
   private final @NonNull Agency agency;
 
@@ -63,6 +74,7 @@ public class AgencyAdminFullResponseDTOBuilder {
         .updateDate(String.valueOf(this.agency.getUpdateDate()))
         .deleteDate(String.valueOf(this.agency.getDeleteDate()))
         .dataProtection(new DataProtectionDTOBuilder(this.agency).fromAgency())
+        .content(getLegalContent())
         .agencyLogo(this.agency.getAgencyLogo());
 
     responseDTO.demographics(getDemographics(this.agency));
@@ -75,6 +87,33 @@ public class AgencyAdminFullResponseDTOBuilder {
     } else {
       return Splitter.on(",").trimResults()
           .splitToList(counsellingRelationsAsCommaSeparatedString).stream().map(AgencyAdminResponseDTO.CounsellingRelationsEnum::valueOf).collect(Collectors.toList());
+    }
+  }
+
+  /**
+   * The agency-wide legal texts (ADR-014 middle level, #222), read back as language→HTML maps —
+   * the shape the admin UI and the tenant API both use. Stored content was already sanitised on
+   * write; a column that never parsed is reported as absent rather than failing the whole agency
+   * read, since a legal text must never be able to take the admin's agency page down with it.
+   */
+  private AgencyLegalContentDTO getLegalContent() {
+    var privacy = toContentMap(this.agency.getContentDpp());
+    var impressum = toContentMap(this.agency.getContentImprint());
+    return privacy == null && impressum == null
+        ? null
+        : new AgencyLegalContentDTO().privacy(privacy).impressum(impressum);
+  }
+
+  private Map<String, String> toContentMap(String storedJson) {
+    if (storedJson == null || storedJson.isBlank()) {
+      return null;
+    }
+    try {
+      return CONTENT_READER.readValue(storedJson);
+    } catch (JsonProcessingException e) {
+      log.warn("Agency {} has unreadable stored legal content, reporting it as absent",
+          this.agency.getId(), e);
+      return null;
     }
   }
 

--- a/src/main/java/de/caritas/cob/agencyservice/api/repository/agency/Agency.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/repository/agency/Agency.java
@@ -200,6 +200,22 @@ public class Agency implements TenantAware {
   @JdbcTypeCode(Types.LONGVARCHAR)
   private String settings;
 
+  /**
+   * ADR-014 middle level of the chain tenant → agency → department: the Beratungsstelle's own data
+   * privacy policy as a JSON language→HTML map, inherited by every Fachbereich that has not
+   * published one of its own. Unlike a department text this has no draft state — an imprint names
+   * the responsible entity and the Beratungsstelle is always its own, so what is stored is what is
+   * in force.
+   */
+  @Column(name = "content_dpp", columnDefinition = "longtext")
+  @JdbcTypeCode(Types.LONGVARCHAR)
+  private String contentDpp;
+
+  /** Agency-wide imprint; see {@link #contentDpp}. */
+  @Column(name = "content_imprint", columnDefinition = "longtext")
+  @JdbcTypeCode(Types.LONGVARCHAR)
+  private String contentImprint;
+
   @Transient
   public boolean hasAnyDemographicsAttributes() {
     return getAgeTo() != null || getAgeFrom() != null || getGenders() != null;

--- a/src/main/java/de/caritas/cob/agencyservice/api/service/DepartmentLegalService.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/service/DepartmentLegalService.java
@@ -50,26 +50,41 @@ public class DepartmentLegalService {
    *
    * <p><b>Unassign semantics (this release):</b> clearing {@code dpp_id}/{@code imprint_id} makes a
    * department reference-less again, so it falls back to its own inline {@code content_dpp}/{@code
-   * content_imprint} — NOT to a tenant-level fallback document. The backfill deliberately keeps the
-   * inline columns for one release as this read-fallback and as the rollback anchor; they are not
-   * cleared on unassign. Tenant-level fallback is future work (see ADR-014 / #134).
+   * content_imprint}. The backfill deliberately keeps the inline columns for one release as this
+   * read-fallback and as the rollback anchor; they are not cleared on unassign.
+   *
+   * <p>Whatever the department resolves to, an unpublished or absent result then inherits the
+   * agency-wide text (#222) — the middle level of the chain tenant → agency → department. The
+   * tenant remains the last fallback and is still resolved client-side (see ADR-014 / #134).
    */
   private String resolveDpp(AgencyTopic department) {
     LegalText referenced = department.getDpp();
-    if (referenced != null) {
-      return publishedContentOrNull(referenced.getContent(), referenced.getPublicationStatus());
-    }
-    return publishedContentOrNull(
-        department.getContentDpp(), department.getPublicationStatus());
+    var own =
+        referenced != null
+            ? publishedContentOrNull(referenced.getContent(), referenced.getPublicationStatus())
+            : publishedContentOrNull(department.getContentDpp(), department.getPublicationStatus());
+    return own != null ? own : agencyWideOrNull(department.getAgency().getContentDpp());
   }
 
   private String resolveImprint(AgencyTopic department) {
     LegalText referenced = department.getImprint();
-    if (referenced != null) {
-      return publishedContentOrNull(referenced.getContent(), referenced.getPublicationStatus());
-    }
-    return publishedContentOrNull(
-        department.getContentImprint(), department.getPublicationStatusImprint());
+    var own =
+        referenced != null
+            ? publishedContentOrNull(referenced.getContent(), referenced.getPublicationStatus())
+            : publishedContentOrNull(
+                department.getContentImprint(), department.getPublicationStatusImprint());
+    return own != null ? own : agencyWideOrNull(department.getAgency().getContentImprint());
+  }
+
+  /**
+   * The inherited middle level of the ADR-014 chain tenant → agency → department. It carries no
+   * publication status of its own: a Beratungsstelle's stored text is the text in force, so any
+   * department that has not published its own keeps showing it. That is deliberate — a department
+   * still drafting must not blank out a legally required document, so a DRAFT falls through to
+   * here rather than resolving to nothing.
+   */
+  private String agencyWideOrNull(String agencyWideContent) {
+    return agencyWideContent == null || agencyWideContent.isBlank() ? null : agencyWideContent;
   }
 
   private void assertAgencyIsNotDeleted(Agency agency) {

--- a/src/main/resources/db/changelog/agencyservice-master.xml
+++ b/src/main/resources/db/changelog/agencyservice-master.xml
@@ -71,6 +71,9 @@
   <!-- ADR-014: shared legal-text objects (legal_text table + department references + backfill
        that merges byte-identical inline texts into one shared row per tenant/kind/status). -->
   <include file="db/changelog/changeset/0026_legal_text/0026_changeSet.xml"/>
+  <!-- ADR-014: agency-wide legal texts — the middle level of tenant → agency → department that
+       the ADR assumed but the schema never had (#222). Additive and nullable. -->
+  <include file="db/changelog/changeset/0027_agency_legal_text/0027_changeSet.xml"/>
 
   <!--
     L1 gap detection (2026-07-04): the consolidated changelog was run against a fresh MariaDB

--- a/src/main/resources/db/changelog/changeset/0027_agency_legal_text/0027_changeSet.xml
+++ b/src/main/resources/db/changelog/changeset/0027_agency_legal_text/0027_changeSet.xml
@@ -1,0 +1,14 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd">
+    <!-- ADR-014: the agency-wide legal texts the chain tenant -> agency -> department always
+         assumed but never had. Purely additive and nullable, so existing rows keep inheriting
+         from the tenant exactly as before until an admin authors an agency-wide text. -->
+    <changeSet author="oriso" id="addAgencyLegalText">
+        <sqlFile path="db/changelog/changeset/0027_agency_legal_text/addAgencyLegalText.sql" stripComments="true"/>
+        <rollback>
+            <sqlFile path="db/changelog/changeset/0027_agency_legal_text/addAgencyLegalText-rollback.sql" stripComments="true"/>
+        </rollback>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changeset/0027_agency_legal_text/addAgencyLegalText-rollback.sql
+++ b/src/main/resources/db/changelog/changeset/0027_agency_legal_text/addAgencyLegalText-rollback.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `agencyservice`.`agency` DROP COLUMN IF EXISTS content_dpp;
+ALTER TABLE `agencyservice`.`agency` DROP COLUMN IF EXISTS content_imprint;

--- a/src/main/resources/db/changelog/changeset/0027_agency_legal_text/addAgencyLegalText.sql
+++ b/src/main/resources/db/changelog/changeset/0027_agency_legal_text/addAgencyLegalText.sql
@@ -1,0 +1,9 @@
+-- ADR-014 middle level of the chain tenant -> agency -> department: the Beratungsstelle's own
+-- data privacy policy and imprint, stored as a JSON language->HTML map like the department
+-- columns. No publication_status counterpart: what is stored is what is in force, and every
+-- Fachbereich inherits it until it publishes one of its own.
+ALTER TABLE `agencyservice`.`agency`
+ADD COLUMN IF NOT EXISTS content_dpp longtext NULL;
+
+ALTER TABLE `agencyservice`.`agency`
+ADD COLUMN IF NOT EXISTS content_imprint longtext NULL;

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/service/AgencyAdminServiceTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/service/AgencyAdminServiceTest.java
@@ -26,7 +26,9 @@ import de.caritas.cob.agencyservice.api.admin.service.agency.DemographicsConvert
 import de.caritas.cob.agencyservice.api.admin.validation.DeleteAgencyValidator;
 import de.caritas.cob.agencyservice.api.exception.httpresponses.ConflictException;
 import de.caritas.cob.agencyservice.api.exception.httpresponses.NotFoundException;
+import de.caritas.cob.agencyservice.api.admin.service.legal.LegalContentSanitizer;
 import de.caritas.cob.agencyservice.api.model.AgencyAdminResponseDTO;
+import de.caritas.cob.agencyservice.api.model.AgencyLegalContentDTO;
 import de.caritas.cob.agencyservice.api.model.AgencyTypeRequestDTO;
 import de.caritas.cob.agencyservice.api.model.DataProtectionContactDTO;
 import de.caritas.cob.agencyservice.api.model.DataProtectionDTO;
@@ -45,6 +47,7 @@ import de.caritas.cob.agencyservice.api.service.AgencyService;
 import de.caritas.cob.agencyservice.api.util.AuthenticatedUser;
 import de.caritas.cob.agencyservice.api.util.JsonConverter;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import org.jeasy.random.EasyRandom;
 import org.junit.jupiter.api.BeforeEach;
@@ -76,6 +79,9 @@ class AgencyAdminServiceTest {
 
   @Mock
   AgencyTopicMergeService mergeService;
+
+  @Mock
+  LegalContentSanitizer legalContentSanitizer;
 
   @Mock
   AgencyTopicRepository agencyTopicRepository;
@@ -316,6 +322,125 @@ class AgencyAdminServiceTest {
     verify(this.userAdminService).adaptRelatedConsultantsForChange(AGENCY_ID,
         requestDTO.getAgencyType().getValue());
     verify(this.agencyRepository).save(any());
+  }
+
+  @Test
+  void updateAgency_Should_storeAgencyWideLegalTexts_SanitizedNotVerbatim() {
+    var agency = this.easyRandom.nextObject(Agency.class);
+    clearDataProtection(agency);
+    agency.setCounsellingRelations(null);
+    when(agencyRepository.findById(AGENCY_ID)).thenReturn(Optional.of(agency));
+    when(agencyRepository.save(any())).thenReturn(agency);
+    when(legalContentSanitizer.sanitizeToJson(Map.of("de", "<p>DSE</p><script>x</script>")))
+        .thenReturn("{\"de\":\"<p>DSE</p>\"}");
+    when(legalContentSanitizer.sanitizeToJson(Map.of("de", "<p>Impressum</p>")))
+        .thenReturn("{\"de\":\"<p>Impressum</p>\"}");
+
+    var updateAgencyDTO = this.easyRandom.nextObject(UpdateAgencyDTO.class);
+    updateAgencyDTO.setContent(
+        new AgencyLegalContentDTO()
+            .privacy(Map.of("de", "<p>DSE</p><script>x</script>"))
+            .impressum(Map.of("de", "<p>Impressum</p>")));
+
+    agencyAdminService.updateAgency(AGENCY_ID, updateAgencyDTO);
+
+    verify(agencyRepository).save(agencyArgumentCaptor.capture());
+    // Admin-authored HTML must take the same sanitisation path as the department texts.
+    assertEquals("{\"de\":\"<p>DSE</p>\"}", agencyArgumentCaptor.getValue().getContentDpp());
+    assertEquals(
+        "{\"de\":\"<p>Impressum</p>\"}", agencyArgumentCaptor.getValue().getContentImprint());
+  }
+
+  @Test
+  void updateAgency_Should_keepStoredLegalTexts_When_updateCarriesNoContent() {
+    // The defect class this epic exists to remove: an update about something else — a phone
+    // number, an opening hour — must never wipe a legally required document.
+    var agency = this.easyRandom.nextObject(Agency.class);
+    clearDataProtection(agency);
+    agency.setCounsellingRelations(null);
+    agency.setContentDpp("{\"de\":\"<p>bestehende DSE</p>\"}");
+    agency.setContentImprint("{\"de\":\"<p>bestehendes Impressum</p>\"}");
+    when(agencyRepository.findById(AGENCY_ID)).thenReturn(Optional.of(agency));
+    when(agencyRepository.save(any())).thenReturn(agency);
+
+    var updateAgencyDTO = this.easyRandom.nextObject(UpdateAgencyDTO.class);
+    updateAgencyDTO.setContent(null);
+
+    agencyAdminService.updateAgency(AGENCY_ID, updateAgencyDTO);
+
+    verify(agencyRepository).save(agencyArgumentCaptor.capture());
+    assertEquals(
+        "{\"de\":\"<p>bestehende DSE</p>\"}", agencyArgumentCaptor.getValue().getContentDpp());
+    assertEquals(
+        "{\"de\":\"<p>bestehendes Impressum</p>\"}",
+        agencyArgumentCaptor.getValue().getContentImprint());
+  }
+
+  @Test
+  void updateAgency_Should_keepTheOtherText_When_onlyOneKindIsSent() {
+    var agency = this.easyRandom.nextObject(Agency.class);
+    clearDataProtection(agency);
+    agency.setCounsellingRelations(null);
+    agency.setContentImprint("{\"de\":\"<p>bestehendes Impressum</p>\"}");
+    when(agencyRepository.findById(AGENCY_ID)).thenReturn(Optional.of(agency));
+    when(agencyRepository.save(any())).thenReturn(agency);
+    when(legalContentSanitizer.sanitizeToJson(Map.of("de", "<p>neue DSE</p>")))
+        .thenReturn("{\"de\":\"<p>neue DSE</p>\"}");
+
+    var updateAgencyDTO = this.easyRandom.nextObject(UpdateAgencyDTO.class);
+    updateAgencyDTO.setContent(
+        new AgencyLegalContentDTO().privacy(Map.of("de", "<p>neue DSE</p>")));
+
+    agencyAdminService.updateAgency(AGENCY_ID, updateAgencyDTO);
+
+    verify(agencyRepository).save(agencyArgumentCaptor.capture());
+    assertEquals("{\"de\":\"<p>neue DSE</p>\"}", agencyArgumentCaptor.getValue().getContentDpp());
+    assertEquals(
+        "{\"de\":\"<p>bestehendes Impressum</p>\"}",
+        agencyArgumentCaptor.getValue().getContentImprint());
+  }
+
+  @Test
+  void updateAgency_Should_keepStoredLegalText_When_anEmptyMapIsSent() {
+    // The generated request model initialises both maps to empty ones, so "I sent no privacy
+    // policy" and "I sent an empty privacy policy" arrive identically. Treating that as a deletion
+    // would hand the silent-wipe defect back to every partial update.
+    var agency = this.easyRandom.nextObject(Agency.class);
+    clearDataProtection(agency);
+    agency.setCounsellingRelations(null);
+    agency.setContentDpp("{\"de\":\"<p>bestehende DSE</p>\"}");
+    when(agencyRepository.findById(AGENCY_ID)).thenReturn(Optional.of(agency));
+    when(agencyRepository.save(any())).thenReturn(agency);
+
+    var updateAgencyDTO = this.easyRandom.nextObject(UpdateAgencyDTO.class);
+    updateAgencyDTO.setContent(new AgencyLegalContentDTO().privacy(Map.of()));
+
+    agencyAdminService.updateAgency(AGENCY_ID, updateAgencyDTO);
+
+    verify(agencyRepository).save(agencyArgumentCaptor.capture());
+    assertEquals(
+        "{\"de\":\"<p>bestehende DSE</p>\"}", agencyArgumentCaptor.getValue().getContentDpp());
+  }
+
+  @Test
+  void updateAgency_Should_emptyLegalText_When_theLanguageKeyCarriesEmptyContent() {
+    // Deliberate removal stays possible — it just has to name the language, which is exactly what
+    // an emptied editor sends.
+    var agency = this.easyRandom.nextObject(Agency.class);
+    clearDataProtection(agency);
+    agency.setCounsellingRelations(null);
+    agency.setContentDpp("{\"de\":\"<p>bestehende DSE</p>\"}");
+    when(agencyRepository.findById(AGENCY_ID)).thenReturn(Optional.of(agency));
+    when(agencyRepository.save(any())).thenReturn(agency);
+    when(legalContentSanitizer.sanitizeToJson(Map.of("de", ""))).thenReturn("{\"de\":\"\"}");
+
+    var updateAgencyDTO = this.easyRandom.nextObject(UpdateAgencyDTO.class);
+    updateAgencyDTO.setContent(new AgencyLegalContentDTO().privacy(Map.of("de", "")));
+
+    agencyAdminService.updateAgency(AGENCY_ID, updateAgencyDTO);
+
+    verify(agencyRepository).save(agencyArgumentCaptor.capture());
+    assertEquals("{\"de\":\"\"}", agencyArgumentCaptor.getValue().getContentDpp());
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/service/agency/AgencyAdminFullResponseDTOBuilderTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/service/agency/AgencyAdminFullResponseDTOBuilderTest.java
@@ -121,4 +121,43 @@ class AgencyAdminFullResponseDTOBuilderTest {
     assertThat(agencyLinks.getPostcodeRanges().getHref()).isEqualTo(String.format("/agencyadmin/postcoderanges/%s", this.agency.getId()));
   }
 
+  @Test
+  void fromAgency_Should_exposeAgencyWideLegalTexts_AsLanguageMaps() {
+    // Shirloin's finding on ORISO-Admin#562: without this the admin editor could never read back
+    // what it had just saved and silently fell through to the tenant text forever.
+    this.agency.setContentDpp("{\"de\":\"<p>DSE</p>\",\"en\":\"<p>Privacy</p>\"}");
+    this.agency.setContentImprint("{\"de\":\"<p>Impressum</p>\"}");
+
+    var content = new AgencyAdminFullResponseDTOBuilder(agency).fromAgency().getEmbedded()
+        .getContent();
+
+    assertThat(content).isNotNull();
+    assertThat(content.getPrivacy()).containsEntry("de", "<p>DSE</p>")
+        .containsEntry("en", "<p>Privacy</p>");
+    assertThat(content.getImpressum()).containsEntry("de", "<p>Impressum</p>");
+  }
+
+  @Test
+  void fromAgency_Should_omitContent_When_theAgencyAuthoredNoLegalText() {
+    this.agency.setContentDpp(null);
+    this.agency.setContentImprint("   ");
+
+    var result = new AgencyAdminFullResponseDTOBuilder(agency).fromAgency();
+
+    assertNull(result.getEmbedded().getContent());
+  }
+
+  @Test
+  void fromAgency_Should_reportUnreadableContentAsAbsent_RatherThanFailTheWholeRead() {
+    // A legal text must never be able to take the admin's agency page down with it.
+    this.agency.setContentDpp("not json at all");
+    this.agency.setContentImprint("{\"de\":\"<p>Impressum</p>\"}");
+
+    var content = new AgencyAdminFullResponseDTOBuilder(agency).fromAgency().getEmbedded()
+        .getContent();
+
+    assertNull(content.getPrivacy());
+    assertThat(content.getImpressum()).containsEntry("de", "<p>Impressum</p>");
+  }
+
 }

--- a/src/test/java/de/caritas/cob/agencyservice/api/service/DepartmentLegalServiceTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/service/DepartmentLegalServiceTest.java
@@ -173,6 +173,78 @@ class DepartmentLegalServiceTest {
   }
 
   @Test
+  void getPublishedDepartmentLegal_Should_fallBackToAgencyWideText_When_departmentHasNoneOfItsOwn() {
+    // ADR-014 chain tenant -> agency -> department: a Fachbereich that never authored anything
+    // shows what its Beratungsstelle publishes, not nothing.
+    var department = department(null, PublicationStatus.DRAFT, null, PublicationStatus.DRAFT);
+    department.getAgency().setContentDpp("{\"de\":\"<p>DSE der Stelle</p>\"}");
+    department.getAgency().setContentImprint("{\"de\":\"<p>Impressum der Stelle</p>\"}");
+
+    var view = service.getPublishedDepartmentLegal(7L, 42L);
+
+    assertThat(view.dppContent()).isEqualTo("{\"de\":\"<p>DSE der Stelle</p>\"}");
+    assertThat(view.imprintContent()).isEqualTo("{\"de\":\"<p>Impressum der Stelle</p>\"}");
+  }
+
+  @Test
+  void getPublishedDepartmentLegal_Should_preferOwnPublishedText_OverAgencyWideText() {
+    // Publishing is what leaves the inheritance for good.
+    var department =
+        department(
+            "{\"de\":\"<p>eigene DSE</p>\"}", PublicationStatus.PUBLISHED, null,
+            PublicationStatus.DRAFT);
+    department.getAgency().setContentDpp("{\"de\":\"<p>DSE der Stelle</p>\"}");
+
+    var view = service.getPublishedDepartmentLegal(7L, 42L);
+
+    assertThat(view.dppContent()).isEqualTo("{\"de\":\"<p>eigene DSE</p>\"}");
+  }
+
+  @Test
+  void getPublishedDepartmentLegal_Should_keepShowingAgencyWideText_While_ownTextIsStillDraft() {
+    // The draft copy is invisible to users until it is published — until then the inherited text
+    // stays in force. A draft must never blank out a legally required document.
+    var department =
+        department(
+            "{\"de\":\"<p>Entwurf</p>\"}", PublicationStatus.DRAFT, null, PublicationStatus.DRAFT);
+    department.getAgency().setContentDpp("{\"de\":\"<p>DSE der Stelle</p>\"}");
+
+    var view = service.getPublishedDepartmentLegal(7L, 42L);
+
+    assertThat(view.dppContent()).isEqualTo("{\"de\":\"<p>DSE der Stelle</p>\"}");
+  }
+
+  @Test
+  void getPublishedDepartmentLegal_Should_fallBackToAgencyWideText_When_referencedTextIsDraft() {
+    var department = department(null, PublicationStatus.DRAFT, null, PublicationStatus.DRAFT);
+    department.getAgency().setContentDpp("{\"de\":\"<p>DSE der Stelle</p>\"}");
+    department.setDpp(
+        LegalText.builder()
+            .id(100L)
+            .kind(LegalTextKind.DPP)
+            .label("Entwurf")
+            .content("{\"de\":\"<p>Entwurf</p>\"}")
+            .publicationStatus(PublicationStatus.DRAFT)
+            .build());
+
+    var view = service.getPublishedDepartmentLegal(7L, 42L);
+
+    assertThat(view.dppContent()).isEqualTo("{\"de\":\"<p>DSE der Stelle</p>\"}");
+  }
+
+  @Test
+  void getPublishedDepartmentLegal_Should_returnNull_When_neitherLevelHasText() {
+    // A blank agency column is an absent text, not an empty-but-present document.
+    var department = department(null, PublicationStatus.DRAFT, null, PublicationStatus.DRAFT);
+    department.getAgency().setContentDpp("   ");
+
+    var view = service.getPublishedDepartmentLegal(7L, 42L);
+
+    assertThat(view.dppContent()).isNull();
+    assertThat(view.imprintContent()).isNull();
+  }
+
+  @Test
   void getPublishedDepartmentLegal_Should_throwNotFound_When_departmentMissing() {
     when(agencyTopicRepository.findByAgency_IdAndTopicId(7L, 99L)).thenReturn(Optional.empty());
 

--- a/src/test/resources/database/AgencyDatabase.sql
+++ b/src/test/resources/database/AgencyDatabase.sql
@@ -45,6 +45,8 @@ create table AGENCY
     MATRIX_USER_ID varchar(255) null default null,
     MATRIX_PASSWORD varchar(255) null default null,
     SETTINGS longtext null default null,
+    CONTENT_DPP longtext null default null,
+    CONTENT_IMPRINT longtext null default null,
     primary key (ID)
 );
 CREATE SEQUENCE SEQUENCE_AGENCY


### PR DESCRIPTION
## Problem

ADR-014 states the inheritance chain **tenant → agency → department** and repeatedly refers to
"existing agency-level content (`agency.content.privacy` / `.impressum`)". That level never
existed:

- `Agency` carries `data_protection_*` **contact** data, no legal text.
- `AgencyAdminResponseDTO` has no `content` property, so `GET .../agencies/{id}` cannot return one.
- `UpdateAgencyDTO` has none either, so the `content` object ORISO-Admin has been sending on
  `PUT .../agencies/{id}` was silently discarded.

@Shirloin found the symptom on ORISO-Admin#562: the "Alle Fachbereiche" editor always shows the
tenant text, even directly after saving, because the admin-side merge falls back to tenant when the
agency half is permanently `undefined`. The ORISO-Admin type `AgencyData.content` has declared the
field since commit 5b4d517 — it was never backed by the API.

Without this level a Beratungsstelle cannot have its own imprint without authoring the same text
once per Fachbereich. An imprint names the responsible entity and a Beratungsstelle is a different
responsible entity from its Träger, so this is a legal requirement, not a convenience.

## What changed

- **Schema** `0027_agency_legal_text`: `agency.content_dpp` / `content_imprint`, additive and
  nullable, with rollback. Existing rows keep inheriting from the tenant exactly as before until an
  admin authors an agency-wide text.
- **Admin API** reads `content.privacy` / `content.impressum` as language→HTML maps and writes them
  through the canonical `LegalContentSanitizer`, the same path the department texts take.
- **Public resolution** falls back to the agency text when a department has none published.

## Two judgement calls worth reviewing

**Empty means untouched, not "delete".** The generated request model initialises both maps to empty
ones, so a client sending only the imprint is indistinguishable from one sending an empty privacy
policy. Treating empty as a deletion would hand the silent-wipe defect this epic exists to remove
back to every partial update. Emptying a text is therefore expressed as `{"de": ""}` — what an
emptied editor sends anyway. Documented on the schema.

**A drafting department keeps showing the inherited text.** A department whose own text is DRAFT
falls through to the agency-wide one rather than resolving to `null`. A draft must not be able to
blank out a legally required document while someone is still writing it.

## Verification

```
Tests run: 542, Failures: 0, Errors: 0, Skipped: 0 — BUILD SUCCESS
You have 0 Checkstyle violations.
```

New coverage: agency fallback and its precedence against own/published/draft/referenced texts
(`DepartmentLegalServiceTest`), sanitised write plus the untouched/empty/partial rules
(`AgencyAdminServiceTest`), read-back as maps and unreadable content reported as absent
(`AgencyAdminFullResponseDTOBuilderTest`).

Note: `AgencyServiceIT` remains red on `pre-dev` independently of this change (#197).

Closes OpenResilienceInitiative/ORISO-AgencyService#222
Refs OpenResilienceInitiative/ORISO-Admin#562
Part of epic OpenResilienceInitiative/ORISO-Frontend#86

🤖 Generated with [Claude Code](https://claude.com/claude-code)
