### PR TITLE
Allow Liquibase context override

### DIFF
--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -45,7 +45,7 @@ spring.jpa.hibernate.ddl-auto=validate
 # to the always-on structural changesets.
 spring.liquibase.change-log=classpath:db/changelog/agencyservice-master.xml
 spring.liquibase.enabled=${SPRING_LIQUIBASE_ENABLED:true}
-spring.liquibase.contexts=seed
+spring.liquibase.contexts=${SPRING_LIQUIBASE_CONTEXTS:seed}
 
 # ---------------- Local App Settings ----------------
 app.base.url=http://localhost:8084

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -49,7 +49,7 @@ spring.jpa.hibernate.ddl-auto=validate
 # until Helm package L3 lands.
 spring.liquibase.change-log=classpath:db/changelog/agencyservice-master.xml
 spring.liquibase.enabled=${SPRING_LIQUIBASE_ENABLED:true}
-spring.liquibase.contexts=production
+spring.liquibase.contexts=${SPRING_LIQUIBASE_CONTEXTS:production}
 
 # ---------------- Local App Settings ----------------
 app.base.url=http://localhost:8084

--- a/src/main/resources/application-staging.properties
+++ b/src/main/resources/application-staging.properties
@@ -48,7 +48,7 @@ spring.jpa.hibernate.ddl-auto=validate
 # Unlabelled structural changesets carry no context and therefore still run in every context.
 spring.liquibase.change-log=classpath:db/changelog/agencyservice-master.xml
 spring.liquibase.enabled=${SPRING_LIQUIBASE_ENABLED:true}
-spring.liquibase.contexts=production
+spring.liquibase.contexts=${SPRING_LIQUIBASE_CONTEXTS:production}
 
 # ---------------- Local App Settings ----------------
 app.base.url=http://localhost:8084


### PR DESCRIPTION
## Summary
- keep the service-owned agencyservice master changelog path in the image
- allow Helm/runtime to override Liquibase contexts via SPRING_LIQUIBASE_CONTEXTS
- preserve existing profile defaults when the env var is unset

## Validation
- mvn -q -DskipTests validate