### PR TITLE
fix(search): stop negative pagination from throwing, and load the search fixture

### DIFF
--- a/src/main/java/de/caritas/cob/agencyservice/api/admin/service/agency/AgencyAdminSearchService.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/admin/service/agency/AgencyAdminSearchService.java
@@ -221,10 +221,14 @@ public class AgencyAdminSearchService {
       addOrderBy(agencyAdminSearch, criteriaBuilder, criteriaQuery, expression, javaType);
     }
 
-    // Pagination
-    int firstResult = agencyAdminSearch.getPageNumber() == 0 ? 0
+    // Pagination. Page size and page number arrive straight from query parameters, so both can
+    // be negative. Only the zero case was handled, and a negative size reached
+    // setMaxResults() and surfaced as a 500 ("Max results cannot be negative"). Non-positive
+    // size now means no results, and a non-positive page number means the first page — the same
+    // contract the zero case already had (#206).
+    int firstResult = agencyAdminSearch.getPageNumber() <= 1 ? 0
         : (agencyAdminSearch.getPageNumber() - 1) * agencyAdminSearch.getPageSize();
-    return agencyAdminSearch.getPageSize() == 0 ? Lists.newArrayList()
+    return agencyAdminSearch.getPageSize() <= 0 ? Lists.newArrayList()
         : entityManager.createQuery(criteriaQuery)
             .setFirstResult(firstResult)
             .setMaxResults(agencyAdminSearch.getPageSize())

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/service/agency/AgencyAdminSearchServiceSearchIT.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/service/agency/AgencyAdminSearchServiceSearchIT.java
@@ -33,13 +33,17 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.transaction.annotation.Transactional;
+import org.springframework.test.context.jdbc.Sql;
 
 @SpringBootTest(classes = AgencyServiceApplication.class)
-@TestPropertySource(properties = "spring.profiles.active=testing")
+// topics off: this suite covers search, pagination and sorting, not topic enrichment. With the
+// feature on, every result mapping calls the real ConsultingTypeService on :8083 (#206). The
+// sibling AgencyAdminSearchServiceIT already draws the boundary here.
+@TestPropertySource(properties = {"spring.profiles.active=testing",
+    "feature.topics.enabled=false"})
 @AutoConfigureTestDatabase(replace = Replace.ANY)
 @DirtiesContext(classMode = ClassMode.BEFORE_CLASS)
-@Transactional
+@Sql(scripts = "/database/AgencyDatabase.sql")
 class AgencyAdminSearchServiceSearchIT {
 
   @Autowired
@@ -47,6 +51,15 @@ class AgencyAdminSearchServiceSearchIT {
 
   @MockitoBean
   AuthenticatedUser authenticatedUser;
+
+  /**
+   * TopicEnrichmentService is @ConditionalOnExpression on feature.topics.enabled, but
+   * AgencyController requires it as a @NonNull constructor argument. Turning the feature off
+   * therefore removes the bean and the whole context fails to load, so the mock has to stand in
+   * for it. Same pairing as the sibling AgencyAdminSearchServiceIT (#206).
+   */
+  @MockitoBean
+  private de.caritas.cob.agencyservice.api.service.TopicEnrichmentService topicEnrichmentService;
 
   @BeforeEach
   public void setUp() {


### PR DESCRIPTION
## Why

Closes OpenResilienceInitiative/ORISO-AgencyService#206
Refs OpenResilienceInitiative/ORISO-AgencyService#185

Stacked on #199 for the ADR-014 columns, since this PR starts loading `AgencyDatabase.sql`. Retarget to `pre-dev` once #199 merges.

**Correction to the issue, which I wrote wrong.** #206 says the 1133-row corpus "lives nowhere in this repo" and proposes rewriting the suite. It does exist: `/database/AgencyDatabase.sql` holds **1138** `INSERT INTO AGENCY` rows — exactly the `1000` + `138` the pagination test expects, with `1133` being that set minus the soft-deleted rows. Agency 883 at postcode `88662` and the `Überlingen` / `Oberschwaben` rows the keyword tests look for are all there.

The suite simply never loaded the file. Its sibling `AgencyAdminSearchServiceIT` — same package, same corpus, green — carries the `@Sql`. No rewrite, no changed assertion counts.

## Test side

1. **The missing `@Sql`.**
2. **Drop the class-level `@Transactional`.** With it, the script's DDL and the test transaction interact so the inserted rows are not visible to the queries — the suite stayed at `size <0>` even with the `@Sql` in place. The green sibling is not transactional either.
3. **`feature.topics.enabled=false` *and* a `TopicEnrichmentService` mock.** With topics on, every result mapping calls the real ConsultingTypeService on `:8083` and the suite fails with `Connection refused`. With topics off, `TopicEnrichmentService` disappears — it is `@ConditionalOnExpression("${feature.topics.enabled:true}")` — while `AgencyController` still requires it as a `@NonNull` constructor argument, so the whole context fails to load. Both halves are required. The sibling already pairs them this way.

That third point is the same wiring as #203: a controller unconditionally depending on a conditionally-registered bean. Worth a look on its own merits, but not changed here.

## Production side — the one genuine defect

```java
int firstResult = pageNumber == 0 ? 0 : (pageNumber - 1) * pageSize;
return pageSize == 0 ? emptyList() : ... .setMaxResults(pageSize) ...
```

`applySortingAndPagination` special-cased zero but not negatives. A negative size reached `setMaxResults()`:

```
IllegalArgumentException: Max results cannot be negative
  at AgencyAdminSearchService.applySortingAndPagination(AgencyAdminSearchService.java:230)
```

and a negative page number produced a negative offset. `page` and `perPage` arrive straight from query parameters, so a client sending `perPage=-1` got a 500 rather than an empty result.

Non-positive size now means no results; a non-positive page number means the first page. That is the contract the zero case already had, and the one `searchAgencies_Should_returnEmptyList_When_paginationParamsAreNegative` asserts by its name.

## Verification

Java 21 (`openjdk 21.0.11`):

| | tests | failures | errors |
| --- | --- | --- | --- |
| `AgencyAdminSearchServiceSearchIT` before | 19 | 7 | 2 |
| after | 19 | 0 | 0 |

Full `./mvnw -B -fae verify` on this branch, to confirm the pagination change regressed nothing: 716 tests, 7 failures, 31 errors — every one of them in a suite owned by #203, #204, #205, #208, #209 or #210, none of which are in this branch. No new red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)