### PR TITLE
test(agency-service): load the fixture the read assertions were written for

### DIFF
--- a/src/test/java/de/caritas/cob/agencyservice/api/service/AgencyServiceIT.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/service/AgencyServiceIT.java
@@ -12,13 +12,22 @@ import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabas
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.junit4.SpringRunner;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = AgencyServiceApplication.class)
 @TestPropertySource(properties = "spring.profiles.active=testing")
 @AutoConfigureTestDatabase(replace = Replace.ANY)
+@Sql(scripts = "/database/AgencyDatabase.sql")
 public class AgencyServiceIT extends AgencyServiceITBase {
+
+  /**
+   * Without this the suite reaches the real TenantService on localhost:8089 and fails with
+   * "Connection refused" (#205). The tenant-aware sibling already mocks it.
+   */
+  @MockitoBean
+  private TenantService tenantService;
 
   @Test
   public void getAgencies_Should_returnMatchingAgencies_When_postcodeAndConsultingTypeIsGiven()

--- a/src/test/java/de/caritas/cob/agencyservice/api/service/AgencyServiceITBase.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/service/AgencyServiceITBase.java
@@ -5,6 +5,8 @@ import java.util.Optional;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
 
 import de.caritas.cob.agencyservice.api.exception.MissingConsultingTypeException;
 import de.caritas.cob.agencyservice.api.manager.consultingtype.ConsultingTypeManager;
@@ -35,14 +37,22 @@ public class AgencyServiceITBase {
   @MockitoBean
   private TopicEnrichmentService topicEnrichmentService;
 
+  @Autowired
+  private PlatformTransactionManager transactionManager;
+
   public void getAgencies_Should_returnMatchingAgencies_When_postcodeAndConsultingTypeIsGiven()
       throws MissingConsultingTypeException {
 
     when(consultingTypeManager.getConsultingTypeSettings(CONSULTING_TYPE_PREGNANCY)).thenReturn(CONSULTING_TYPE_SETTINGS_PREGNANCY);
     String postCode = "88662";
 
-    List<FullAgencyResponseDTO> resultAgencies = agencyService
-        .getAgencies(Optional.of(postCode), CONSULTING_TYPE_PREGNANCY, Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
+    // The response mapping walks Agency.agencyTopics lazily. A real request has an open
+    // session for the whole request (open-in-view); a plain test method does not, so without
+    // this boundary the call dies with LazyInitializationException (#205).
+    List<FullAgencyResponseDTO> resultAgencies = new TransactionTemplate(transactionManager)
+        .execute(status -> agencyService.getAgencies(Optional.of(postCode),
+            CONSULTING_TYPE_PREGNANCY, Optional.empty(), Optional.empty(), Optional.empty(),
+            Optional.empty()));
 
     assertThat(resultAgencies, hasSize(1));
     FullAgencyResponseDTO resultAgency = resultAgencies.get(0);
@@ -77,11 +87,15 @@ public class AgencyServiceITBase {
     String postCode = "45501";
     Integer topicId = 1;
 
-    List<FullAgencyResponseDTO> resultAgencies = agencyService.getAgencies(postCode, topicId);
+    // Same lazy agencyTopics mapping as above — needs a session boundary (#205).
+    List<FullAgencyResponseDTO> resultAgencies = new TransactionTemplate(transactionManager)
+        .execute(status -> agencyService.getAgencies(postCode, topicId));
 
     assertThat(resultAgencies, hasSize(1));
     FullAgencyResponseDTO resultAgency = resultAgencies.get(0);
-    assertThat(resultAgency.getId(), is(14352L));
+    // 14352 is the AGENCY_POSTCODE_RANGE id covering 45501-45600; the agency it belongs to is
+    // 1735. The old expectation asserted the range id against an agency id (#205).
+    assertThat(resultAgency.getId(), is(1735L));
   }
 
 }

--- a/src/test/java/de/caritas/cob/agencyservice/api/service/AgencyServiceTenantAwareIT.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/service/AgencyServiceTenantAwareIT.java
@@ -31,6 +31,9 @@ import org.springframework.transaction.annotation.Transactional;
 @AutoConfigureTestDatabase(replace = Replace.ANY)
 @DirtiesContext(classMode = ClassMode.BEFORE_CLASS)
 @TestPropertySource(properties = "multitenancy.enabled=true")
+// AgencyDatabase.sql first: setTenants.sql only UPDATEs agency rows, so without the seed it
+// silently updated nothing and every read in the base fixture came back empty (#205).
+@Sql(value = "/database/AgencyDatabase.sql", executionPhase = ExecutionPhase.BEFORE_TEST_METHOD)
 @Sql(value = "/setTenants.sql", executionPhase = ExecutionPhase.BEFORE_TEST_METHOD)
 @Transactional(propagation = Propagation.NEVER)
 public class AgencyServiceTenantAwareIT extends AgencyServiceITBase {


### PR DESCRIPTION
## Why

Closes OpenResilienceInitiative/ORISO-AgencyService#205
Refs OpenResilienceInitiative/ORISO-AgencyService#185

Stacked on #199 for the ADR-014 columns, since this PR starts loading `AgencyDatabase.sql`. Retarget to `pre-dev` once #199 merges.

**Correction to the issue text:** #205 says the seed data these assertions need is missing. It is not. `/database/AgencyDatabase.sql` contains 1138 agencies, including agency 883 at postcode `88662` with consulting type 2, and postcode range `45501-45600`. `AgencyServiceIT` and `AgencyServiceTenantAwareIT` simply never loaded it — unlike every other IT in the repo that reads agencies.

## The four causes

**1. No fixture.** Neither class carried `@Sql(scripts = "/database/AgencyDatabase.sql")`, so every read returned an empty list. The tenant-aware suite did have `@Sql("/setTenants.sql")`, but that only runs `UPDATE AGENCY SET TENANT_ID = '1'` — with no rows it updated nothing and reported success, which is why the suite looked configured while having no data. Same trap as #204.

**2. A live TenantService call.** `AgencyServiceIT` reached `http://localhost:8089/tenant/public/single` and failed with `Connection refused`. `TenantService` is now mocked, mirroring the tenant-aware sibling that already did this.

**3. Lazy `agencyTopics` outside a session.**

```
LazyInitializationException: Cannot lazily initialize collection of role
  'Agency.agencyTopics' with key '883' (no session)
```

The response mapping walks the collection lazily. A real request keeps a session open for its whole duration via open-in-view; a plain test method does not. The two affected reads now run inside a `TransactionTemplate`.

Worth noting: `AgencyServiceTenantAwareIT` already autowired a `PlatformTransactionManager` and never used it. This is what it was for — the field has been dead since the suite stopped passing.

**4. An assertion that could never have passed.**

```java
assertThat(resultAgency.getId(), is(14352L));   // -> was <1735L>
```

`14352` is the `AGENCY_POSTCODE_RANGE` id covering `45501-45600`. The agency that range belongs to is `1735`. The test compared a range id against an agency id. The service was right; the expectation was wrong. Corrected to `1735` with the reasoning in a comment.

## Verification

Java 21 (`openjdk 21.0.11`):

| Suite | before | after |
| --- | --- | --- |
| `AgencyServiceIT` | 5 tests, 3 failures, 2 errors | 5 tests, 0 failures, 0 errors |
| `AgencyServiceTenantAwareIT` | 3 tests, 2 failures, 1 error | 3 tests, 0 failures, 0 errors |

Test-only change. No production code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)