### PR TITLE
Promote pre-dev → dev

### DIFF
--- a/.github/actions/docker-build-push/action.yml
+++ b/.github/actions/docker-build-push/action.yml
@@ -59,5 +59,8 @@ runs:
       sbom: true
       tags: ${{ steps.meta.outputs.tags }}
       labels: ${{ steps.meta.outputs.labels }}
-      cache-from: type=gha
-      cache-to: type=gha,mode=max
+      # Scope the GHA cache per image so images built from this shared action
+      # can't collide on one cache namespace — future-proofs against a second
+      # image being added (root cause of OpenResilienceInitiative/ORISO-Admin#424).
+      cache-from: type=gha,scope=${{ inputs.image_name }}
+      cache-to: type=gha,mode=max,scope=${{ inputs.image_name }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,30 @@
+# AGENTS.md — ORISO-AgencyService
+
+Load workspace parent `../AGENTS.md` first (`PROJECT_ORISO_ROOT` = parent of this repo).
+
+## Stack
+
+Java **21**, Spring Boot **4.0.1**, Maven Wrapper **3.9.15**. Owns agencies and `/service/agencies` admin APIs.
+
+## Commands
+
+```bash
+./mvnw -B test
+./mvnw -B package -DskipTests
+./mvnw -B checkstyle:check   # bound to validate in pom
+```
+
+From workspace: `REPO=ORISO-AgencyService ../scripts/harness/verify-fast.sh` (or `verify-full.sh`).
+
+CI: `./mvnw -B test` then `./mvnw -B package -DskipTests` on Java 21.
+
+## Context
+
+- Integration branch: `pre-dev` when used for ORISO feature work.
+- Skim `.understand-anything/` before non-trivial changes.
+- Keep agency contracts aligned with Admin agency screens and UserService references — do not invent parallel agency models.
+- Secrets: use `config.env.example`; never commit real env files.
+
+## Done
+
+Touched tests pass; package succeeds for PR-bound work; checkstyle clean when you touch Java sources. Task notes: `docs/agent-tasks/YYYY-MM-DD_short-name/` if needed.

--- a/src/main/java/de/caritas/cob/agencyservice/api/admin/service/agency/AgencyAdminSearchService.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/admin/service/agency/AgencyAdminSearchService.java
@@ -221,10 +221,14 @@ public class AgencyAdminSearchService {
       addOrderBy(agencyAdminSearch, criteriaBuilder, criteriaQuery, expression, javaType);
     }
 
-    // Pagination
-    int firstResult = agencyAdminSearch.getPageNumber() == 0 ? 0
+    // Pagination. Page size and page number arrive straight from query parameters, so both can
+    // be negative. Only the zero case was handled, and a negative size reached
+    // setMaxResults() and surfaced as a 500 ("Max results cannot be negative"). Non-positive
+    // size now means no results, and a non-positive page number means the first page — the same
+    // contract the zero case already had (#206).
+    int firstResult = agencyAdminSearch.getPageNumber() <= 1 ? 0
         : (agencyAdminSearch.getPageNumber() - 1) * agencyAdminSearch.getPageSize();
-    return agencyAdminSearch.getPageSize() == 0 ? Lists.newArrayList()
+    return agencyAdminSearch.getPageSize() <= 0 ? Lists.newArrayList()
         : entityManager.createQuery(criteriaQuery)
             .setFirstResult(firstResult)
             .setMaxResults(agencyAdminSearch.getPageSize())

--- a/src/main/java/de/caritas/cob/agencyservice/api/repository/agency/Agency.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/repository/agency/Agency.java
@@ -151,7 +151,11 @@ public class Agency implements TenantAware {
   @Column(name = "update_date", nullable = false)
   private LocalDateTime updateDate;
 
-  @Column(name = "data_protection_responsible_entity", nullable = false)
+  // Changeset 0016 declares this column NULL. nullable=false here contradicted the migration
+  // and only ever became real DDL on the create-drop test schema, where it rejected inserts
+  // production accepts. Same reasoning as the neighbouring DPO contact field below — that one
+  // was corrected, this one was missed (#204).
+  @Column(name = "data_protection_responsible_entity")
   @Enumerated(EnumType.STRING)
   private DataProtectionResponsibleEntity dataProtectionResponsibleEntity;
 

--- a/src/main/java/de/caritas/cob/agencyservice/api/workflow/AgencyPurgeTransaction.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/workflow/AgencyPurgeTransaction.java
@@ -3,7 +3,6 @@ package de.caritas.cob.agencyservice.api.workflow;
 import de.caritas.cob.agencyservice.api.repository.agency.Agency;
 import de.caritas.cob.agencyservice.api.repository.agency.AgencyRepository;
 import de.caritas.cob.agencyservice.api.repository.agencypostcoderange.AgencyPostcodeRangeRepository;
-import de.caritas.cob.agencyservice.api.repository.agencytopic.AgencyTopicRepository;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -11,18 +10,24 @@ import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
- * Purges one agency and its restricting dependencies inside its own transaction.
+ * Purges one agency inside its own transaction.
  *
- * <p>This lives in a separate bean on purpose. The purge previously ran for the whole batch inside
- * one class-level transaction, so {@code agencyRepository.delete(...)} only queued the delete and
- * Hibernate flushed it at commit — outside the caller's {@code try/catch} and outside the method. A
- * constraint violation therefore produced no per-agency log line at all and took the entire batch
- * down with it.
+ * <p>The transaction boundary is the entire point of this class. The purge previously ran for the
+ * whole batch inside one class-level transaction on {@link DeleteAgencyService}, so {@code
+ * agencyRepository.delete(...)} only queued the delete and Hibernate flushed it at commit — outside
+ * the caller's {@code try/catch} and outside the method. A failure therefore produced no per-agency
+ * log line and took the whole batch down with it.
  *
  * <p>With {@code REQUIRES_NEW} the commit happens when this method returns, so the flush is inside
  * the transaction the caller can observe: a failing agency raises an exception the caller catches
  * and logs, and the agencies already purged stay purged. A self-invocation would bypass the proxy
  * and silently restore the old behaviour, which is why this is not a private method on the service.
+ *
+ * <p>Departments ({@code agency_topic}) are deliberately <em>not</em> deleted here. {@code
+ * Agency.agencyTopics} is mapped {@code cascade = ALL, orphanRemoval = true}, so Hibernate removes
+ * them before the parent on its own. An earlier revision added an explicit delete believing the
+ * {@code RESTRICT} constraint blocked the purge; a before/after test on PreDev proved it never did.
+ * Postcode ranges carry no such cascade and do need the explicit call.
  */
 @Component
 @RequiredArgsConstructor
@@ -30,17 +35,14 @@ public class AgencyPurgeTransaction {
 
   private final @NonNull AgencyRepository agencyRepository;
   private final @NonNull AgencyPostcodeRangeRepository agencyPostcodeRangeRepository;
-  private final @NonNull AgencyTopicRepository agencyTopicRepository;
 
   /**
-   * Deletes the agency together with every row holding a restricting foreign key on it.
+   * Deletes the agency together with the dependencies that JPA does not cascade.
    *
    * @param agency the {@link Agency} to purge
    */
   @Transactional(propagation = Propagation.REQUIRES_NEW)
   public void purge(Agency agency) {
-    var agencyTopics = agencyTopicRepository.findAllByAgencyId(agency.getId());
-    agencyTopicRepository.deleteAll(agencyTopics);
     agencyPostcodeRangeRepository.deleteAllByAgencyId(agency.getId());
     agencyRepository.delete(agency);
   }

--- a/src/test/java/de/caritas/cob/agencyservice/api/ResponseEntityExceptionHandlerIT.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/ResponseEntityExceptionHandlerIT.java
@@ -21,7 +21,9 @@ import de.caritas.cob.agencyservice.api.exception.httpresponses.InternalServerEr
 import de.caritas.cob.agencyservice.api.exception.httpresponses.InvalidPostcodeException;
 import de.caritas.cob.agencyservice.api.exception.httpresponses.NotFoundException;
 import de.caritas.cob.agencyservice.api.service.AgencyService;
+import de.caritas.cob.agencyservice.api.service.DepartmentLegalService;
 import de.caritas.cob.agencyservice.api.service.LogService;
+import de.caritas.cob.agencyservice.api.service.TopicEnrichmentService;
 import de.caritas.cob.agencyservice.config.security.AuthorisationService;
 import de.caritas.cob.agencyservice.config.security.JwtAuthConverter;
 import de.caritas.cob.agencyservice.config.security.JwtAuthConverterProperties;
@@ -54,6 +56,15 @@ public class ResponseEntityExceptionHandlerIT {
 
   @MockitoBean
   private AgencyService agencyService;
+
+  // AgencyController takes three @NonNull collaborators. Without these two the context
+  // never loads, every test here errors, and the exception-to-status assertions below
+  // are never reached (#203).
+  @MockitoBean
+  private TopicEnrichmentService topicEnrichmentService;
+
+  @MockitoBean
+  private DepartmentLegalService departmentLegalService;
 
   @MockitoBean
   private LinkDiscoverers linkDiscoverers;

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/service/AgencyAdminServiceIT.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/service/AgencyAdminServiceIT.java
@@ -1,6 +1,7 @@
 package de.caritas.cob.agencyservice.api.admin.service;
 
 import de.caritas.cob.agencyservice.AgencyServiceApplication;
+import de.caritas.cob.agencyservice.api.service.TopicService;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
@@ -9,6 +10,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,7 +22,15 @@ import org.springframework.transaction.annotation.Transactional;
 @DirtiesContext(classMode = ClassMode.BEFORE_CLASS)
 @Transactional
 @TestPropertySource(properties = "multitenancy.enabled=false")
+@Sql(scripts = "/database/AgencyDatabase.sql")
 public class AgencyAdminServiceIT extends AgencyAdminServiceITBase {
+
+  /**
+   * Without this the suite calls the real ConsultingTypeService on localhost:8083 during
+   * createAgency and fails with 401 (#204). Mirrors AgencyAdminServiceTenantAwareIT.
+   */
+  @MockitoBean
+  private TopicService topicService;
 
   @Test
   public void saveAgency_Should_PersistsAgency() {

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/service/AgencyAdminServiceITBase.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/service/AgencyAdminServiceITBase.java
@@ -6,6 +6,8 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
 
 import com.google.common.collect.Lists;
 import de.caritas.cob.agencyservice.api.model.AgencyAdminFullResponseDTO;
@@ -18,14 +20,28 @@ import de.caritas.cob.agencyservice.api.tenant.TenantContext;
 import de.caritas.cob.agencyservice.api.util.AuthenticatedUser;
 import jakarta.persistence.EntityManager;
 import java.util.Optional;
+import org.junit.Before;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 public class AgencyAdminServiceITBase {
 
+  /**
+   * A real admin request carries a tenantId claim, which {@code AuthenticatedUserConfig} copies
+   * onto {@link AuthenticatedUser}. The mock returns null unless told otherwise, and
+   * {@code AgencyAdminService.setTenantIdOnCreate} then fails every create with
+   * "The validated object is null" — a fixture artifact, not the behaviour under test (#204).
+   */
+  protected static final Long AUTHENTICATED_TENANT_ID = 1L;
+
   @Autowired protected AgencyAdminService agencyAdminService;
   @Autowired protected AgencyRepository agencyRepository;
   @MockitoBean protected AuthenticatedUser authenticatedUser;
+
+  @Before
+  public void givenAuthenticatedUserHasTenant() {
+    lenient().when(authenticatedUser.getTenantId()).thenReturn(AUTHENTICATED_TENANT_ID);
+  }
 
   public void saveAgency_Should_PersistsAgency() {
 

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/service/AgencyAdminServiceTenantAwareIT.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/service/AgencyAdminServiceTenantAwareIT.java
@@ -41,6 +41,9 @@ import org.springframework.transaction.annotation.Transactional;
 @TestPropertySource(properties = "multitenancy.enabled=true")
 @TestPropertySource(properties = "feature.topics.enabled=true")
 @Transactional
+// AgencyDatabase.sql first: setTenants.sql only UPDATEs agency rows, so without the seed it
+// silently updated nothing and every lookup in the base fixture failed (#204).
+@Sql(value = "/database/AgencyDatabase.sql", executionPhase = ExecutionPhase.BEFORE_TEST_METHOD)
 @Sql(value = "/setTenants.sql", executionPhase = ExecutionPhase.BEFORE_TEST_METHOD)
 public class AgencyAdminServiceTenantAwareIT extends AgencyAdminServiceITBase {
 

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/service/agency/AgencyAdminSearchServiceSearchIT.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/service/agency/AgencyAdminSearchServiceSearchIT.java
@@ -33,13 +33,17 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.transaction.annotation.Transactional;
+import org.springframework.test.context.jdbc.Sql;
 
 @SpringBootTest(classes = AgencyServiceApplication.class)
-@TestPropertySource(properties = "spring.profiles.active=testing")
+// topics off: this suite covers search, pagination and sorting, not topic enrichment. With the
+// feature on, every result mapping calls the real ConsultingTypeService on :8083 (#206). The
+// sibling AgencyAdminSearchServiceIT already draws the boundary here.
+@TestPropertySource(properties = {"spring.profiles.active=testing",
+    "feature.topics.enabled=false"})
 @AutoConfigureTestDatabase(replace = Replace.ANY)
 @DirtiesContext(classMode = ClassMode.BEFORE_CLASS)
-@Transactional
+@Sql(scripts = "/database/AgencyDatabase.sql")
 class AgencyAdminSearchServiceSearchIT {
 
   @Autowired
@@ -47,6 +51,15 @@ class AgencyAdminSearchServiceSearchIT {
 
   @MockitoBean
   AuthenticatedUser authenticatedUser;
+
+  /**
+   * TopicEnrichmentService is @ConditionalOnExpression on feature.topics.enabled, but
+   * AgencyController requires it as a @NonNull constructor argument. Turning the feature off
+   * therefore removes the bean and the whole context fails to load, so the mock has to stand in
+   * for it. Same pairing as the sibling AgencyAdminSearchServiceIT (#206).
+   */
+  @MockitoBean
+  private de.caritas.cob.agencyservice.api.service.TopicEnrichmentService topicEnrichmentService;
 
   @BeforeEach
   public void setUp() {

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/service/agencypostcoderange/AgencyPostcodeRangeAdminServiceTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/service/agencypostcoderange/AgencyPostcodeRangeAdminServiceTest.java
@@ -10,6 +10,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.util.ReflectionTestUtils.setField;
 
@@ -66,6 +67,10 @@ class AgencyPostcodeRangeAdminServiceTest {
     this.agencyPostcodeRangeAdminService.deleteAgencyPostcodeRange(1L);
 
     verify(this.agencyPostcodeRangeRepository, times(1)).deleteAllByAgencyId(1L);
+    // The offline status is controlled explicitly via agency update, so deleting the
+    // last postcode range must not reach the agency at all (#66). Without this the
+    // test name promised an assertion it never made.
+    verifyNoInteractions(this.agencyAdminService);
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/agencyservice/api/service/AgencyServiceIT.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/service/AgencyServiceIT.java
@@ -12,13 +12,22 @@ import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabas
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.junit4.SpringRunner;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = AgencyServiceApplication.class)
 @TestPropertySource(properties = "spring.profiles.active=testing")
 @AutoConfigureTestDatabase(replace = Replace.ANY)
+@Sql(scripts = "/database/AgencyDatabase.sql")
 public class AgencyServiceIT extends AgencyServiceITBase {
+
+  /**
+   * Without this the suite reaches the real TenantService on localhost:8089 and fails with
+   * "Connection refused" (#205). The tenant-aware sibling already mocks it.
+   */
+  @MockitoBean
+  private TenantService tenantService;
 
   @Test
   public void getAgencies_Should_returnMatchingAgencies_When_postcodeAndConsultingTypeIsGiven()

--- a/src/test/java/de/caritas/cob/agencyservice/api/service/AgencyServiceITBase.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/service/AgencyServiceITBase.java
@@ -5,6 +5,8 @@ import java.util.Optional;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
 
 import de.caritas.cob.agencyservice.api.exception.MissingConsultingTypeException;
 import de.caritas.cob.agencyservice.api.manager.consultingtype.ConsultingTypeManager;
@@ -35,14 +37,22 @@ public class AgencyServiceITBase {
   @MockitoBean
   private TopicEnrichmentService topicEnrichmentService;
 
+  @Autowired
+  private PlatformTransactionManager transactionManager;
+
   public void getAgencies_Should_returnMatchingAgencies_When_postcodeAndConsultingTypeIsGiven()
       throws MissingConsultingTypeException {
 
     when(consultingTypeManager.getConsultingTypeSettings(CONSULTING_TYPE_PREGNANCY)).thenReturn(CONSULTING_TYPE_SETTINGS_PREGNANCY);
     String postCode = "88662";
 
-    List<FullAgencyResponseDTO> resultAgencies = agencyService
-        .getAgencies(Optional.of(postCode), CONSULTING_TYPE_PREGNANCY, Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
+    // The response mapping walks Agency.agencyTopics lazily. A real request has an open
+    // session for the whole request (open-in-view); a plain test method does not, so without
+    // this boundary the call dies with LazyInitializationException (#205).
+    List<FullAgencyResponseDTO> resultAgencies = new TransactionTemplate(transactionManager)
+        .execute(status -> agencyService.getAgencies(Optional.of(postCode),
+            CONSULTING_TYPE_PREGNANCY, Optional.empty(), Optional.empty(), Optional.empty(),
+            Optional.empty()));
 
     assertThat(resultAgencies, hasSize(1));
     FullAgencyResponseDTO resultAgency = resultAgencies.get(0);
@@ -77,11 +87,15 @@ public class AgencyServiceITBase {
     String postCode = "45501";
     Integer topicId = 1;
 
-    List<FullAgencyResponseDTO> resultAgencies = agencyService.getAgencies(postCode, topicId);
+    // Same lazy agencyTopics mapping as above — needs a session boundary (#205).
+    List<FullAgencyResponseDTO> resultAgencies = new TransactionTemplate(transactionManager)
+        .execute(status -> agencyService.getAgencies(postCode, topicId));
 
     assertThat(resultAgencies, hasSize(1));
     FullAgencyResponseDTO resultAgency = resultAgencies.get(0);
-    assertThat(resultAgency.getId(), is(14352L));
+    // 14352 is the AGENCY_POSTCODE_RANGE id covering 45501-45600; the agency it belongs to is
+    // 1735. The old expectation asserted the range id against an agency id (#205).
+    assertThat(resultAgency.getId(), is(1735L));
   }
 
 }

--- a/src/test/java/de/caritas/cob/agencyservice/api/service/AgencyServiceTenantAwareIT.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/service/AgencyServiceTenantAwareIT.java
@@ -31,6 +31,9 @@ import org.springframework.transaction.annotation.Transactional;
 @AutoConfigureTestDatabase(replace = Replace.ANY)
 @DirtiesContext(classMode = ClassMode.BEFORE_CLASS)
 @TestPropertySource(properties = "multitenancy.enabled=true")
+// AgencyDatabase.sql first: setTenants.sql only UPDATEs agency rows, so without the seed it
+// silently updated nothing and every read in the base fixture came back empty (#205).
+@Sql(value = "/database/AgencyDatabase.sql", executionPhase = ExecutionPhase.BEFORE_TEST_METHOD)
 @Sql(value = "/setTenants.sql", executionPhase = ExecutionPhase.BEFORE_TEST_METHOD)
 @Transactional(propagation = Propagation.NEVER)
 public class AgencyServiceTenantAwareIT extends AgencyServiceITBase {

--- a/src/test/java/de/caritas/cob/agencyservice/api/workflow/AgencyPurgeTransactionTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/workflow/AgencyPurgeTransactionTest.java
@@ -1,15 +1,10 @@
 package de.caritas.cob.agencyservice.api.workflow;
 
 import static org.mockito.Mockito.inOrder;
-import static org.mockito.Mockito.when;
 
-import com.google.common.collect.Lists;
 import de.caritas.cob.agencyservice.api.repository.agency.Agency;
 import de.caritas.cob.agencyservice.api.repository.agency.AgencyRepository;
 import de.caritas.cob.agencyservice.api.repository.agencypostcoderange.AgencyPostcodeRangeRepository;
-import de.caritas.cob.agencyservice.api.repository.agencytopic.AgencyTopic;
-import de.caritas.cob.agencyservice.api.repository.agencytopic.AgencyTopicRepository;
-import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -23,26 +18,25 @@ class AgencyPurgeTransactionTest {
 
   @Mock AgencyPostcodeRangeRepository agencyPostcodeRangeRepository;
 
-  @Mock AgencyTopicRepository agencyTopicRepository;
-
   @InjectMocks AgencyPurgeTransaction agencyPurgeTransaction;
 
+  /**
+   * Postcode ranges hold a RESTRICT foreign key on agency and are not cascaded by JPA, so they have
+   * to be removed first. Departments are not asserted here: they are removed by the {@code cascade =
+   * ALL, orphanRemoval = true} mapping on {@code Agency.agencyTopics}, which a mock-based unit test
+   * cannot observe — that ordering is Hibernate's, not this class's.
+   */
   @Test
-  void purge_Should_deleteAgencyTopicsAndPostcodeRangesBeforeTheAgency() {
-    // given — agency_topic holds a RESTRICT foreign key on agency and was never deleted
+  void purge_Should_deletePostcodeRangesBeforeTheAgency() {
+    // given
     var agency = new Agency();
     agency.setId(268L);
-    var agencyTopic = new AgencyTopic();
-    when(agencyTopicRepository.findAllByAgencyId(268L))
-        .thenReturn(Lists.newArrayList(agencyTopic));
 
     // when
     agencyPurgeTransaction.purge(agency);
 
     // then
-    var inOrder =
-        inOrder(agencyTopicRepository, agencyPostcodeRangeRepository, agencyRepository);
-    inOrder.verify(agencyTopicRepository).deleteAll(List.of(agencyTopic));
+    var inOrder = inOrder(agencyPostcodeRangeRepository, agencyRepository);
     inOrder.verify(agencyPostcodeRangeRepository).deleteAllByAgencyId(268L);
     inOrder.verify(agencyRepository).delete(agency);
   }

--- a/src/test/resources/database/AgencyDatabase.sql
+++ b/src/test/resources/database/AgencyDatabase.sql
@@ -1,11 +1,13 @@
 DROP TABLE IF EXISTS AGENCY_POSTCODE_RANGE;
 DROP TABLE IF EXISTS AGENCY_TOPIC;
+DROP TABLE IF EXISTS LEGAL_TEXT;
 DROP TABLE IF EXISTS AGENCY;
 DROP TABLE IF EXISTS AGENCY_ADMIN_CONTROL;
 DROP TABLE IF EXISTS DIOCESE;
 
 DROP SEQUENCE IF EXISTS SEQUENCE_AGENCY_POSTCODE_RANGE;
 DROP SEQUENCE IF EXISTS SEQUENCE_AGENCY_TOPIC;
+DROP SEQUENCE IF EXISTS SEQUENCE_LEGAL_TEXT;
 DROP SEQUENCE IF EXISTS SEQUENCE_AGENCY;
 DROP SEQUENCE IF EXISTS SEQUENCE_AGENCY_ADMIN_CONTROL;
 
@@ -67,6 +69,24 @@ CREATE SEQUENCE SEQUENCE_AGENCY_POSTCODE_RANGE
     START WITH 100000
     INCREMENT BY 1;
 
+-- ADR-014 (Liquibase changeset 0026_legal_text): legal texts are first-class shared
+-- objects owned by a Träger, referenced by departments instead of being inlined.
+create table LEGAL_TEXT
+(
+    ID                 bigint      not null,
+    TENANT_ID          bigint      null,
+    KIND               varchar(20) not null,
+    LABEL              varchar(255) not null,
+    CONTENT            longtext    null,
+    PUBLICATION_STATUS varchar(20) not null default 'DRAFT',
+    CREATE_DATE        timestamp,
+    UPDATE_DATE        timestamp,
+    primary key (ID)
+);
+CREATE SEQUENCE SEQUENCE_LEGAL_TEXT
+    START WITH 100000
+    INCREMENT BY 1;
+
 create table AGENCY_TOPIC
 (
     ID            bigint     not null,
@@ -78,8 +98,12 @@ create table AGENCY_TOPIC
     PUBLICATION_STATUS varchar(20) not null default 'DRAFT',
     CONTENT_IMPRINT longtext null,
     PUBLICATION_STATUS_IMPRINT varchar(20) not null default 'DRAFT',
+    DPP_ID        bigint     null,
+    IMPRINT_ID    bigint     null,
     primary key (ID),
-    foreign key (AGENCY_ID) references AGENCY (ID)
+    foreign key (AGENCY_ID) references AGENCY (ID),
+    foreign key (DPP_ID) references LEGAL_TEXT (ID),
+    foreign key (IMPRINT_ID) references LEGAL_TEXT (ID)
 );
 CREATE SEQUENCE SEQUENCE_AGENCY_TOPIC
     START WITH 100000


### PR DESCRIPTION
Promotes pre-dev into dev.

**Merge method: Create a merge commit — do NOT squash.** Squashing a pre-dev→dev promotion collapses the two-parent link and destroys ancestry, reintroducing phantom conflicts next time.