### PR TITLE
Honor global Liquibase enablement

### DIFF
--- a/src/main/resources/application-testing.properties
+++ b/src/main/resources/application-testing.properties
@@ -39,11 +39,11 @@ spring.jpa.properties.hibernate.format_sql=false
 spring.jpa.hibernate.ddl-auto=create-drop
 
 # ---------------- Liquibase ----------------
-# Left OFF for the testing profile: schema comes from Hibernate ddl-auto=create-drop on H2.
-# Hardcoded false (NOT the SPRING_LIQUIBASE_ENABLED kill switch) so it stays off regardless
-# of environment. change-log points at the consolidated master for consistency only.
+# Left OFF by default for the testing profile: schema comes from Hibernate
+# ddl-auto=create-drop on H2. Still honor SPRING_LIQUIBASE_ENABLED when a
+# deployment/test harness deliberately exercises Liquibase for all services.
 spring.liquibase.change-log=classpath:db/changelog/agencyservice-master.xml
-spring.liquibase.enabled=false
+spring.liquibase.enabled=${SPRING_LIQUIBASE_ENABLED:false}
 
 # ---------------- Local App Settings ----------------
 app.base.url=http://localhost:8084


### PR DESCRIPTION
## Summary

- makes the testing profile honor `SPRING_LIQUIBASE_ENABLED` while preserving the default off behavior for H2/create-drop tests
- keeps the service master changelog wired consistently when Liquibase is explicitly enabled

## Validation

- confirmed `src/main/resources/db/changelog/agencyservice-master.xml` exists
- inspected rendered properties with `rg spring.liquibase src/main/resources/application*.properties`
