### PR TITLE
feat: apply effective permission settings to public agency response

### DIFF
--- a/src/main/java/de/caritas/cob/agencyservice/api/converter/AgencyEffectivePermissionSettingsApplier.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/converter/AgencyEffectivePermissionSettingsApplier.java
@@ -1,0 +1,171 @@
+package de.caritas.cob.agencyservice.api.converter;
+
+import de.caritas.cob.agencyservice.api.model.AgencyAdminAllowedPermissionToggles;
+import de.caritas.cob.agencyservice.api.model.AgencyAdminControls;
+import de.caritas.cob.agencyservice.api.model.Settings;
+import java.util.List;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+import org.springframework.stereotype.Component;
+
+/**
+ * Applies an upper role's effective permission constraints ({@link AgencyAdminControls}) to the
+ * public feature flags served to the counselling app. {@code allowedPermissionToggles == false}
+ * forces the feature off; {@code enforcedPermissionToggles == true} forces it on; anything else is
+ * left as the agency set it. Mirrors ORISO-TenantService's {@code
+ * EffectivePermissionSettingsApplier} (ADR-013 P4) at the agency level. This is the server-side
+ * single source of truth so the Frontend needs no awareness of the controls (which must not be
+ * attached to the public agency response — see the callers of this class).
+ */
+@Component
+public class AgencyEffectivePermissionSettingsApplier {
+
+  private record ToggleBinding(
+      Function<AgencyAdminAllowedPermissionToggles, Boolean> getter,
+      BiConsumer<Settings, Boolean> setter) {}
+
+  // One binding per conversation/media feature: the toggle getter <-> the Settings feature-flag
+  // setter it governs. `appearance` has no Settings counterpart (governs theme customization
+  // visibility, not a chat feature flag) and is intentionally not bound here.
+  private static final List<ToggleBinding> BINDINGS =
+      List.of(
+          new ToggleBinding(
+              AgencyAdminAllowedPermissionToggles::getAnonymousChat,
+              Settings::setFeatureAnonymousChatEnabled),
+          new ToggleBinding(
+              AgencyAdminAllowedPermissionToggles::getGroupChat,
+              Settings::setFeatureGroupChatV2Enabled),
+          new ToggleBinding(
+              AgencyAdminAllowedPermissionToggles::getCalls, Settings::setFeatureCallsEnabled),
+          new ToggleBinding(
+              AgencyAdminAllowedPermissionToggles::getSupervision,
+              Settings::setFeatureSupervisionEnabled),
+          new ToggleBinding(
+              AgencyAdminAllowedPermissionToggles::getSupervisionAnonymousChats,
+              Settings::setFeatureSupervisionAnonymousChatsEnabled),
+          new ToggleBinding(
+              AgencyAdminAllowedPermissionToggles::getSupervisionOneOnOneChats,
+              Settings::setFeatureSupervisionOneOnOneChatsEnabled),
+          new ToggleBinding(
+              AgencyAdminAllowedPermissionToggles::getAudioCalls,
+              Settings::setFeatureAudioCallsEnabled),
+          new ToggleBinding(
+              AgencyAdminAllowedPermissionToggles::getAudioCallsAnonymousChats,
+              Settings::setFeatureAudioCallsAnonymousChatsEnabled),
+          new ToggleBinding(
+              AgencyAdminAllowedPermissionToggles::getAudioCallsOneOnOneChats,
+              Settings::setFeatureAudioCallsOneOnOneChatsEnabled),
+          new ToggleBinding(
+              AgencyAdminAllowedPermissionToggles::getAudioCallsGroupChats,
+              Settings::setFeatureAudioCallsGroupChatsEnabled),
+          new ToggleBinding(
+              AgencyAdminAllowedPermissionToggles::getAudioCallsSupervisionChats,
+              Settings::setFeatureAudioCallsSupervisionChatsEnabled),
+          new ToggleBinding(
+              AgencyAdminAllowedPermissionToggles::getVideoCalls,
+              Settings::setFeatureVideoCallsEnabled),
+          new ToggleBinding(
+              AgencyAdminAllowedPermissionToggles::getVideoCallsAnonymousChats,
+              Settings::setFeatureVideoCallsAnonymousChatsEnabled),
+          new ToggleBinding(
+              AgencyAdminAllowedPermissionToggles::getVideoCallsOneOnOneChats,
+              Settings::setFeatureVideoCallsOneOnOneChatsEnabled),
+          new ToggleBinding(
+              AgencyAdminAllowedPermissionToggles::getVideoCallsGroupChats,
+              Settings::setFeatureVideoCallsGroupChatsEnabled),
+          new ToggleBinding(
+              AgencyAdminAllowedPermissionToggles::getVideoCallsSupervisionChats,
+              Settings::setFeatureVideoCallsSupervisionChatsEnabled),
+          new ToggleBinding(
+              AgencyAdminAllowedPermissionToggles::getThreads, Settings::setFeatureThreadsEnabled),
+          new ToggleBinding(
+              AgencyAdminAllowedPermissionToggles::getThreadsAnonymousChats,
+              Settings::setFeatureThreadsAnonymousChatsEnabled),
+          new ToggleBinding(
+              // Irregular: threadsOneOnOneChats -> featureThreadsOneOnOneEnabled (mirrors
+              // ORISO-TenantService's binding).
+              AgencyAdminAllowedPermissionToggles::getThreadsOneOnOneChats,
+              Settings::setFeatureThreadsOneOnOneEnabled),
+          new ToggleBinding(
+              AgencyAdminAllowedPermissionToggles::getThreadsGroupChats,
+              Settings::setFeatureThreadsGroupChatsEnabled),
+          new ToggleBinding(
+              AgencyAdminAllowedPermissionToggles::getThreadsSupervisionChats,
+              Settings::setFeatureThreadsSupervisionChatsEnabled),
+          new ToggleBinding(
+              AgencyAdminAllowedPermissionToggles::getVoiceMessages,
+              Settings::setFeatureVoiceMessagesEnabled),
+          new ToggleBinding(
+              AgencyAdminAllowedPermissionToggles::getVoiceMessagesAnonymousChats,
+              Settings::setFeatureVoiceMessagesAnonymousChatsEnabled),
+          new ToggleBinding(
+              AgencyAdminAllowedPermissionToggles::getVoiceMessagesOneOnOneChats,
+              Settings::setFeatureVoiceMessagesOneOnOneChatsEnabled),
+          new ToggleBinding(
+              AgencyAdminAllowedPermissionToggles::getVoiceMessagesGroupChats,
+              Settings::setFeatureVoiceMessagesGroupChatsEnabled),
+          new ToggleBinding(
+              AgencyAdminAllowedPermissionToggles::getVoiceMessagesSupervisionChats,
+              Settings::setFeatureVoiceMessagesSupervisionChatsEnabled),
+          new ToggleBinding(
+              AgencyAdminAllowedPermissionToggles::getMediaUpload,
+              Settings::setFeatureMediaUploadEnabled),
+          new ToggleBinding(
+              AgencyAdminAllowedPermissionToggles::getMediaUploadAnonymousChats,
+              Settings::setFeatureMediaUploadAnonymousChatsEnabled),
+          new ToggleBinding(
+              AgencyAdminAllowedPermissionToggles::getMediaUploadOneOnOneChats,
+              Settings::setFeatureMediaUploadOneOnOneChatsEnabled),
+          new ToggleBinding(
+              AgencyAdminAllowedPermissionToggles::getMediaUploadGroupChats,
+              Settings::setFeatureMediaUploadGroupChatsEnabled),
+          new ToggleBinding(
+              AgencyAdminAllowedPermissionToggles::getMediaUploadSupervisionChats,
+              Settings::setFeatureMediaUploadSupervisionChatsEnabled),
+          new ToggleBinding(
+              AgencyAdminAllowedPermissionToggles::getMediaInlineDisplay,
+              Settings::setFeatureMediaInlineDisplayEnabled),
+          new ToggleBinding(
+              AgencyAdminAllowedPermissionToggles::getMediaInlineDisplayAnonymousChats,
+              Settings::setFeatureMediaInlineDisplayAnonymousChatsEnabled),
+          new ToggleBinding(
+              AgencyAdminAllowedPermissionToggles::getMediaInlineDisplayOneOnOneChats,
+              Settings::setFeatureMediaInlineDisplayOneOnOneChatsEnabled),
+          new ToggleBinding(
+              AgencyAdminAllowedPermissionToggles::getMediaInlineDisplayGroupChats,
+              Settings::setFeatureMediaInlineDisplayGroupChatsEnabled),
+          new ToggleBinding(
+              AgencyAdminAllowedPermissionToggles::getMediaInlineDisplaySupervisionChats,
+              Settings::setFeatureMediaInlineDisplaySupervisionChatsEnabled),
+          new ToggleBinding(
+              AgencyAdminAllowedPermissionToggles::getMediaAiScan,
+              Settings::setFeatureMediaAiScanEnabled),
+          new ToggleBinding(
+              AgencyAdminAllowedPermissionToggles::getMediaAiScanAnonymousChats,
+              Settings::setFeatureMediaAiScanAnonymousChatsEnabled),
+          new ToggleBinding(
+              AgencyAdminAllowedPermissionToggles::getMediaAiScanOneOnOneChats,
+              Settings::setFeatureMediaAiScanOneOnOneChatsEnabled),
+          new ToggleBinding(
+              AgencyAdminAllowedPermissionToggles::getMediaAiScanGroupChats,
+              Settings::setFeatureMediaAiScanGroupChatsEnabled),
+          new ToggleBinding(
+              AgencyAdminAllowedPermissionToggles::getMediaAiScanSupervisionChats,
+              Settings::setFeatureMediaAiScanSupervisionChatsEnabled));
+
+  public void applyTo(Settings settings, AgencyAdminControls controls) {
+    if (settings == null || controls == null) {
+      return;
+    }
+    AgencyAdminAllowedPermissionToggles allowed = controls.getAllowedPermissionToggles();
+    AgencyAdminAllowedPermissionToggles enforced = controls.getEnforcedPermissionToggles();
+    for (ToggleBinding binding : BINDINGS) {
+      if (allowed != null && Boolean.FALSE.equals(binding.getter().apply(allowed))) {
+        binding.setter().accept(settings, false);
+      }
+      if (enforced != null && Boolean.TRUE.equals(binding.getter().apply(enforced))) {
+        binding.setter().accept(settings, true);
+      }
+    }
+  }
+}

--- a/src/main/java/de/caritas/cob/agencyservice/api/service/AgencyService.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/service/AgencyService.java
@@ -7,6 +7,7 @@ import com.google.common.collect.Lists;
 import de.caritas.cob.agencyservice.api.admin.service.agency.AgencySettingsService;
 import de.caritas.cob.agencyservice.api.admin.service.agency.DemographicsConverter;
 import de.caritas.cob.agencyservice.api.admin.service.agencyadmincontrol.AgencyAdminControlsService;
+import de.caritas.cob.agencyservice.api.converter.AgencyEffectivePermissionSettingsApplier;
 import de.caritas.cob.agencyservice.api.exception.MissingConsultingTypeException;
 import de.caritas.cob.agencyservice.api.exception.httpresponses.BadRequestException;
 import de.caritas.cob.agencyservice.api.exception.httpresponses.InternalServerErrorException;
@@ -72,6 +73,9 @@ public class AgencyService {
   private final @NonNull AgencySettingsService agencySettingsService;
 
   private final @NonNull AgencyAdminControlsService agencyAdminControlsService;
+
+  private final @NonNull AgencyEffectivePermissionSettingsApplier
+      effectivePermissionSettingsApplier;
 
   @Value("${feature.topics.enabled}")
   private boolean topicsFeatureEnabled;
@@ -452,9 +456,20 @@ public class AgencyService {
         .settings(buildAgencySettings(agency));
   }
 
+  /**
+   * Builds the settings served on the public/registration-facing agency response. Bakes the
+   * platform admin controls into the effective feature flags (forced-off disabled, enforced-on
+   * locked on) without exposing the controls themselves — see {@link
+   * AgencyEffectivePermissionSettingsApplier}. Mirrors ORISO-TenantService's
+   * withEffectivePermissions (ADR-013 P4). The admin-facing path ({@code AgencyAdminService})
+   * still attaches the raw controls via {@link
+   * AgencyAdminControlsService#enrichSettingsWithAgencyAdminControls} so the Admin UI can render
+   * disabled-not-hidden state.
+   */
   private Settings buildAgencySettings(Agency agency) {
     var settings = agencySettingsService.toSettings(agency.getSettings());
-    return agencyAdminControlsService.enrichSettingsWithAgencyAdminControls(settings);
+    effectivePermissionSettingsApplier.applyTo(settings, agencyAdminControlsService.getControls());
+    return settings;
   }
 
   protected String getRenderedAgencySpecificPrivacy(Agency agency) {

--- a/src/test/java/de/caritas/cob/agencyservice/api/converter/AgencyEffectivePermissionSettingsApplierTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/converter/AgencyEffectivePermissionSettingsApplierTest.java
@@ -1,0 +1,87 @@
+package de.caritas.cob.agencyservice.api.converter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import de.caritas.cob.agencyservice.api.model.AgencyAdminAllowedPermissionToggles;
+import de.caritas.cob.agencyservice.api.model.AgencyAdminControls;
+import de.caritas.cob.agencyservice.api.model.Settings;
+import org.junit.jupiter.api.Test;
+
+class AgencyEffectivePermissionSettingsApplierTest {
+
+  private final AgencyEffectivePermissionSettingsApplier applier =
+      new AgencyEffectivePermissionSettingsApplier();
+
+  @Test
+  void applyTo_should_forceFeatureOff_whenUpperRoleDisallowsIt() {
+    var settings = new Settings().featureVideoCallsEnabled(true);
+    var controls =
+        new AgencyAdminControls()
+            .allowedPermissionToggles(
+                new AgencyAdminAllowedPermissionToggles().videoCalls(false));
+
+    applier.applyTo(settings, controls);
+
+    assertThat(settings.getFeatureVideoCallsEnabled()).isFalse();
+  }
+
+  @Test
+  void applyTo_should_forceFeatureOn_whenUpperRoleEnforcesIt() {
+    var settings = new Settings().featureAudioCallsEnabled(false);
+    var controls =
+        new AgencyAdminControls()
+            .enforcedPermissionToggles(
+                new AgencyAdminAllowedPermissionToggles().audioCalls(true));
+
+    applier.applyTo(settings, controls);
+
+    assertThat(settings.getFeatureAudioCallsEnabled()).isTrue();
+  }
+
+  @Test
+  void applyTo_should_leaveUnconstrainedFeatureUnchanged() {
+    var settings = new Settings().featureThreadsEnabled(true);
+    var controls =
+        new AgencyAdminControls()
+            .allowedPermissionToggles(new AgencyAdminAllowedPermissionToggles());
+
+    applier.applyTo(settings, controls);
+
+    assertThat(settings.getFeatureThreadsEnabled()).isTrue();
+  }
+
+  @Test
+  void applyTo_should_doNothing_whenControlsAreNull() {
+    var settings = new Settings().featureVideoCallsEnabled(true);
+
+    applier.applyTo(settings, null);
+
+    assertThat(settings.getFeatureVideoCallsEnabled()).isTrue();
+  }
+
+  @Test
+  void applyTo_should_doNothing_whenSettingsAreNull() {
+    var controls =
+        new AgencyAdminControls()
+            .enforcedPermissionToggles(
+                new AgencyAdminAllowedPermissionToggles().audioCalls(true));
+
+    // Must not throw.
+    applier.applyTo(null, controls);
+  }
+
+  @Test
+  void applyTo_should_letEnforcedOnWin_whenBothAllowedOffAndEnforcedOnAreSet() {
+    var settings = new Settings().featureCallsEnabled(true);
+    var togglesAllowed = new AgencyAdminAllowedPermissionToggles().calls(false);
+    var togglesEnforced = new AgencyAdminAllowedPermissionToggles().calls(true);
+    var controls =
+        new AgencyAdminControls()
+            .allowedPermissionToggles(togglesAllowed)
+            .enforcedPermissionToggles(togglesEnforced);
+
+    applier.applyTo(settings, controls);
+
+    assertThat(settings.getFeatureCallsEnabled()).isTrue();
+  }
+}

--- a/src/test/java/de/caritas/cob/agencyservice/api/service/AgencyServiceMatrixCredentialsTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/service/AgencyServiceMatrixCredentialsTest.java
@@ -38,6 +38,11 @@ class AgencyServiceMatrixCredentialsTest {
   @Mock private ApplicationSettingsService applicationSettingsService;
   @Mock private AgencySettingsService agencySettingsService;
   @Mock private AgencyAdminControlsService agencyAdminControlsService;
+
+  @org.mockito.Spy
+  private final de.caritas.cob.agencyservice.api.converter.AgencyEffectivePermissionSettingsApplier
+      effectivePermissionSettingsApplier =
+          new de.caritas.cob.agencyservice.api.converter.AgencyEffectivePermissionSettingsApplier();
   @Spy
   private AgencyMatrixPasswordCipher matrixPasswordCipher =
       new AgencyMatrixPasswordCipher(APP_KEY);

--- a/src/test/java/de/caritas/cob/agencyservice/api/service/AgencyServiceTenantAwareTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/service/AgencyServiceTenantAwareTest.java
@@ -64,6 +64,11 @@ public class AgencyServiceTenantAwareTest {
   @Mock
   private AgencyAdminControlsService agencyAdminControlsService;
 
+  @org.mockito.Spy
+  private final de.caritas.cob.agencyservice.api.converter.AgencyEffectivePermissionSettingsApplier
+      effectivePermissionSettingsApplier =
+          new de.caritas.cob.agencyservice.api.converter.AgencyEffectivePermissionSettingsApplier();
+
   private static final Long TENANT_ID = 1L;
 
   @Before

--- a/src/test/java/de/caritas/cob/agencyservice/api/service/AgencyServiceTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/service/AgencyServiceTest.java
@@ -40,6 +40,8 @@ import de.caritas.cob.agencyservice.api.exception.httpresponses.BadRequestExcept
 import de.caritas.cob.agencyservice.api.exception.httpresponses.InternalServerErrorException;
 import de.caritas.cob.agencyservice.api.exception.httpresponses.NotFoundException;
 import de.caritas.cob.agencyservice.api.manager.consultingtype.ConsultingTypeManager;
+import de.caritas.cob.agencyservice.api.model.AgencyAdminAllowedPermissionToggles;
+import de.caritas.cob.agencyservice.api.model.AgencyAdminControls;
 import de.caritas.cob.agencyservice.api.model.AgencyResponseDTO;
 import de.caritas.cob.agencyservice.api.model.FullAgencyResponseDTO;
 import de.caritas.cob.agencyservice.api.repository.agency.Agency;
@@ -106,6 +108,11 @@ public class AgencyServiceTest {
   @Mock
   AgencyAdminControlsService agencyAdminControlsService;
 
+  @org.mockito.Spy
+  private final de.caritas.cob.agencyservice.api.converter.AgencyEffectivePermissionSettingsApplier
+      effectivePermissionSettingsApplier =
+          new de.caritas.cob.agencyservice.api.converter.AgencyEffectivePermissionSettingsApplier();
+
   @Mock
   ApplicationSettingsService applicationSettingsService;
 
@@ -123,10 +130,6 @@ public class AgencyServiceTest {
     ensureAgencyTopics(AGENCY_ONLINE_U25);
     ensureAgencyTopics(AGENCY_OFFLINE);
     when(agencySettingsService.toSettings(any())).thenReturn(new de.caritas.cob.agencyservice.api.model.Settings());
-    when(agencyAdminControlsService.enrichSettingsWithAgencyAdminControls(any()))
-        .thenAnswer(invocation -> invocation.getArgument(0) != null
-            ? invocation.getArgument(0)
-            : new de.caritas.cob.agencyservice.api.model.Settings());
   }
 
   private void ensureAgencyTopics(Agency agency) {
@@ -356,6 +359,39 @@ public class AgencyServiceTest {
     assertEquals(AGENCY_RESPONSE_DTO.getConsultingType(), result.getConsultingType());
     assertThat(agencyService.getAgencies(Collections.singletonList(AGENCY_ID)),
         everyItem(instanceOf(AgencyResponseDTO.class)));
+  }
+
+  @Test
+  public void getAgencies_With_Ids_Should_ForceFeatureOff_When_PlatformDisallowsIt() {
+    when(agencyRepository.findByIdIn(AGENCY_IDS_LIST)).thenReturn(AGENCY_LIST);
+    when(agencySettingsService.toSettings(any()))
+        .thenReturn(new de.caritas.cob.agencyservice.api.model.Settings().featureCallsEnabled(true));
+    when(agencyAdminControlsService.getControls())
+        .thenReturn(
+            new AgencyAdminControls()
+                .allowedPermissionToggles(
+                    new AgencyAdminAllowedPermissionToggles().calls(false)));
+
+    AgencyResponseDTO result = agencyService.getAgencies(AGENCY_IDS_LIST).get(0);
+
+    assertEquals(false, result.getSettings().getFeatureCallsEnabled());
+  }
+
+  @Test
+  public void getAgencies_With_Ids_Should_NotLeakAgencyAdminControls_OnThePublicResponse() {
+    when(agencyRepository.findByIdIn(AGENCY_IDS_LIST)).thenReturn(AGENCY_LIST);
+    when(agencyAdminControlsService.getControls())
+        .thenReturn(
+            new AgencyAdminControls()
+                .allowedPermissionToggles(
+                    new AgencyAdminAllowedPermissionToggles().calls(false)));
+
+    AgencyResponseDTO result = agencyService.getAgencies(AGENCY_IDS_LIST).get(0);
+
+    // The public response must never carry the raw controls object — only the effective
+    // (merged) feature flags. Guards against regressing to enrichSettingsWithAgencyAdminControls,
+    // which used to attach it here.
+    assertEquals(null, result.getSettings().getAgencyAdminControls());
   }
 
   @Test


### PR DESCRIPTION
## Problem

ORISO-Admin#297 item 3 asks to mirror ORISO-TenantService's `EffectivePermissionSettingsApplier` (ADR-013 P4) at the agency level: bake the platform's allowed/enforced permission toggles into the actual feature flags the counselling app receives.

AgencyService had the data model (`AgencyAdminControls`, #119) but `AgencyService.buildAgencySettings()` — used by the **public, unauthenticated** registration-facing endpoints (`AgencyResponseDTO`/`FullAgencyResponseDTO`, e.g. `GET /agencies/{ids}`, `GET /agencies?consultingType=`) — only *attached* the controls object for display (`AgencyAdminControlsService.enrichSettingsWithAgencyAdminControls`). It never merged them onto the actual flags.

**Found while wiring this in:** that same attach call meant the full platform `agencyAdminControls` (the complete allowed/enforced toggle configuration) was exposed as-is on the public path — any anonymous caller of those endpoints could see it, via the shared `Settings` OpenAPI schema. Not just a missing-enforcement bug, a minor data exposure.

## What changed

- New `AgencyEffectivePermissionSettingsApplier` — exact mirror of TenantService's algorithm (`allowed == false` forces a feature off, `enforced == true` forces it on) and binding-table shape, extended with the media-flag families (`mediaUpload`/`mediaInlineDisplay`/`mediaAiScan`) that exist on the agency-level toggle model but not yet on TenantService's.
- `buildAgencySettings()` now calls the new applier instead of the attach-only enrichment. The raw controls object is no longer part of the public response.
- The **admin-facing** path (`AgencyAdminService`) is untouched — it correctly keeps attaching the raw controls so the Admin UI can render disabled-not-hidden state.

## Verification

- `mvn test` (targeted + full suite) — 576/576 passed (JDK 21; had to add the new applier as a `@Spy` to 3 existing `@InjectMocks AgencyService` test classes that don't mock it)

Part of #297 (item 1, the Admin footer switch, is a separate PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)