### PR TITLE
fix(agency-ids): only a TenantService 404 means the tenant is unknown (TEN-INV-U2 verify)

### DIFF
--- a/api/agencyadminservice.yaml
+++ b/api/agencyadminservice.yaml
@@ -961,7 +961,6 @@ components:
         agencyId:
           type: integer
           format: int64
-          minimum: 1
           description: The manually picked agency ID to reserve. Omit for AUTO mode (smallest free ID).
           example: 21
         tenantId:

--- a/api/agencyadminservice.yaml
+++ b/api/agencyadminservice.yaml
@@ -961,6 +961,7 @@ components:
         agencyId:
           type: integer
           format: int64
+          minimum: 1
           description: The manually picked agency ID to reserve. Omit for AUTO mode (smallest free ID).
           example: 21
         tenantId:

--- a/pom.xml
+++ b/pom.xml
@@ -723,6 +723,10 @@
               <skipTests>false</skipTests>
               <includes>
                 <include>**/*Test.java</include>
+                <!-- the agency ID allocation contract (TEN-INV-U2) is concurrency-critical and
+                     its proof must ride on a blocking check, not only on the continue-on-error
+                     burn-in job that runs the full *IT.* suite -->
+                <include>**/api/admin/service/allocation/*IT.java</include>
               </includes>
             </configuration>
           </execution>

--- a/src/main/java/de/caritas/cob/agencyservice/api/admin/service/allocation/AgencyIdAllocationService.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/admin/service/allocation/AgencyIdAllocationService.java
@@ -4,6 +4,7 @@ import static de.caritas.cob.agencyservice.api.exception.httpresponses.HttpStatu
 
 import de.caritas.cob.agencyservice.api.exception.httpresponses.BadRequestException;
 import de.caritas.cob.agencyservice.api.exception.httpresponses.ConflictException;
+import de.caritas.cob.agencyservice.api.exception.httpresponses.InternalServerErrorException;
 import de.caritas.cob.agencyservice.api.exception.httpresponses.NotFoundException;
 import de.caritas.cob.agencyservice.api.repository.agencyidreservation.AgencyIdReservation;
 import de.caritas.cob.agencyservice.api.repository.agencyidreservation.AgencyIdReservationRepository;
@@ -19,6 +20,7 @@ import org.springframework.transaction.TransactionDefinition;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionTemplate;
+import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestClientException;
 
 /**
@@ -104,13 +106,23 @@ public class AgencyIdAllocationService {
    * @return the reserved agency ID
    */
   public Long reserve(Long requestedAgencyId, Long tenantId) {
+    if (requestedAgencyId != null && requestedAgencyId < 1) {
+      throw new BadRequestException("agencyId must be a positive number");
+    }
     validateTenant(tenantId);
     return requestedAgencyId != null
         ? reserveSpecificId(requestedAgencyId, tenantId)
         : reserveSmallestFreeId(tenantId);
   }
 
-  /** Releases an open reservation, making the ID assignable again. */
+  /**
+   * Releases an open reservation, making the ID assignable again.
+   *
+   * <p>Known limitations, deferred to the invite-wiring chunks (U3/U6, parent
+   * OpenResilienceInitiative/ORISO-Admin#569): there is no per-tenant ownership check (any
+   * agency admin may release any reservation) and no TTL, so an abandoned reservation blocks
+   * its ID until released. Both need the invite linkage that does not exist yet in this repo.
+   */
   @Transactional
   public void release(long agencyId) {
     var reservation = reservationRepository.findById(agencyId)
@@ -218,15 +230,22 @@ public class AgencyIdAllocationService {
     }
     try {
       // Existence check only: agency invites carry a tenant, but tenant IDs are reserved in
-      // TenantService (U1), never here. TenantService's restricted endpoint does not expose an
-      // active flag yet; once U1 lands, this seam is the single place to tighten the check.
+      // TenantService (U1), never here. An inactive-tenant check is currently unimplementable:
+      // the consumed RestrictedTenantDTO (services/tenantservice.yaml) exposes no active/status
+      // field. Once the TenantService contract exposes it, this seam is the single place to
+      // tighten the check.
       var tenant = tenantService.getRestrictedTenantDataByTenantId(tenantId);
       if (tenant == null || tenant.getId() == null) {
         throw new BadRequestException("Tenant " + tenantId + " does not exist");
       }
+    } catch (HttpClientErrorException.NotFound e) {
+      // only a definite 404 from TenantService means nonexistence
+      throw new BadRequestException("Tenant " + tenantId + " does not exist");
     } catch (RestClientException e) {
-      throw new BadRequestException(
-          "Tenant " + tenantId + " does not exist or cannot be validated");
+      // any other client failure (outage, 5xx, timeout) is an infrastructure problem — never
+      // report it as tenant nonexistence (fail closed, but with the honest status class)
+      throw new InternalServerErrorException(
+          "Tenant " + tenantId + " could not be validated against TenantService", e);
     }
   }
 }

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/service/allocation/AgencyIdAllocationServiceIT.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/service/allocation/AgencyIdAllocationServiceIT.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.when;
 
 import de.caritas.cob.agencyservice.api.exception.httpresponses.BadRequestException;
 import de.caritas.cob.agencyservice.api.exception.httpresponses.ConflictException;
+import de.caritas.cob.agencyservice.api.exception.httpresponses.InternalServerErrorException;
 import de.caritas.cob.agencyservice.api.exception.httpresponses.NotFoundException;
 import de.caritas.cob.agencyservice.api.repository.agencyidreservation.AgencyIdReservationRepository;
 import de.caritas.cob.agencyservice.api.service.TenantService;
@@ -25,6 +26,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
 import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
 import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
@@ -34,6 +37,7 @@ import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionTemplate;
+import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestClientException;
 
 /**
@@ -170,11 +174,33 @@ class AgencyIdAllocationServiceIT {
   @Test
   void reserve_Should_rejectRequest_When_tenantDoesNotExist() {
     when(tenantService.getRestrictedTenantDataByTenantId(UNKNOWN_TENANT_ID))
-        .thenThrow(new RestClientException("404 tenant not found"));
+        .thenThrow(HttpClientErrorException.NotFound.create(
+            HttpStatus.NOT_FOUND, "Not Found", HttpHeaders.EMPTY, new byte[0], null));
 
     assertThatThrownBy(() -> allocationService.reserve(21L, UNKNOWN_TENANT_ID))
         .isInstanceOf(BadRequestException.class);
     assertThat(reservationRepository.existsById(21L)).isFalse();
+  }
+
+  @Test
+  void reserve_Should_signalServerError_When_tenantServiceIsUnavailable() {
+    // a TenantService outage is not tenant nonexistence: it must surface as a 500-class
+    // error, never as 400 "tenant does not exist" (verify finding, analogous to U1)
+    when(tenantService.getRestrictedTenantDataByTenantId(EXISTING_TENANT_ID))
+        .thenThrow(new RestClientException("connection refused"));
+
+    assertThatThrownBy(() -> allocationService.reserve(21L, EXISTING_TENANT_ID))
+        .isInstanceOf(InternalServerErrorException.class);
+    assertThat(reservationRepository.existsById(21L)).isFalse();
+  }
+
+  @Test
+  void reserve_Should_rejectRequest_When_requestedIdIsNotPositive() {
+    assertThatThrownBy(() -> allocationService.reserve(0L, null))
+        .isInstanceOf(BadRequestException.class);
+    assertThatThrownBy(() -> allocationService.reserve(-7L, null))
+        .isInstanceOf(BadRequestException.class);
+    assertThat(reservationRepository.count()).isZero();
   }
 
   @Test


### PR DESCRIPTION
## Problem

The adversarial verify of the TEN-INV-U2 allocation contract (PR #215) raised four non-blocking findings. The most important one is a **misleading error classification**: `validateTenant` treated *any* failure of the TenantService call as "this tenant does not exist" and answered **400**. So a TenantService outage, a 5xx, or a timeout blamed the caller for a bad tenant id and made an infrastructure problem look like a client error — the same trap that was narrowed on the U1 side.

The remaining findings: a non-positive agency ID (`0`, negative) created a junk reservation row instead of being rejected; the allocation integration tests — the concurrency proof for the whole contract — ran only in the `continue-on-error` burn-in job, so a regression could not fail the gate.

## What changed

- **Narrow tenant-validation error classification.** Only a definite **404** from TenantService now means "tenant does not exist" → **400**. Any other client failure (outage, 5xx, timeout) surfaces as **500**, analogous to the U1 `DataAccessException` narrowing. Infrastructure failures are no longer reported as caller errors.
- **Reject non-positive agency IDs on `reserve`** with 400 instead of persisting a junk reservation row; the OpenAPI request schema documents `minimum: 1`.
- **Gate-enforce the allocation ITs.** `pom.xml` now runs the allocation `*IT` classes in the blocking test phase, so the concurrency proof no longer rides only on the `continue-on-error` burn-in job.
- **Document the deferred gaps instead of half-implementing them.** The inactive-tenant check stays unimplementable until the consumed `RestrictedTenantDTO` exposes an active/status flag (single seam noted in `validateTenant`); `release()` ownership checks and TTL need the invite linkage from U3/U6 (javadoc note).

This is deliberately a small, review-hardening-only change on top of #215 — no new contract surface.

## Testing

Verified locally at this branch tip (JDK 21, H2 testing profile, `./mvnw test`):

- **Blocking test phase: 549 tests, 0 failures, 0 errors — BUILD SUCCESS.**
- The `pom.xml` gate-enforcement is demonstrably in effect: the allocation ITs now run inside that blocking phase — `AgencyIdAllocationServiceIT` **17 tests green** and `AgencyIdAllocationServiceTenantScopeIT` **3 tests green** (20 allocation ITs total, 3 of them new on this branch). Their concurrency and tenant-scope assertions therefore gate the build instead of riding on the `continue-on-error` burn-in job.
- New/extended cases in `AgencyIdAllocationServiceIT` covering this change: a TenantService 404 maps to 400 with nothing persisted; a non-404 client failure (outage/5xx) maps to 500 rather than 400; `reserve` with a non-positive id is rejected with 400 and leaves no reservation row.

Not re-run here: the Docker-backed `LiquibaseChangelogDriftIT` (MariaDB) — unaffected by this change, which touches no changesets.

### End-to-end chain evidence

Exercised as part of the tenant-admin onboarding chain test on a clean-slate local stack rebuilt from the chunk branches of Admin#569. Relevant to this PR: **S1** (invite with AUTO id → mail via STARTTLS catcher → onboarding link → organisation data + DPA → account → TOTP → login), **S2** (SMTP down yields 502, the invite stays DRAFT/FAILED with no success toast — the error-classification path this PR narrows), and **S3** (AUTO takes the smallest free id, a taken manual id blocks sending, rapid invites get distinct ids). Continuity checks C1–C6 passed.

## Stack

This is PR **2 of 2** in the AgencyService stack for Admin#569 and the **top** of the stack. It targets `fix/ten-inv-u2-agency-id-allocation`, not `pre-dev`.

1. #215 — `fix/ten-inv-u2-agency-id-allocation` → `pre-dev` (merge first)
2. **this PR** — `fix/ten-inv-hardening-as` → `fix/ten-inv-u2-agency-id-allocation`

Its head equals the proven integration state: `git diff --stat fix/ten-inv-hardening-as..avv-fix` is empty, so #215 plus this PR together reproduce the exact tree that passed the chain test.

Refs OpenResilienceInitiative/ORISO-AgencyService#214
Part of OpenResilienceInitiative/ORISO-Admin#569

🤖 Generated with [Claude Code](https://claude.com/claude-code)
