### PR TITLE
Make the legacy integration quarantine green (#185)

### DIFF
--- a/src/main/java/de/caritas/cob/agencyservice/api/admin/validation/AgencyValidator.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/admin/validation/AgencyValidator.java
@@ -62,7 +62,8 @@ public class AgencyValidator {
   }
 
   private ValidateAgencyDTO fromUpdateAgencyDto(Long agencyId, UpdateAgencyDTO updateAgencyDTO) {
-    var existingAgency = agencyRepository.findById(agencyId).orElseThrow(() -> new BadRequestException("Agency with id " + agencyId + "not found!"));
+    var existingAgency = agencyRepository.findById(agencyId)
+        .orElseThrow(() -> new BadRequestException("Agency with id " + agencyId + " not found!"));
     return ValidateAgencyDTO.builder()
         .id(agencyId)
         .postcode(updateAgencyDTO.getPostcode())

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/service/agencypostcoderange/AgencyPostcodeRangeAdminServiceIT.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/service/agencypostcoderange/AgencyPostcodeRangeAdminServiceIT.java
@@ -1,7 +1,6 @@
 package de.caritas.cob.agencyservice.api.admin.service.agencypostcoderange;
 
 import de.caritas.cob.agencyservice.AgencyServiceApplication;
-import de.caritas.cob.agencyservice.api.exception.httpresponses.NotFoundException;
 import de.caritas.cob.agencyservice.api.repository.agencypostcoderange.AgencyPostcodeRangeRepository;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -41,9 +40,9 @@ public class AgencyPostcodeRangeAdminServiceIT extends AgencyPostcodeRangeAdminS
     super.deleteAgencyPostcodeRange_Should_deletePostcodeRange_When_agencyIdExists();
   }
 
-  @Test(expected = NotFoundException.class)
-  public void deleteAgencyPostcodeRange_Should_throwNotFound_When_agencyIdNotExists() {
-    super.deleteAgencyPostcodeRange_Should_throwNotFound_When_agencyIdNotExists();
+  @Test
+  public void deleteAgencyPostcodeRange_Should_beNoOp_When_agencyIdNotExists() {
+    super.deleteAgencyPostcodeRange_Should_beNoOp_When_agencyIdNotExists();
   }
 
 }

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/service/agencypostcoderange/AgencyPostcodeRangeAdminServiceITBase.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/service/agencypostcoderange/AgencyPostcodeRangeAdminServiceITBase.java
@@ -49,10 +49,18 @@ public class AgencyPostcodeRangeAdminServiceITBase {
     assertThat(this.agencyPostcodeRangeRepository.findAllByAgencyId(agencyId), hasSize(0));
   }
 
-  public void deleteAgencyPostcodeRange_Should_throwNotFound_When_agencyIdNotExists() {
+  /**
+   * Deleting the ranges of an unknown agency is an idempotent no-op: the service is a single
+   * {@code deleteAllByAgencyId} with no existence check (the offline side effect and its lookup
+   * were removed on purpose, #66). The contract is "the agency has no ranges afterwards", which
+   * holds whether or not it ever existed — so this must not throw (#210).
+   */
+  public void deleteAgencyPostcodeRange_Should_beNoOp_When_agencyIdNotExists() {
     var agencyId = -1L;
 
     this.agencyPostcodeRangeAdminService.deleteAgencyPostcodeRange(agencyId);
+
+    assertThat(this.agencyPostcodeRangeRepository.findAllByAgencyId(agencyId), hasSize(0));
   }
 
 }

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/service/agencypostcoderange/AgencyPostcodeRangeAdminServiceTenantAwareIT.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/service/agencypostcoderange/AgencyPostcodeRangeAdminServiceTenantAwareIT.java
@@ -80,8 +80,8 @@ public class AgencyPostcodeRangeAdminServiceTenantAwareIT extends AgencyPostcode
   }
 
   @Test
-  public void deleteAgencyPostcodeRange_Should_accept_When_agencyIdNotExists() {
-    super.deleteAgencyPostcodeRange_Should_throwNotFound_When_agencyIdNotExists();
+  public void deleteAgencyPostcodeRange_Should_beNoOp_When_agencyIdNotExists() {
+    super.deleteAgencyPostcodeRange_Should_beNoOp_When_agencyIdNotExists();
   }
 
 }

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/validation/AgencyValidatorIT.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/validation/AgencyValidatorIT.java
@@ -6,6 +6,7 @@ import static de.caritas.cob.agencyservice.testHelper.TestConstants.INVALID_CONS
 import static de.caritas.cob.agencyservice.testHelper.TestConstants.INVALID_POSTCODE;
 import static de.caritas.cob.agencyservice.testHelper.TestConstants.VALID_POSTCODE;
 import static java.util.Collections.singletonList;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
@@ -22,10 +23,14 @@ import de.caritas.cob.agencyservice.api.util.AuthenticatedUser;
 import de.caritas.cob.agencyservice.api.manager.consultingtype.ConsultingTypeManager;
 import de.caritas.cob.agencyservice.api.model.AgencyDTO;
 import de.caritas.cob.agencyservice.api.model.UpdateAgencyDTO;
+import de.caritas.cob.agencyservice.api.service.TenantService;
 import de.caritas.cob.agencyservice.consultingtypeservice.generated.web.model.ExtendedConsultingTypeResponseDTO;
 import de.caritas.cob.agencyservice.consultingtypeservice.generated.web.model.WhiteSpotDTO;
+import de.caritas.cob.agencyservice.tenantservice.generated.web.model.RestrictedTenantDTO;
+import de.caritas.cob.agencyservice.tenantservice.generated.web.model.Settings;
 import de.caritas.cob.agencyservice.useradminservice.generated.web.model.ConsultantAdminResponseDTO;
 import org.jeasy.random.EasyRandom;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -36,6 +41,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.junit4.SpringRunner;
 
 @RunWith(SpringRunner.class)
@@ -43,6 +49,10 @@ import org.springframework.test.context.junit4.SpringRunner;
 @TestPropertySource(properties = "spring.profiles.active=testing")
 @AutoConfigureTestDatabase(replace = Replace.ANY)
 @DirtiesContext(classMode = ClassMode.BEFORE_CLASS)
+// The four update-path tests validate an EXISTING agency, so the validator has to be able to load
+// it. Without the seed every one of them dies in AgencyValidator.fromUpdateAgencyDto with
+// "Agency with id 1 not found!" and never reaches the rule it is meant to exercise (#208).
+@Sql(scripts = "/database/AgencyDatabase.sql")
 public class AgencyValidatorIT {
 
   @Autowired
@@ -56,6 +66,21 @@ public class AgencyValidatorIT {
 
   @MockitoBean
   private AuthenticatedUser authenticatedUser;
+
+  /**
+   * The update path runs AgencyDataProtectionValidator, which asks the TenantService whether the
+   * central data-protection template is enabled. Unmocked that is a live call to localhost:8089
+   * and every update test dies with a 400 before reaching its own rule (same cause as #205).
+   */
+  @MockitoBean
+  private TenantService tenantService;
+
+  @Before
+  public void setupTenantSettings() {
+    when(tenantService.getRestrictedTenantDataByTenantId(any()))
+        .thenReturn(new RestrictedTenantDTO()
+            .settings(new Settings().featureCentralDataProtectionTemplateEnabled(false)));
+  }
 
   @Test(expected = InvalidPostcodeException.class)
   public void validate_Should_ThrowInvalidPostcodeException_WhenCreateAndAgencyPostcodeIsInvalid() {

--- a/src/test/java/de/caritas/cob/agencyservice/api/controller/AgencyAdminControllerDataProtectionValidationIT.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/controller/AgencyAdminControllerDataProtectionValidationIT.java
@@ -1,0 +1,153 @@
+package de.caritas.cob.agencyservice.api.controller;
+
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import de.caritas.cob.agencyservice.api.admin.service.UserAdminService;
+import de.caritas.cob.agencyservice.api.manager.consultingtype.ConsultingTypeManager;
+import de.caritas.cob.agencyservice.api.model.DataProtectionContactDTO;
+import de.caritas.cob.agencyservice.api.model.DataProtectionDTO;
+import de.caritas.cob.agencyservice.api.model.UpdateAgencyDTO;
+import de.caritas.cob.agencyservice.api.repository.agency.AgencyRepository;
+import de.caritas.cob.agencyservice.api.service.TenantService;
+import de.caritas.cob.agencyservice.api.service.TopicEnrichmentService;
+import de.caritas.cob.agencyservice.api.tenant.TenantContext;
+import de.caritas.cob.agencyservice.api.util.AuthenticatedUser;
+import de.caritas.cob.agencyservice.api.util.JsonConverter;
+import de.caritas.cob.agencyservice.consultingtypeservice.generated.web.model.ExtendedConsultingTypeResponseDTO;
+import de.caritas.cob.agencyservice.tenantservice.generated.web.model.RestrictedTenantDTO;
+import de.caritas.cob.agencyservice.tenantservice.generated.web.model.Settings;
+import de.caritas.cob.agencyservice.testHelper.PathConstants;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.context.WebApplicationContext;
+
+/**
+ * Data-protection validation on the agency update path, with the ADR-003 requirement switched ON.
+ *
+ * <p>The {@code testing} profile sets {@code agency.department.require-dpo-contact=false} — the
+ * deliberate "dev mode" from ADR-003 that lets the other suites create agencies without a complete
+ * DPO contact. That switch made the rule unreachable, which is why this assertion sat red in the
+ * #185 quarantine: it expected a 400 from a validator that returns early under the profile it runs
+ * in. It was a test-configuration defect, not the production validation gap #209 suspected.
+ *
+ * <p>Pinning the property to {@code true} here is what production actually runs, so the rule is now
+ * covered at IT level for the first time. Kept as its own class because the property is
+ * context-level: flipping it inside {@link AgencyAdminControllerIT} would change every other test
+ * in that suite.
+ */
+@SpringBootTest
+@ActiveProfiles("testing")
+@TestPropertySource(properties = {"feature.topics.enabled=false",
+    "agency.department.require-dpo-contact=true"})
+@AutoConfigureMockMvc(addFilters = false)
+@Transactional
+@Sql(scripts = "/database/AgencyDatabase.sql")
+class AgencyAdminControllerDataProtectionValidationIT {
+
+  private static final String CSRF_TOKEN = "test";
+
+  private MockMvc mockMvc;
+
+  @Autowired
+  private WebApplicationContext context;
+
+  @Autowired
+  private AgencyRepository agencyRepository;
+
+  @MockitoBean
+  private ConsultingTypeManager consultingTypeManager;
+
+  @MockitoBean
+  private TopicEnrichmentService topicEnrichmentService;
+
+  @MockitoBean
+  private AuthenticatedUser authenticatedUser;
+
+  @MockitoBean
+  private UserAdminService userAdminService;
+
+  @MockitoBean
+  private TenantService tenantService;
+
+  @BeforeEach
+  void setup() throws Exception {
+    TenantContext.clear();
+    mockMvc = MockMvcBuilders.webAppContextSetup(context).apply(springSecurity()).build();
+    when(consultingTypeManager.getConsultingTypeSettings(anyInt()))
+        .thenReturn(new ExtendedConsultingTypeResponseDTO());
+    when(authenticatedUser.getTenantId()).thenReturn(1L);
+    // Central data protection ON: the branch that delegates to the validation service.
+    when(tenantService.getRestrictedTenantDataByTenantId(Mockito.any()))
+        .thenReturn(new RestrictedTenantDTO()
+            .settings(new Settings().featureCentralDataProtectionTemplateEnabled(true)));
+  }
+
+  private MockHttpServletRequestBuilder withCsrf(MockHttpServletRequestBuilder builder) {
+    return builder.cookie(new Cookie("CSRF-TOKEN", CSRF_TOKEN)).header("X-CSRF-TOKEN", CSRF_TOKEN);
+  }
+
+  private UpdateAgencyDTO updateWithDataProtection(DataProtectionDTO dataProtection) {
+    return new UpdateAgencyDTO()
+        .name("Test update name")
+        .description(null)
+        .offline(true)
+        .external(false)
+        .dataProtection(dataProtection);
+  }
+
+  @Test
+  @WithMockUser(authorities = "AUTHORIZATION_AGENCY_ADMIN")
+  void updateAgency_Should_returnStatusBadRequest_When_CentralDataProtectionIsEnabled_And_PayloadContainsInvalidDataProtectionContent()
+      throws Exception {
+    var agencyDTO = updateWithDataProtection(new DataProtectionDTO()
+        .dataProtectionResponsibleEntity(
+            DataProtectionDTO.DataProtectionResponsibleEntityEnum.DATA_PROTECTION_OFFICER)
+        .dataProtectionOfficerContact(new DataProtectionContactDTO()));
+
+    mockMvc.perform(withCsrf(put(PathConstants.UPDATE_DELETE_AGENCY_PATH)
+            .contentType(APPLICATION_JSON)
+            .content(JsonConverter.convertToJson(agencyDTO))))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  @WithMockUser(authorities = "AUTHORIZATION_AGENCY_ADMIN")
+  void updateAgency_Should_returnSuccess_When_DataProtectionOfficerContactIsComplete()
+      throws Exception {
+    var agencyDTO = updateWithDataProtection(new DataProtectionDTO()
+        .dataProtectionResponsibleEntity(
+            DataProtectionDTO.DataProtectionResponsibleEntityEnum.DATA_PROTECTION_OFFICER)
+        .dataProtectionOfficerContact(new DataProtectionContactDTO()
+            .nameAndLegalForm("Caritasverband e. V.")
+            .city("Mainz")
+            .postcode("55116")
+            .email("datenschutz@example.org")));
+
+    mockMvc.perform(withCsrf(put(PathConstants.UPDATE_DELETE_AGENCY_PATH)
+            .contentType(APPLICATION_JSON)
+            .content(JsonConverter.convertToJson(agencyDTO))))
+        .andExpect(status().isOk());
+
+    var savedAgency = agencyRepository.findById(1L).orElseThrow();
+    org.junit.jupiter.api.Assertions.assertEquals("Test update name", savedAgency.getName());
+  }
+}

--- a/src/test/java/de/caritas/cob/agencyservice/api/controller/AgencyAdminControllerIT.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/controller/AgencyAdminControllerIT.java
@@ -361,31 +361,10 @@ class AgencyAdminControllerIT {
     assertNull(savedAgency.getDescription());
   }
 
-  @Test
-  @WithMockUser(authorities = "AUTHORIZATION_AGENCY_ADMIN")
-  void updateAgency_Should_returnStatusBadRequest_When_CentralDataProtectionIsEnabled_And_PayloadContainsInvalidDataProtectionContent() throws Exception {
-    var response = new ExtendedConsultingTypeResponseDTO();
-
-    Long tenantId = agencyRepository.findById(1L).get().getTenantId();
-    when(consultingTypeManager.getConsultingTypeSettings(anyInt())).thenReturn(response);
-
-    when(tenantService.getRestrictedTenantDataByTenantId(tenantId))
-        .thenReturn(new de.caritas.cob.agencyservice.tenantservice.generated.web.model.RestrictedTenantDTO().settings(new Settings().featureCentralDataProtectionTemplateEnabled(true)));
-
-    var agencyDTO = new UpdateAgencyDTO()
-        .name("Test update name")
-        .description(null)
-        .offline(true)
-        .external(false)
-        .dataProtection(new DataProtectionDTO().dataProtectionResponsibleEntity(DataProtectionDTO.DataProtectionResponsibleEntityEnum.DATA_PROTECTION_OFFICER)
-            .dataProtectionOfficerContact(new DataProtectionContactDTO()));
-
-
-    mockMvc.perform(withCsrf(put(PathConstants.UPDATE_DELETE_AGENCY_PATH)
-            .contentType(APPLICATION_JSON)
-            .content(JsonConverter.convertToJson(agencyDTO))))
-        .andExpect(status().isBadRequest());
-  }
+  // The "invalid data-protection content is rejected" case moved to
+  // AgencyAdminControllerDataProtectionValidationIT (#209): the rule it asserts is switched OFF in
+  // the testing profile by ADR-003 dev mode (agency.department.require-dpo-contact=false), so it
+  // could never pass here. That suite pins the property to the production value instead.
 
   @Test
   @WithMockUser(authorities = "AUTHORIZATION_AGENCY_ADMIN")


### PR DESCRIPTION
## Why
The job `legacy integration quarantine (#185, expires 2026-09-30)` fails on every PR view — including on `pre-dev` itself (d4397c4) and on #246 and #243. It is non-blocking, but it puts a red X on green PRs; @shazia-k asked about exactly this on #246 today.

**The scope was much smaller than the quarantine metadata suggested.** #185 still quotes 29 failures / 51 errors, and the briefing for this work said ~19/86. The actual current CI run is **221 tests, 2 failures, 4 errors in 3 suites** — the earlier clusters were already fixed by #199 and #203–#206. Reproduced locally, identical profile.

## Failure taxonomy

| # | Root cause | Suite | Red | Treatment |
| --- | --- | --- | --- | --- |
| 1 | Suite has no `@Sql` fixture, so the agency under test was never seeded — all four update-path tests die in `AgencyValidator.fromUpdateAgencyDto` before reaching their own rule. Seeding then exposed a second, masked cause: `AgencyDataProtectionValidator` makes a live `TenantService` call to `localhost:8089` (same cause as #205). | `AgencyValidatorIT` | 4 errors | **Repaired** — added the `AgencyDatabase.sql` fixture and a `TenantService` stub, like the sibling suites |
| 2 | Test asserts a rule its own profile switches off: the `testing` profile sets `agency.department.require-dpo-contact=false` (ADR-003 dev mode), so the validator returns early and the update is accepted with 200. | `AgencyAdminControllerIT` | 1 failure | **Repaired** — moved into a new `AgencyAdminControllerDataProtectionValidationIT` that pins the property to the production value |
| 3 | Stale expectation: `deleteAgencyPostcodeRange` is a bare `deleteAllByAgencyId` with no existence check — the lookup went with the offline side effect #66 removed on purpose. The tenant-aware sibling had already been renamed to `..._accept_...` but still called the `throwNotFound` base method, so two suites asserted opposite contracts from one shared base. | `AgencyPostcodeRangeAdminServiceIT` | 1 failure | **Updated** — one honestly named base method asserting the idempotent no-op |

Three causes, all test-side. **Nothing was excluded, disabled or tagged, and no production code was changed to make a test pass.** The job is green because the tests are green.

## Repaired vs excluded
- Repaired: 6 tests across 3 suites (clusters 1–3 above).
- Excluded / `@Disabled`: **none** — no cluster needed infrastructure CI cannot provide.
- Production changes: exactly one, cosmetic and unrelated to any assertion — the missing space in `"Agency with id 1not found!"` (`AgencyValidator`), which #208 asked for. No test asserted the malformed string.
- Net test count: 221 → 222 (one misconfigured test replaced by two that pass for the right reason, so the ADR-003 DPO rule now has IT coverage for the first time).

**#209 resolution, stated explicitly as that issue requires:** this was a **test-configuration defect, not a production validation gap**. The rule works — the new suite proves it rejects an incomplete DPO contact with 400 and accepts a complete one with 200 when `require-dpo-contact=true`, which is what production runs.

I deliberately did **not** touch `api/agencyadminservice.yaml`: the `$ref` + `type: object` generator errors @shazia-k flagged on #246 are hers to fix, and they are log noise that never failed this build.

## Verification
`./mvnw -B -fae verify` (the exact command the quarantine job runs), JDK 21, twice consecutively:
- 576 unit tests, 0 failures, 0 errors
- 222 integration tests, 0 failures, 0 errors, 2 skipped (pre-existing)
- checkstyle `google_checks_light.xml` clean, BUILD SUCCESS

The quarantine job itself is untouched — not deleted, not forced green. It should simply go green on this branch. Deciding whether to retire the job and its 2026-09-30 deadline belongs to #185 once it has been green on `pre-dev` for the required consecutive runs.

## Reviewer test plan
- [ ] `./mvnw -B -fae verify` locally on this branch is green (JDK 21)
- [ ] The `legacy integration quarantine (#185, ...)` check on this PR is green
- [ ] `AgencyValidatorIT`: 8/8, and the two negative tests fail for their own reason when broken deliberately, not for a missing agency
- [ ] `AgencyAdminControllerDataProtectionValidationIT`: incomplete DPO contact → 400, complete → 200
- [ ] `AgencyPostcodeRangeAdminServiceIT` / `...TenantAwareIT`: both assert the same idempotent-delete contract
- [ ] Confirm you agree the idempotent no-op is the intended contract for deleting ranges of an unknown agency (#210)

Refs #185, #208, #209, #210. Same red check seen on #246 and #243.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
