### PR TITLE
Legal-text version history, consent text and server-side inheritance (ADR-021)

### DIFF
--- a/api/agencyadminservice.yaml
+++ b/api/agencyadminservice.yaml
@@ -632,6 +632,141 @@ paths:
       security:
         - Bearer: [ ]
 
+  /agencyadmin/agencies/{agencyId}/topics/{topicId}/legal-versions:
+    get:
+      tags:
+        - admin-agency-controller
+      summary: >-
+        The publication history of a department's (Fachbereich = agency x topic) data privacy
+        policy or imprint, newest first (ADR-021 decision 3). Each entry is an immutable snapshot
+        of the wording as published, with who published it and when, and until when it was in
+        force (supersededAt null = still in force). A draft-save creates no entry.
+        [Authorization: Role: agency-admin or restricted-agency-admin scoped to its own agencies]
+      operationId: getDepartmentLegalTextVersions
+      parameters:
+        - name: agencyId
+          in: path
+          description: Agency Id (Beratungszentrum)
+          required: true
+          schema:
+            type: integer
+            format: int64
+        - name: topicId
+          in: path
+          description: Topic Id (Fachbereich)
+          required: true
+          schema:
+            type: integer
+            format: int64
+        - name: kind
+          in: query
+          description: Which document's history to list
+          required: true
+          schema:
+            type: string
+            enum: [ DPP, IMPRINT ]
+      responses:
+        200:
+          description: OK - publication history, newest first (empty if never published)
+          content:
+            'application/json':
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/LegalTextVersionDTO'
+        400:
+          description: BAD REQUEST - caller may not access this agency
+        401:
+          description: UNAUTHORIZED - no/invalid role/authorization
+        404:
+          description: NOT FOUND - department (agency x topic) not found
+        500:
+          description: INTERNAL SERVER ERROR - server encountered unexpected condition
+      security:
+        - Bearer: [ ]
+
+  /agencyadmin/agencies/{agencyId}/legal-versions:
+    get:
+      tags:
+        - admin-agency-controller
+      summary: >-
+        The publication history of a Beratungsstelle's agency-wide data privacy policy or imprint,
+        newest first (ADR-021 decision 3). The agency level carries no publication status ("what is
+        stored, applies"), so a save is a publish there and every agency update that changes the
+        wording adds an entry; an update that leaves it unchanged does not.
+        [Authorization: Role: agency-admin or restricted-agency-admin scoped to its own agencies]
+      operationId: getAgencyLegalTextVersions
+      parameters:
+        - name: agencyId
+          in: path
+          description: Agency Id (Beratungszentrum)
+          required: true
+          schema:
+            type: integer
+            format: int64
+        - name: kind
+          in: query
+          description: Which document's history to list
+          required: true
+          schema:
+            type: string
+            enum: [ DPP, IMPRINT ]
+      responses:
+        200:
+          description: OK - publication history, newest first (empty if never published)
+          content:
+            'application/json':
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/LegalTextVersionDTO'
+        400:
+          description: BAD REQUEST - caller may not access this agency
+        401:
+          description: UNAUTHORIZED - no/invalid role/authorization
+        404:
+          description: NOT FOUND - agency not found
+        500:
+          description: INTERNAL SERVER ERROR - server encountered unexpected condition
+      security:
+        - Bearer: [ ]
+
+  /agencyadmin/legal-versions/{versionId}:
+    get:
+      tags:
+        - admin-agency-controller
+      summary: >-
+        One archived legal-text version, verbatim (ADR-021 decision 3). Authorization is derived
+        from the version's stored owner, so a version id is not a capability for another
+        Beratungsstelle's or Träger's document.
+        [Authorization: Role: agency-admin or restricted-agency-admin scoped to its own agencies]
+      operationId: getLegalTextVersion
+      parameters:
+        - name: versionId
+          in: path
+          description: Surrogate id of the archived version
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        200:
+          description: OK - the archived version
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/LegalTextVersionDTO'
+        400:
+          description: BAD REQUEST - caller may not access this version's owner
+        401:
+          description: UNAUTHORIZED - no/invalid role/authorization
+        404:
+          description: NOT FOUND - version not found
+        500:
+          description: INTERNAL SERVER ERROR - server encountered unexpected condition
+      security:
+        - Bearer: [ ]
+
   /agencyadmin/agencies/{agencyId}/topics/{topicId}/imprint:
     get:
       tags:
@@ -1647,6 +1782,59 @@ components:
           type: integer
           format: int64
           description: How many departments currently reference this text
+
+    LegalTextVersionDTO:
+      type: object
+      description: >
+        One immutable snapshot of a legal text as it was published (ADR-021 decision 3).
+
+        Identity is the surrogate `id`, never `publishedAt`: MariaDB `datetime` has no sub-second
+        precision, and keying versions by their timestamp is what forced the AVV work to truncate
+        to seconds and made equality matches fail silently.
+      required:
+        - id
+        - kind
+        - ownerLevel
+        - ownerId
+        - publishedAt
+      properties:
+        id:
+          type: integer
+          format: int64
+          description: Surrogate identity of this version — the only key clients should use
+        kind:
+          type: string
+          enum: [ DPP, IMPRINT ]
+        ownerLevel:
+          type: string
+          description: >
+            Which level of the ADR-021 ladder this document belongs to. DEPARTMENT = Fachbereich
+            (agency_topic), AGENCY = Beratungsstelle, SHARED = an ADR-014 shared legal-text object.
+            The Träger and platform-operator levels live in ORISO-TenantService.
+          enum: [ DEPARTMENT, AGENCY, SHARED ]
+        ownerId:
+          type: integer
+          format: int64
+          description: Id of the owning row, interpreted per ownerLevel
+        content:
+          type: string
+          nullable: true
+          description: The wording as published, verbatim - a JSON language->HTML map string
+        publishedAt:
+          type: string
+          description: When this wording came into force
+          example: "2026-08-16T13:12:08"
+        publishedBy:
+          type: string
+          nullable: true
+          description: >
+            Keycloak user id of the publisher, or null where no authenticated publisher was
+            recorded. Null is an honest unknown, never a guessed value (#212).
+        supersededAt:
+          type: string
+          nullable: true
+          description: When a newer version replaced this one; null = still in force
+          example: "2026-09-01T09:00:00"
 
     CreateLegalTextDTO:
       type: object

--- a/api/agencyadminservice.yaml
+++ b/api/agencyadminservice.yaml
@@ -1380,6 +1380,23 @@ components:
           additionalProperties:
             type: string
           example: { "de": "<p>Impressum</p>" }
+        consentText:
+          type: object
+          description: >
+            ADR-021 decision 4: the consent sentence belonging to the agency-wide data privacy
+            policy, per language code. Not a document of its own — it shares the policy's history.
+
+            Tokens use the `{{key}}` dialect, never Freemarker `${key}`: Träger-authored text must
+            never reach a template engine that can invoke object methods. `{{Beratungsstelle}}` and
+            `{{Thema}}` are substituted server-side, `{{legal_links}}` is left standing for the
+            client, which owns the link targets.
+
+            A stored sentence must contain `{{legal_links}}`; publishing one without it is rejected
+            with a 400. The cookie/authentication notice is NOT part of this text — it is a fixed
+            addendum rendered by the client.
+          additionalProperties:
+            type: string
+          example: { "de": "Ich habe die {{legal_links}} gelesen." }
 
     DataProtectionDTO:
         type: object
@@ -1775,6 +1792,13 @@ components:
           type: string
           nullable: true
           description: Stored multilingual content as a JSON language->HTML map string
+        consentText:
+          type: string
+          nullable: true
+          description: >
+            For DPP texts, the consent sentence stored with the policy (ADR-021 decision 4), as a
+            JSON language->text map string. Always null for imprints, which are an information duty
+            and never consent-bearing.
         publicationStatus:
           type: string
           enum: [ DRAFT, PUBLISHED ]
@@ -1820,6 +1844,14 @@ components:
           type: string
           nullable: true
           description: The wording as published, verbatim - a JSON language->HTML map string
+        consentText:
+          type: string
+          nullable: true
+          description: >
+            The consent sentence as published alongside the policy (ADR-021 decision 4), a JSON
+            language->text map string. Null for imprints and for policies without one. Changing
+            only the consent wording still produces a new version whose body may be identical —
+            that is the point: one version pointer covers both.
         publishedAt:
           type: string
           description: When this wording came into force
@@ -1854,6 +1886,14 @@ components:
             Keys with the __meta suffix carry JSON translation metadata instead of HTML.
           additionalProperties:
             type: string
+        consentText:
+          type: object
+          description: >
+            DPP only: the consent sentence stored with this policy (ADR-021 decision 4), per
+            language code. Publishing a sentence without the `{{legal_links}}` token is rejected
+            with a 400.
+          additionalProperties:
+            type: string
         publish:
           type: boolean
           description: 'true = mark PUBLISHED; false/absent = keep as DRAFT'
@@ -1871,6 +1911,14 @@ components:
           type: object
           description: Language code (e.g. de, en) to HTML text (multilingual map).
             Keys with the __meta suffix carry JSON translation metadata instead of HTML.
+          additionalProperties:
+            type: string
+        consentText:
+          type: object
+          description: >
+            DPP only: the consent sentence stored with this policy (ADR-021 decision 4), per
+            language code. Publishing a sentence without the `{{legal_links}}` token is rejected
+            with a 400.
           additionalProperties:
             type: string
         publish:
@@ -1939,6 +1987,28 @@ components:
           example:
             de: '<p>Datenschutzerklärung des Fachbereichs ...</p>'
             en: '<p>Data privacy policy of the department ...</p>'
+        consentText:
+          type: object
+          description: >
+            ADR-021 decision 4: the consent sentence a help-seeker ticks, stored WITH this policy
+            rather than as a legal text of its own, per language code. It therefore shares this
+            policy's publication status and its version history.
+
+            Tokens use the `{{key}}` dialect, never Freemarker `${key}` — Träger-authored text must
+            never reach a template engine where `${...}` can invoke object methods (ADR-021
+            decision 6). `{{Beratungsstelle}}` and `{{Thema}}` are substituted server-side;
+            `{{legal_links}}` is left standing for the client, which owns the link targets.
+
+            Publishing a sentence that does not contain `{{legal_links}}` is rejected with a 400:
+            that validator, not a legal stacking rule, is what keeps the platform's mandatory
+            disclosures reachable when a Träger replaces the default sentence.
+
+            Omit or send empty to keep the platform's default sentence. The cookie/authentication
+            notice is not part of this text and is never stored.
+          additionalProperties:
+            type: string
+          example:
+            de: 'Ich habe die {{legal_links}} der {{Beratungsstelle}} gelesen.'
         publish:
           type: boolean
           description: 'true = mark PUBLISHED (final legal document); false/absent = keep as DRAFT (draft-save)'
@@ -1965,6 +2035,12 @@ components:
           type: string
           nullable: true
           description: Stored multilingual content as a JSON language->HTML map string; null if never authored
+        consentText:
+          type: string
+          nullable: true
+          description: >
+            Stored consent sentence as a JSON language->text map string; null when the Träger
+            authored none, in which case the platform's default sentence applies.
         publicationStatus:
           type: string
           description: Current publication status of the department's data privacy policy

--- a/api/agencyservice.yaml
+++ b/api/agencyservice.yaml
@@ -175,9 +175,24 @@ paths:
     get:
       tags:
         - agency-controller
-      summary: 'Returns the published legal texts (data privacy policy and imprint) of a
-        department (agency x topic). Draft or never-authored texts are returned as null content -
-        drafts are never exposed to users. [Authorization: none]'
+      summary: >-
+        Returns the legal texts in force for a department (Fachbereich = agency x topic), resolved
+        server-side across all four ADR-021 levels (Fachbereich -> Beratungsstelle -> Träger ->
+        platform operator) and with the server-owned placeholders already substituted.
+
+        Drafts are never exposed: a Fachbereich still drafting falls through to the level above
+        rather than blanking out a legally required document.
+
+        `{{Beratungsstelle}}` and `{{Thema}}` are substituted here; `{{legal_links}}` is left
+        standing on purpose, because the link targets come from the frontend deployment
+        configuration and the backend does not know them (ADR-021 decision 5). Any token that
+        remains is the client's half of the substitution.
+
+        Each text reports the level it was resolved from and, for the levels whose history
+        AgencyService owns, the id of the published version it corresponds to. That version id is
+        what a consuming service pins a recorded consent to (ORISO-UserService
+        `session.consented_legal_version_id`, ADR-022 decision 2).
+        [Authorization: none]
       operationId: getDepartmentLegal
       parameters:
         - name: agencyId
@@ -376,8 +391,41 @@ components:
         content:
           type: string
           nullable: true
-          description: Published multilingual content as a JSON language->HTML map string;
-            null when the text is a draft or was never authored (drafts are never exposed)
+          description: >-
+            The wording in force as a JSON language->HTML map string, with the server-owned
+            placeholders already substituted. Null when nothing is authored on any of the four
+            levels. Drafts are never exposed.
+        consentText:
+          type: string
+          nullable: true
+          description: >-
+            The consent sentence stored with the data privacy policy (ADR-021 decision 4), as a
+            JSON language->text map string with `{{Beratungsstelle}}` / `{{Thema}}` substituted and
+            `{{legal_links}}` left for the client. Always null on the imprint, which is an
+            information duty and never a consent gate (decision 7), and null when the Träger
+            authored no sentence — the platform's default then applies.
+
+            The cookie/authentication notice is NOT part of this text: it is a fixed, non-editable
+            addendum the client renders beneath the sentence.
+        sourceLevel:
+          type: string
+          nullable: true
+          description: >-
+            Which rung of the ADR-021 ladder this wording came from. "The privacy policy" without a
+            level is not a valid statement (decision 1), so the level is always reported.
+            NONE = nothing is authored anywhere on the chain.
+          enum: [ DEPARTMENT, AGENCY, TENANT, PLATFORM, NONE ]
+        versionId:
+          type: integer
+          format: int64
+          nullable: true
+          description: >-
+            Id of the `legal_text_version` snapshot this wording corresponds to. Null for the
+            Träger and platform levels, whose history lives in ORISO-TenantService rather than here.
+
+            This is the identifier a consuming service pins a recorded consent to
+            (ORISO-UserService `session.consented_legal_version_id`, ADR-022 decision 2) — without
+            it, "is this room cleared for the version currently in force" cannot be answered.
 
     AgencyTopicsDTO:
       type: object

--- a/src/main/java/de/caritas/cob/agencyservice/api/admin/controller/AgencyAdminController.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/admin/controller/AgencyAdminController.java
@@ -12,6 +12,7 @@ import de.caritas.cob.agencyservice.api.admin.service.department.DepartmentDetai
 import de.caritas.cob.agencyservice.api.admin.service.legal.DepartmentDataProtectionService;
 import de.caritas.cob.agencyservice.api.admin.service.legal.DepartmentImprintService;
 import de.caritas.cob.agencyservice.api.admin.service.legal.LegalTextAdminService;
+import de.caritas.cob.agencyservice.api.admin.service.legal.LegalTextVersionAdminService;
 import de.caritas.cob.agencyservice.api.repository.legaltext.LegalTextKind;
 import de.caritas.cob.agencyservice.api.admin.validation.AgencyValidator;
 import de.caritas.cob.agencyservice.api.exception.httpresponses.BadRequestException;
@@ -23,6 +24,7 @@ import de.caritas.cob.agencyservice.api.model.AgencyIdResponseDTO;
 import de.caritas.cob.agencyservice.api.model.CreateLegalTextDTO;
 import de.caritas.cob.agencyservice.api.model.LegalTextAdminDTO;
 import de.caritas.cob.agencyservice.api.model.LegalTextAssignmentDTO;
+import de.caritas.cob.agencyservice.api.model.LegalTextVersionDTO;
 import de.caritas.cob.agencyservice.api.model.UpdateLegalTextDTO;
 import de.caritas.cob.agencyservice.api.model.AgencyAdminFullResponseDTO;
 import de.caritas.cob.agencyservice.api.model.AgencyAdminSearchResultDTO;
@@ -70,6 +72,7 @@ public class AgencyAdminController implements AgencyadminApi {
   private final @NonNull DepartmentDetailsService departmentDetailsService;
   private final @NonNull DepartmentImprintService departmentImprintService;
   private final @NonNull LegalTextAdminService legalTextAdminService;
+  private final @NonNull LegalTextVersionAdminService legalTextVersionAdminService;
   private final @NonNull AgencyIdAllocationService agencyIdAllocationService;
 
   /**
@@ -514,6 +517,50 @@ public class AgencyAdminController implements AgencyadminApi {
         LegalTextKind.valueOf(legalTextAssignmentDTO.getKind().getValue()),
         legalTextAssignmentDTO.getLegalTextId());
     return ResponseEntity.noContent().build();
+  }
+
+  /**
+   * ADR-021 decision 3: the publication history of one department's DPP or imprint, newest first.
+   * IDOR/tenant guards live in the service.
+   */
+  @Override
+  public ResponseEntity<List<LegalTextVersionDTO>> getDepartmentLegalTextVersions(
+      Long agencyId, Long topicId, String kind) {
+    var views =
+        legalTextVersionAdminService.listDepartmentVersions(
+            agencyId, topicId, LegalTextKind.valueOf(kind));
+    return ResponseEntity.ok(views.stream().map(this::toLegalTextVersionDto).toList());
+  }
+
+  /**
+   * ADR-021 decision 3 on the Beratungsstelle level, which has no publication status: every agency
+   * update that changes the stored wording is a publish there.
+   */
+  @Override
+  public ResponseEntity<List<LegalTextVersionDTO>> getAgencyLegalTextVersions(
+      Long agencyId, String kind) {
+    var views = legalTextVersionAdminService.listAgencyVersions(agencyId, LegalTextKind.valueOf(kind));
+    return ResponseEntity.ok(views.stream().map(this::toLegalTextVersionDto).toList());
+  }
+
+  /** One archived version, verbatim; authorised against the version's stored owner. */
+  @Override
+  public ResponseEntity<LegalTextVersionDTO> getLegalTextVersion(Long versionId) {
+    return ResponseEntity.ok(
+        toLegalTextVersionDto(legalTextVersionAdminService.getVersion(versionId)));
+  }
+
+  private LegalTextVersionDTO toLegalTextVersionDto(
+      de.caritas.cob.agencyservice.api.admin.service.legal.LegalTextVersionView view) {
+    return new LegalTextVersionDTO()
+        .id(view.id())
+        .kind(LegalTextVersionDTO.KindEnum.fromValue(view.kind().name()))
+        .ownerLevel(LegalTextVersionDTO.OwnerLevelEnum.fromValue(view.ownerLevel().name()))
+        .ownerId(view.ownerId())
+        .content(view.content())
+        .publishedAt(view.publishedAt() == null ? null : view.publishedAt().toString())
+        .publishedBy(view.publishedBy())
+        .supersededAt(view.supersededAt() == null ? null : view.supersededAt().toString());
   }
 
   private LegalTextAdminDTO toLegalTextAdminDto(

--- a/src/main/java/de/caritas/cob/agencyservice/api/admin/controller/AgencyAdminController.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/admin/controller/AgencyAdminController.java
@@ -346,6 +346,7 @@ public class AgencyAdminController implements AgencyadminApi {
     var response =
         new DepartmentDataProtectionContentDTO()
             .content(view.content())
+            .consentText(view.consentText())
             .publicationStatus(
                 DepartmentDataProtectionContentDTO.PublicationStatusEnum.fromValue(
                     view.publicationStatus().name()));
@@ -360,6 +361,7 @@ public class AgencyAdminController implements AgencyadminApi {
             agencyId,
             topicId,
             departmentDataProtectionDTO.getContent(),
+            departmentDataProtectionDTO.getConsentText(),
             Boolean.TRUE.equals(departmentDataProtectionDTO.getPublish()));
     var response =
         new DepartmentDataProtectionResponseDTO()
@@ -485,6 +487,7 @@ public class AgencyAdminController implements AgencyadminApi {
             LegalTextKind.valueOf(createLegalTextDTO.getKind().getValue()),
             createLegalTextDTO.getLabel(),
             createLegalTextDTO.getContent(),
+            createLegalTextDTO.getConsentText(),
             Boolean.TRUE.equals(createLegalTextDTO.getPublish()));
     return ResponseEntity.ok(toLegalTextAdminDto(view));
   }
@@ -498,6 +501,7 @@ public class AgencyAdminController implements AgencyadminApi {
             legalTextId,
             updateLegalTextDTO.getLabel(),
             updateLegalTextDTO.getContent(),
+            updateLegalTextDTO.getConsentText(),
             // null = preserve the current publication status (see service javadoc)
             updateLegalTextDTO.getPublish());
     return ResponseEntity.ok(toLegalTextAdminDto(view));
@@ -558,6 +562,7 @@ public class AgencyAdminController implements AgencyadminApi {
         .ownerLevel(LegalTextVersionDTO.OwnerLevelEnum.fromValue(view.ownerLevel().name()))
         .ownerId(view.ownerId())
         .content(view.content())
+        .consentText(view.consentText())
         .publishedAt(view.publishedAt() == null ? null : view.publishedAt().toString())
         .publishedBy(view.publishedBy())
         .supersededAt(view.supersededAt() == null ? null : view.supersededAt().toString());
@@ -570,6 +575,7 @@ public class AgencyAdminController implements AgencyadminApi {
         .kind(LegalTextAdminDTO.KindEnum.fromValue(view.kind().name()))
         .label(view.label())
         .content(view.content())
+        .consentText(view.consentText())
         .publicationStatus(
             LegalTextAdminDTO.PublicationStatusEnum.fromValue(view.publicationStatus().name()))
         .usageCount(view.usageCount());

--- a/src/main/java/de/caritas/cob/agencyservice/api/admin/service/AgencyAdminService.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/admin/service/AgencyAdminService.java
@@ -21,7 +21,10 @@ import de.caritas.cob.agencyservice.api.model.AgencyAdminFullResponseDTO;
 import de.caritas.cob.agencyservice.api.model.AgencyDTO;
 import de.caritas.cob.agencyservice.api.model.AgencyTypeRequestDTO;
 import de.caritas.cob.agencyservice.api.admin.service.legal.LegalContentSanitizer;
+import de.caritas.cob.agencyservice.api.admin.service.legal.LegalTextVersionService;
 import de.caritas.cob.agencyservice.api.model.AgencyLegalContentDTO;
+import de.caritas.cob.agencyservice.api.repository.legaltext.LegalTextKind;
+import de.caritas.cob.agencyservice.api.repository.legaltext.LegalTextLevel;
 import de.caritas.cob.agencyservice.api.model.UpdateAgencyDTO;
 import de.caritas.cob.agencyservice.api.repository.agency.Agency;
 import de.caritas.cob.agencyservice.api.repository.agency.AgencyRepository;
@@ -72,6 +75,7 @@ public class AgencyAdminService {
   private final @NonNull AgencyIdAllocationService agencyIdAllocationService;
   private final @NonNull TransactionOperations agencyCreationTransaction;
   private final @NonNull LegalContentSanitizer legalContentSanitizer;
+  private final @NonNull LegalTextVersionService legalTextVersionService;
 
   @Autowired(required = false)
   private AgencyTopicEnrichmentService agencyTopicEnrichmentService;
@@ -269,7 +273,37 @@ public class AgencyAdminService {
     enrichWithAgencyTopicsIfTopicFeatureEnabled(updatedAgency);
     this.appointmentService.syncAgencyDataToAppointmentService(updatedAgency);
     agencyRepository.flush();
+    recordAgencyLegalTextVersions(updatedAgency);
     return buildAgencyAdminFullResponse(updatedAgency);
+  }
+
+  /**
+   * ADR-021 decision 3 on the Beratungsstelle level (level 3).
+   *
+   * <p>That level deliberately carries <b>no publication status</b> — CONTEXT-legal-documents puts
+   * it as "what is stored, applies", and every Fachbereich inherits it until it publishes one of
+   * its own. There is consequently no publish button to hang a snapshot on, so <em>a save is a
+   * publish here</em>: whatever an agency update leaves stored is the wording in force from that
+   * moment, and that is precisely what the history has to record.
+   *
+   * <p>Recording runs after the save, on the persisted wording, and {@link
+   * LegalTextVersionService#recordPublication} drops a wording identical to the current version.
+   * Without that, an update about opening hours — which resends the untouched legal texts — would
+   * manufacture a new "version" of a document nobody edited.
+   */
+  private void recordAgencyLegalTextVersions(Agency agency) {
+    legalTextVersionService.recordPublication(
+        LegalTextLevel.AGENCY,
+        agency.getId(),
+        LegalTextKind.DPP,
+        agency.getTenantId(),
+        agency.getContentDpp());
+    legalTextVersionService.recordPublication(
+        LegalTextLevel.AGENCY,
+        agency.getId(),
+        LegalTextKind.IMPRINT,
+        agency.getTenantId(),
+        agency.getContentImprint());
   }
 
   private void applySettingsUpdate(UpdateAgencyDTO updateAgencyDTO) {

--- a/src/main/java/de/caritas/cob/agencyservice/api/admin/service/AgencyAdminService.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/admin/service/AgencyAdminService.java
@@ -20,6 +20,7 @@ import de.caritas.cob.agencyservice.api.exception.httpresponses.NotFoundExceptio
 import de.caritas.cob.agencyservice.api.model.AgencyAdminFullResponseDTO;
 import de.caritas.cob.agencyservice.api.model.AgencyDTO;
 import de.caritas.cob.agencyservice.api.model.AgencyTypeRequestDTO;
+import de.caritas.cob.agencyservice.api.admin.service.legal.ConsentTextService;
 import de.caritas.cob.agencyservice.api.admin.service.legal.LegalContentSanitizer;
 import de.caritas.cob.agencyservice.api.admin.service.legal.LegalTextVersionService;
 import de.caritas.cob.agencyservice.api.model.AgencyLegalContentDTO;
@@ -76,6 +77,7 @@ public class AgencyAdminService {
   private final @NonNull TransactionOperations agencyCreationTransaction;
   private final @NonNull LegalContentSanitizer legalContentSanitizer;
   private final @NonNull LegalTextVersionService legalTextVersionService;
+  private final @NonNull ConsentTextService consentTextService;
 
   @Autowired(required = false)
   private AgencyTopicEnrichmentService agencyTopicEnrichmentService;
@@ -297,13 +299,15 @@ public class AgencyAdminService {
         agency.getId(),
         LegalTextKind.DPP,
         agency.getTenantId(),
-        agency.getContentDpp());
+        agency.getContentDpp(),
+        agency.getConsentText());
     legalTextVersionService.recordPublication(
         LegalTextLevel.AGENCY,
         agency.getId(),
         LegalTextKind.IMPRINT,
         agency.getTenantId(),
-        agency.getContentImprint());
+        agency.getContentImprint(),
+        null);
   }
 
   private void applySettingsUpdate(UpdateAgencyDTO updateAgencyDTO) {
@@ -337,6 +341,22 @@ public class AgencyAdminService {
     return sentContent == null || sentContent.isEmpty()
         ? storedContent
         : legalContentSanitizer.sanitizeToJson(sentContent);
+  }
+
+  /**
+   * ADR-021 decision 4: the agency-wide consent sentence is a field of the agency-wide DPP, and
+   * follows the same "absent keeps, empty clears" rule as the policy itself.
+   *
+   * <p>The mandatory-token validator always runs on a submitted sentence, because this level has no
+   * publication status: what is stored is in force (ADR-021 decision 2 / CONTEXT-legal-documents).
+   * There is no draft state in which an incomplete sentence could safely rest here.
+   */
+  private String resolveConsentTextForUpdate(Agency agency, UpdateAgencyDTO updateAgencyDTO) {
+    var sent = legalContent(updateAgencyDTO, AgencyLegalContentDTO::getConsentText);
+    if (sent == null || sent.isEmpty()) {
+      return agency.getConsentText();
+    }
+    return consentTextService.sanitizeAndValidate(sent, true);
   }
 
   private String resolveSettingsForUpdate(Agency agency, UpdateAgencyDTO updateAgencyDTO) {
@@ -421,7 +441,8 @@ public class AgencyAdminService {
         .contentImprint(
             resolveLegalTextForUpdate(
                 agency.getContentImprint(),
-                legalContent(updateAgencyDTO, AgencyLegalContentDTO::getImpressum)));
+                legalContent(updateAgencyDTO, AgencyLegalContentDTO::getImpressum)))
+        .consentText(resolveConsentTextForUpdate(agency, updateAgencyDTO));
 
     applyDataProtectionUpdate(agency, updateAgencyDTO, agencyBuilder);
 

--- a/src/main/java/de/caritas/cob/agencyservice/api/admin/service/AgencyAdminService.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/admin/service/AgencyAdminService.java
@@ -40,6 +40,7 @@ import java.time.ZoneOffset;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.Function;
 
 import de.caritas.cob.agencyservice.api.util.AuthenticatedUser;
@@ -271,11 +272,16 @@ public class AgencyAdminService {
   public AgencyAdminFullResponseDTO updateAgency(Long agencyId, UpdateAgencyDTO updateAgencyDTO) {
     var agency = agencyRepository.findById(agencyId).orElseThrow(NotFoundException::new);
     applySettingsUpdate(updateAgencyDTO);
+    // Read the stored wording before the merge overwrites it: what makes an agency-level save a
+    // publish is that the wording CHANGED, and afterwards there is nothing left to compare against.
+    final var storedDpp = agency.getContentDpp();
+    final var storedConsent = agency.getConsentText();
+    final var storedImprint = agency.getContentImprint();
     var updatedAgency = agencyRepository.save(mergeAgencies(agency, updateAgencyDTO));
     enrichWithAgencyTopicsIfTopicFeatureEnabled(updatedAgency);
     this.appointmentService.syncAgencyDataToAppointmentService(updatedAgency);
     agencyRepository.flush();
-    recordAgencyLegalTextVersions(updatedAgency);
+    recordAgencyLegalTextVersions(updatedAgency, storedDpp, storedConsent, storedImprint);
     return buildAgencyAdminFullResponse(updatedAgency);
   }
 
@@ -288,26 +294,36 @@ public class AgencyAdminService {
    * publish here</em>: whatever an agency update leaves stored is the wording in force from that
    * moment, and that is precisely what the history has to record.
    *
-   * <p>Recording runs after the save, on the persisted wording, and {@link
-   * LegalTextVersionService#recordPublication} drops a wording identical to the current version.
-   * Without that, an update about opening hours — which resends the untouched legal texts — would
-   * manufacture a new "version" of a document nobody edited.
+   * <p><b>Only an actual change is a publish.</b> Comparing against the previously stored wording
+   * is what makes that true, and {@link LegalTextVersionService#recordPublication} deduplicating
+   * against the open version is not enough on its own: changeset 0031 deliberately backfills no
+   * history, so for every agency that already had legal texts there IS no open version to
+   * deduplicate against. The first unrelated update — a phone number, the opening hours — would
+   * otherwise snapshot the untouched old wording stamped with the current time and assert that the
+   * policy came into force at that moment. A date invented for a document nobody edited is exactly
+   * the false evidence #212 refuses to backfill.
    */
-  private void recordAgencyLegalTextVersions(Agency agency) {
-    legalTextVersionService.recordPublication(
-        LegalTextLevel.AGENCY,
-        agency.getId(),
-        LegalTextKind.DPP,
-        agency.getTenantId(),
-        agency.getContentDpp(),
-        agency.getConsentText());
-    legalTextVersionService.recordPublication(
-        LegalTextLevel.AGENCY,
-        agency.getId(),
-        LegalTextKind.IMPRINT,
-        agency.getTenantId(),
-        agency.getContentImprint(),
-        null);
+  private void recordAgencyLegalTextVersions(
+      Agency agency, String storedDpp, String storedConsent, String storedImprint) {
+    if (!Objects.equals(storedDpp, agency.getContentDpp())
+        || !Objects.equals(storedConsent, agency.getConsentText())) {
+      legalTextVersionService.recordPublication(
+          LegalTextLevel.AGENCY,
+          agency.getId(),
+          LegalTextKind.DPP,
+          agency.getTenantId(),
+          agency.getContentDpp(),
+          agency.getConsentText());
+    }
+    if (!Objects.equals(storedImprint, agency.getContentImprint())) {
+      legalTextVersionService.recordPublication(
+          LegalTextLevel.AGENCY,
+          agency.getId(),
+          LegalTextKind.IMPRINT,
+          agency.getTenantId(),
+          agency.getContentImprint(),
+          null);
+    }
   }
 
   private void applySettingsUpdate(UpdateAgencyDTO updateAgencyDTO) {
@@ -352,11 +368,10 @@ public class AgencyAdminService {
    * There is no draft state in which an incomplete sentence could safely rest here.
    */
   private String resolveConsentTextForUpdate(Agency agency, UpdateAgencyDTO updateAgencyDTO) {
-    var sent = legalContent(updateAgencyDTO, AgencyLegalContentDTO::getConsentText);
-    if (sent == null || sent.isEmpty()) {
-      return agency.getConsentText();
-    }
-    return consentTextService.sanitizeAndValidate(sent, true);
+    return consentTextService.resolveForUpdate(
+        agency.getConsentText(),
+        legalContent(updateAgencyDTO, AgencyLegalContentDTO::getConsentText),
+        true);
   }
 
   private String resolveSettingsForUpdate(Agency agency, UpdateAgencyDTO updateAgencyDTO) {

--- a/src/main/java/de/caritas/cob/agencyservice/api/admin/service/agency/AgencyAdminFullResponseDTOBuilder.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/admin/service/agency/AgencyAdminFullResponseDTOBuilder.java
@@ -100,9 +100,15 @@ public class AgencyAdminFullResponseDTOBuilder {
   private AgencyLegalContentDTO getLegalContent() {
     var privacy = toContentMap(this.agency.getContentDpp());
     var impressum = toContentMap(this.agency.getContentImprint());
-    return privacy == null && impressum == null
+    // ADR-021 decision 4: the consent sentence is a field of the privacy policy, so it is read back
+    // through the same object rather than through a second endpoint.
+    var consentText = toContentMap(this.agency.getConsentText());
+    return privacy == null && impressum == null && consentText == null
         ? null
-        : new AgencyLegalContentDTO().privacy(privacy).impressum(impressum);
+        : new AgencyLegalContentDTO()
+            .privacy(privacy)
+            .impressum(impressum)
+            .consentText(consentText);
   }
 
   private Map<String, String> toContentMap(String storedJson) {

--- a/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/ConsentTextService.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/ConsentTextService.java
@@ -1,0 +1,85 @@
+package de.caritas.cob.agencyservice.api.admin.service.legal;
+
+import de.caritas.cob.agencyservice.api.exception.httpresponses.BadRequestException;
+import java.util.Map;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+/**
+ * Sanitises and validates the consent sentence that belongs to a data protection policy (ADR-021
+ * decision 4: it is a field of the DPP, not a legal-text kind of its own).
+ *
+ * <h2>The mandatory token</h2>
+ *
+ * <p>ADR-021 decision 2 lets a Träger's consent text <em>replace</em> the platform's rather than be
+ * appended to it — two documents governing the same processing eventually contradict each other,
+ * and two checkboxes is a worse experience. What protects the platform's mandatory disclosures is
+ * therefore not a legal stacking rule but this technical one: <b>a consent text cannot be published
+ * unless every authored translation contains {@code {{legal_links}}}</b>. Without it the
+ * help-seeker would tick a sentence with no route to the documents it refers to.
+ *
+ * <p>The rejection is a 400 with a message the editor can show, never a 500. An admin who typed a
+ * sentence and forgot the token has made an ordinary mistake, and the response has to say which
+ * language is missing what.
+ *
+ * <p><b>Authoring nothing is allowed.</b> A Träger that publishes a DPP without a consent sentence
+ * keeps the platform's default sentence; the validator only governs text that exists.
+ *
+ * <p>The cookie/authentication notice is not handled here at all — it is a fixed, non-editable
+ * addendum rendered by the client and is deliberately never persisted per Träger.
+ */
+@Component
+@RequiredArgsConstructor
+public class ConsentTextService {
+
+  private final @NonNull LegalContentSanitizer legalContentSanitizer;
+
+  /**
+   * Sanitises the multilingual consent text and, when {@code publish} is true, enforces the
+   * mandatory token. Returns the stored JSON language→text map, or {@code null} when nothing was
+   * authored (so an absent consent text stays absent instead of becoming an empty document).
+   */
+  public String sanitizeAndValidate(Map<String, String> consentText, boolean publish) {
+    if (isEmpty(consentText)) {
+      return null;
+    }
+    if (publish) {
+      assertMandatoryTokenPresent(consentText);
+    }
+    return legalContentSanitizer.sanitizeToJson(consentText);
+  }
+
+  /**
+   * Every authored translation must carry the token. Checking only one language would let a Träger
+   * publish a compliant German sentence and an English one that leads nowhere.
+   *
+   * <p>{@code __meta} keys carry translation metadata, not prose, and are skipped.
+   */
+  private void assertMandatoryTokenPresent(Map<String, String> consentText) {
+    consentText.forEach(
+        (language, text) -> {
+          if (language == null || language.endsWith("__meta") || isBlank(text)) {
+            return;
+          }
+          if (!text.contains(LegalTextTokens.LEGAL_LINKS_TOKEN)) {
+            throw new BadRequestException(
+                String.format(
+                    "The consent text for language '%s' must contain the %s placeholder before it"
+                        + " can be published: without it the help-seeker has no way to reach the"
+                        + " documents they are agreeing to.",
+                    language, LegalTextTokens.LEGAL_LINKS_TOKEN));
+          }
+        });
+  }
+
+  private boolean isEmpty(Map<String, String> consentText) {
+    return consentText == null
+        || consentText.isEmpty()
+        || consentText.values().stream().allMatch(this::isBlank);
+  }
+
+  private boolean isBlank(String value) {
+    return value == null || value.isBlank();
+  }
+}

--- a/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/ConsentTextService.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/ConsentTextService.java
@@ -1,6 +1,9 @@
 package de.caritas.cob.agencyservice.api.admin.service.legal;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import de.caritas.cob.agencyservice.api.exception.httpresponses.BadRequestException;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
@@ -33,7 +36,12 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class ConsentTextService {
 
+  private static final TypeReference<LinkedHashMap<String, String>> LANGUAGE_MAP =
+      new TypeReference<>() {};
+
   private final @NonNull LegalContentSanitizer legalContentSanitizer;
+
+  private final ObjectMapper objectMapper = new ObjectMapper();
 
   /**
    * Sanitises the multilingual consent text and, when {@code publish} is true, enforces the
@@ -71,6 +79,53 @@ public class ConsentTextService {
                     language, LegalTextTokens.LEGAL_LINKS_TOKEN));
           }
         });
+  }
+
+  /**
+   * Resolves the consent text for an update where the field may simply not have been sent.
+   *
+   * <p><b>Absent keeps.</b> The generated request models initialise map properties to an empty map,
+   * so a client that never heard of this field is indistinguishable from one clearing it — and an
+   * independently deployed Admin updating a label would silently delete the Träger's consent
+   * sentence. That is the same silent-wipe trap {@code AgencyAdminService#resolveLegalTextForUpdate}
+   * already documents for the policy body, resolved the same way: clearing is expressed by sending
+   * the language key with empty content ({@code {"de": ""}}), not by omitting the field.
+   *
+   * <p>A retained sentence is still validated when the update publishes, otherwise omitting the
+   * field would be a way to publish a stored sentence that never passed the token check.
+   */
+  public String resolveForUpdate(String storedConsentJson, Map<String, String> sent, boolean publish) {
+    // Absent is "the map has no entries at all". A map that DOES carry a language key with empty
+    // content is an explicit clear, and must not be confused with the two — it is the only way a
+    // client can ever delete the sentence.
+    if (sent == null || sent.isEmpty()) {
+      if (publish) {
+        assertStoredTextPublishable(storedConsentJson);
+      }
+      return storedConsentJson;
+    }
+    return sanitizeAndValidate(sent, publish);
+  }
+
+  /**
+   * The token check applied to an already-stored sentence, so the "absent keeps" rule above cannot
+   * become a bypass of {@link #assertMandatoryTokenPresent}.
+   *
+   * <p>An unreadable stored value is left alone rather than rejected: it predates this validator,
+   * and refusing to publish a policy because an old consent column will not parse would block the
+   * admin on something they cannot fix from the editor.
+   */
+  public void assertStoredTextPublishable(String storedConsentJson) {
+    if (storedConsentJson == null || storedConsentJson.isBlank()) {
+      return;
+    }
+    final Map<String, String> byLanguage;
+    try {
+      byLanguage = objectMapper.readValue(storedConsentJson, LANGUAGE_MAP);
+    } catch (Exception e) {
+      return;
+    }
+    assertMandatoryTokenPresent(byLanguage);
   }
 
   private boolean isEmpty(Map<String, String> consentText) {

--- a/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/DepartmentDataProtectionService.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/DepartmentDataProtectionService.java
@@ -85,7 +85,11 @@ public class DepartmentDataProtectionService {
     var sanitizedJson = legalContentSanitizer.sanitizeToJson(content);
     // ADR-021 decision 2: validated BEFORE anything is written, so a consent text missing the
     // mandatory token leaves the stored document untouched instead of half-updating it.
-    var sanitizedConsent = consentTextService.sanitizeAndValidate(consentText, publish);
+    // "Absent keeps": an Admin build that predates this field must not wipe the Träger's sentence
+    // by publishing a policy body (see ConsentTextService#resolveForUpdate).
+    var sanitizedConsent =
+        consentTextService.resolveForUpdate(department.getConsentText(), consentText, publish);
+    final var wasPublished = department.getPublicationStatus() == PublicationStatus.PUBLISHED;
     final var status = publish ? PublicationStatus.PUBLISHED : PublicationStatus.DRAFT;
 
     // ADR-014 amendment 2026-07-28: never write through to the referenced shared object. The 0026
@@ -112,6 +116,11 @@ public class DepartmentDataProtectionService {
           department.getAgency() == null ? null : department.getAgency().getTenantId(),
           sanitizedJson,
           sanitizedConsent);
+    } else if (wasPublished) {
+      // Withdrawing a published policy back to DRAFT is not a new version, but the old one has
+      // stopped applying — leaving it open would have the history claim it is still in force.
+      legalTextVersionService.supersedeCurrent(
+          LegalTextLevel.DEPARTMENT, department.getId(), LegalTextKind.DPP);
     }
 
     return status;

--- a/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/DepartmentDataProtectionService.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/DepartmentDataProtectionService.java
@@ -57,6 +57,7 @@ public class DepartmentDataProtectionService {
   private final @NonNull AuthenticatedUser authenticatedUser;
   private final @NonNull UserAdminService userAdminService;
   private final @NonNull LegalTextVersionService legalTextVersionService;
+  private final @NonNull ConsentTextService consentTextService;
 
   /**
    * Sanitises and stores the department's DPP for the given agency × topic. When {@code publish} is
@@ -67,7 +68,11 @@ public class DepartmentDataProtectionService {
    */
   @Transactional
   public PublicationStatus publishDepartmentDataPrivacy(
-      Long agencyId, Long topicId, Map<String, String> content, boolean publish) {
+      Long agencyId,
+      Long topicId,
+      Map<String, String> content,
+      Map<String, String> consentText,
+      boolean publish) {
     assertRestrictedAdminOwnsAgency(agencyId);
 
     AgencyTopic department =
@@ -78,7 +83,10 @@ public class DepartmentDataProtectionService {
     assertCallerTenantMatches(department.getAgency());
 
     var sanitizedJson = legalContentSanitizer.sanitizeToJson(content);
-    var status = publish ? PublicationStatus.PUBLISHED : PublicationStatus.DRAFT;
+    // ADR-021 decision 2: validated BEFORE anything is written, so a consent text missing the
+    // mandatory token leaves the stored document untouched instead of half-updating it.
+    var sanitizedConsent = consentTextService.sanitizeAndValidate(consentText, publish);
+    final var status = publish ? PublicationStatus.PUBLISHED : PublicationStatus.DRAFT;
 
     // ADR-014 amendment 2026-07-28: never write through to the referenced shared object. The 0026
     // backfill merged byte-identical departments onto one row, so writing through would silently
@@ -89,6 +97,7 @@ public class DepartmentDataProtectionService {
       department.setDpp(null);
     }
     department.setContentDpp(sanitizedJson);
+    department.setConsentText(sanitizedConsent);
     department.setPublicationStatus(status);
     department.setUpdateDate(LocalDateTime.now());
     agencyTopicRepository.save(department);
@@ -101,7 +110,8 @@ public class DepartmentDataProtectionService {
           department.getId(),
           LegalTextKind.DPP,
           department.getAgency() == null ? null : department.getAgency().getTenantId(),
-          sanitizedJson);
+          sanitizedJson,
+          sanitizedConsent);
     }
 
     return status;
@@ -126,10 +136,10 @@ public class DepartmentDataProtectionService {
     LegalText referenced = department.getDpp();
     if (referenced != null && !hasPendingDraft(department, referenced)) {
       return new DepartmentDataProtectionView(
-          referenced.getContent(), referenced.getPublicationStatus());
+          referenced.getContent(), referenced.getConsentText(), referenced.getPublicationStatus());
     }
     return new DepartmentDataProtectionView(
-        department.getContentDpp(), department.getPublicationStatus());
+        department.getContentDpp(), department.getConsentText(), department.getPublicationStatus());
   }
 
   /**

--- a/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/DepartmentDataProtectionService.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/DepartmentDataProtectionService.java
@@ -15,6 +15,8 @@ import de.caritas.cob.agencyservice.api.repository.agencytopic.AgencyTopic;
 import de.caritas.cob.agencyservice.api.repository.agencytopic.AgencyTopicRepository;
 import de.caritas.cob.agencyservice.api.repository.agencytopic.PublicationStatus;
 import de.caritas.cob.agencyservice.api.repository.legaltext.LegalText;
+import de.caritas.cob.agencyservice.api.repository.legaltext.LegalTextKind;
+import de.caritas.cob.agencyservice.api.repository.legaltext.LegalTextLevel;
 import de.caritas.cob.agencyservice.api.tenant.TenantContext;
 import de.caritas.cob.agencyservice.api.util.AuthenticatedUser;
 import de.caritas.cob.agencyservice.api.validation.InputSanitizer;
@@ -54,6 +56,7 @@ public class DepartmentDataProtectionService {
   private final @NonNull LegalContentSanitizer legalContentSanitizer;
   private final @NonNull AuthenticatedUser authenticatedUser;
   private final @NonNull UserAdminService userAdminService;
+  private final @NonNull LegalTextVersionService legalTextVersionService;
 
   /**
    * Sanitises and stores the department's DPP for the given agency × topic. When {@code publish} is
@@ -89,6 +92,17 @@ public class DepartmentDataProtectionService {
     department.setPublicationStatus(status);
     department.setUpdateDate(LocalDateTime.now());
     agencyTopicRepository.save(department);
+
+    // ADR-021 decision 3: only a real publish snapshots the wording. A draft-save deliberately
+    // writes no version — that is the #212 distinction update_date could never make.
+    if (publish) {
+      legalTextVersionService.recordPublication(
+          LegalTextLevel.DEPARTMENT,
+          department.getId(),
+          LegalTextKind.DPP,
+          department.getAgency() == null ? null : department.getAgency().getTenantId(),
+          sanitizedJson);
+    }
 
     return status;
   }

--- a/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/DepartmentDataProtectionView.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/DepartmentDataProtectionView.java
@@ -4,7 +4,10 @@ import de.caritas.cob.agencyservice.api.repository.agencytopic.PublicationStatus
 
 /**
  * Read view of a department's (Fachbereich = agency × topic) data privacy policy: the stored
- * multilingual JSON language→HTML {@code content} (may be {@code null} if never authored) and its
- * current {@link PublicationStatus}. Used to prefill the admin editor.
+ * multilingual JSON language→HTML {@code content} (may be {@code null} if never authored), the
+ * consent sentence stored with it (ADR-021 decision 4 — a field of the policy, not a document of
+ * its own; {@code null} means the platform default applies) and their shared {@link
+ * PublicationStatus}. Used to prefill the admin editor.
  */
-public record DepartmentDataProtectionView(String content, PublicationStatus publicationStatus) {}
+public record DepartmentDataProtectionView(
+    String content, String consentText, PublicationStatus publicationStatus) {}

--- a/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/DepartmentImprintService.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/DepartmentImprintService.java
@@ -71,6 +71,8 @@ public class DepartmentImprintService {
     assertCallerTenantMatches(department.getAgency());
 
     var sanitizedJson = legalContentSanitizer.sanitizeToJson(content);
+    final var wasPublished =
+        department.getPublicationStatusImprint() == PublicationStatus.PUBLISHED;
     var status = publish ? PublicationStatus.PUBLISHED : PublicationStatus.DRAFT;
 
     // ADR-014 amendment 2026-07-28: never write through to the referenced shared object. The 0026
@@ -98,6 +100,9 @@ public class DepartmentImprintService {
           sanitizedJson,
           // An imprint is an information duty, never consent-bearing (ADR-021 decision 7).
           null);
+    } else if (wasPublished) {
+      legalTextVersionService.supersedeCurrent(
+          LegalTextLevel.DEPARTMENT, department.getId(), LegalTextKind.IMPRINT);
     }
 
     return status;

--- a/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/DepartmentImprintService.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/DepartmentImprintService.java
@@ -12,6 +12,8 @@ import de.caritas.cob.agencyservice.api.repository.agencytopic.AgencyTopic;
 import de.caritas.cob.agencyservice.api.repository.agencytopic.AgencyTopicRepository;
 import de.caritas.cob.agencyservice.api.repository.agencytopic.PublicationStatus;
 import de.caritas.cob.agencyservice.api.repository.legaltext.LegalText;
+import de.caritas.cob.agencyservice.api.repository.legaltext.LegalTextKind;
+import de.caritas.cob.agencyservice.api.repository.legaltext.LegalTextLevel;
 import de.caritas.cob.agencyservice.api.tenant.TenantContext;
 import de.caritas.cob.agencyservice.api.util.AuthenticatedUser;
 import de.caritas.cob.agencyservice.api.validation.InputSanitizer;
@@ -47,6 +49,7 @@ public class DepartmentImprintService {
   private final @NonNull LegalContentSanitizer legalContentSanitizer;
   private final @NonNull AuthenticatedUser authenticatedUser;
   private final @NonNull UserAdminService userAdminService;
+  private final @NonNull LegalTextVersionService legalTextVersionService;
 
   /**
    * Sanitises and stores the department's imprint for the given agency × topic. When {@code
@@ -82,6 +85,18 @@ public class DepartmentImprintService {
     department.setPublicationStatusImprint(status);
     department.setUpdateDate(LocalDateTime.now());
     agencyTopicRepository.save(department);
+
+    // ADR-021 decision 3: the imprint gets the same history as the DPP. It is an information duty,
+    // never a consent gate (decision 7), but "which imprint was reachable when" is still a question
+    // the platform has to be able to answer.
+    if (publish) {
+      legalTextVersionService.recordPublication(
+          LegalTextLevel.DEPARTMENT,
+          department.getId(),
+          LegalTextKind.IMPRINT,
+          department.getAgency() == null ? null : department.getAgency().getTenantId(),
+          sanitizedJson);
+    }
 
     return status;
   }

--- a/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/DepartmentImprintService.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/DepartmentImprintService.java
@@ -95,7 +95,9 @@ public class DepartmentImprintService {
           department.getId(),
           LegalTextKind.IMPRINT,
           department.getAgency() == null ? null : department.getAgency().getTenantId(),
-          sanitizedJson);
+          sanitizedJson,
+          // An imprint is an information duty, never consent-bearing (ADR-021 decision 7).
+          null);
     }
 
     return status;

--- a/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/LegalAdminAccessGuard.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/LegalAdminAccessGuard.java
@@ -46,6 +46,21 @@ public class LegalAdminAccessGuard {
   }
 
   /**
+   * Library guard, mirroring {@code LegalTextAdminService#assertFullAgencyAdmin}: an ADR-014 shared
+   * legal text applies tenant-wide, across agencies a restricted admin does not administer, so the
+   * library — and equally its publication history, which carries the wording and the publisher
+   * identities — is full-agency-admin only. Restricted admins use the per-department endpoints.
+   */
+  public void assertFullAgencyAdmin() {
+    if (authenticatedUser.hasRestrictedAgencyPriviliges()) {
+      log.warn(
+          "Restricted admin user {} may not read the tenant-wide legal-text history",
+          authenticatedUser.getUserId());
+      throw new AgencyAccessDeniedException();
+    }
+  }
+
+  /**
    * Cross-tenant guard (mirrors {@code AgencyTenantValidator}): a full agency admin of tenant A
    * must not read tenant B's legal texts. Necessary because the Hibernate tenant filter is not
    * installed when {@code multitenancy.enabled=false} (all deployed profiles), so agency-id

--- a/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/LegalAdminAccessGuard.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/LegalAdminAccessGuard.java
@@ -1,0 +1,86 @@
+package de.caritas.cob.agencyservice.api.admin.service.legal;
+
+import de.caritas.cob.agencyservice.api.admin.service.UserAdminService;
+import de.caritas.cob.agencyservice.api.exception.httpresponses.AgencyAccessDeniedException;
+import de.caritas.cob.agencyservice.api.repository.agency.Agency;
+import de.caritas.cob.agencyservice.api.tenant.TenantContext;
+import de.caritas.cob.agencyservice.api.util.AuthenticatedUser;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+/**
+ * The two authorisation checks every admin-facing legal-text endpoint has to pass, extracted so
+ * the ADR-021 version endpoints cannot drift from the publish endpoints they mirror.
+ *
+ * <p>The wording of a published legal document is not secret, but <em>who runs which
+ * Beratungsstelle</em> and what their drafts look like is; the version list would otherwise be an
+ * IDOR hole around the guards {@code DepartmentDataProtectionService} and {@code
+ * DepartmentImprintService} already apply on the write side.
+ */
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class LegalAdminAccessGuard {
+
+  private final @NonNull AuthenticatedUser authenticatedUser;
+  private final @NonNull UserAdminService userAdminService;
+
+  /**
+   * Restricted agency admins may only touch agencies they administer (mirrors {@code
+   * AgencyUpdatePermissionValidator}). Full agency admins are covered by {@link
+   * #assertCallerTenantMatches}.
+   */
+  public void assertRestrictedAdminOwnsAgency(Long agencyId) {
+    if (authenticatedUser.hasRestrictedAgencyPriviliges()) {
+      var adminAgencyIds = userAdminService.getAdminUserAgencyIds(authenticatedUser.requireUserId());
+      if (adminAgencyIds == null || !adminAgencyIds.contains(agencyId)) {
+        log.warn(
+            "Admin user {} may not read the legal texts of agency {}",
+            authenticatedUser.requireUserId(),
+            agencyId);
+        throw new AgencyAccessDeniedException();
+      }
+    }
+  }
+
+  /**
+   * Cross-tenant guard (mirrors {@code AgencyTenantValidator}): a full agency admin of tenant A
+   * must not read tenant B's legal texts. Necessary because the Hibernate tenant filter is not
+   * installed when {@code multitenancy.enabled=false} (all deployed profiles), so agency-id
+   * membership alone does not scope full admins. Tenant {@code 0} (super/technical) and
+   * single-tenant mode (no tenant in context) are unrestricted.
+   */
+  public void assertCallerTenantMatches(Agency agency) {
+    if (agency == null) {
+      throw new AgencyAccessDeniedException();
+    }
+    assertCallerTenantIs(agency.getTenantId());
+  }
+
+  /**
+   * The tenant half of {@link #assertCallerTenantMatches} for objects that are owned by a Träger
+   * without belonging to one agency — the ADR-014 shared legal texts and their version history.
+   */
+  public void assertCallerTenantIs(Long ownerTenantId) {
+    Long effectiveTenantId = resolveEffectiveTenantId();
+    if (effectiveTenantId == null || effectiveTenantId.equals(0L)) {
+      return;
+    }
+    if (!effectiveTenantId.equals(ownerTenantId)) {
+      log.warn(
+          "Admin user {} (tenant {}) may not read legal texts owned by tenant {}",
+          authenticatedUser.getUserId(),
+          effectiveTenantId,
+          ownerTenantId);
+      throw new AgencyAccessDeniedException();
+    }
+  }
+
+  /** The tenant the caller acts for: the token claim, else the resolved request tenant. */
+  public Long resolveEffectiveTenantId() {
+    Long tenantIdFromAuth = authenticatedUser.getTenantId();
+    return tenantIdFromAuth != null ? tenantIdFromAuth : TenantContext.getCurrentTenant();
+  }
+}

--- a/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/LegalContentSanitizer.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/LegalContentSanitizer.java
@@ -66,7 +66,8 @@ public class LegalContentSanitizer {
       assertValidMeta(key, safeValue);
       return safeValue;
     }
-    return inputSanitizer.sanitizeAllowingFormattingAndLinks(safeValue);
+    return LegalTextTokens.restoreKnownTokens(
+        inputSanitizer.sanitizeAllowingFormattingAndLinks(safeValue));
   }
 
   /**

--- a/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/LegalTextAdminService.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/LegalTextAdminService.java
@@ -116,16 +116,39 @@ public class LegalTextAdminService {
     var willBePublished =
         publish != null ? publish : text.getPublicationStatus() == PublicationStatus.PUBLISHED;
 
+    final var wasPublished = text.getPublicationStatus() == PublicationStatus.PUBLISHED;
+
     text.setLabel(label);
     text.setContent(legalContentSanitizer.sanitizeToJson(content));
-    text.setConsentText(resolveConsentText(text.getKind(), consentText, willBePublished));
+    text.setConsentText(
+        resolveConsentTextForUpdate(text, consentText, willBePublished));
     if (publish != null) {
       text.setPublicationStatus(publish ? PublicationStatus.PUBLISHED : PublicationStatus.DRAFT);
     }
     text.setUpdateDate(LocalDateTime.now());
     var saved = legalTextRepository.save(text);
-    recordPublicationIfPublished(saved, saved.getPublicationStatus() == PublicationStatus.PUBLISHED);
+
+    if (saved.getPublicationStatus() == PublicationStatus.PUBLISHED) {
+      recordPublicationIfPublished(saved, true);
+    } else if (wasPublished) {
+      // Unpublishing is not a new version, but the old one has stopped applying: public resolution
+      // now falls through to another level while the last snapshot would still read as in force.
+      legalTextVersionService.supersedeCurrent(
+          LegalTextLevel.SHARED, saved.getId(), saved.getKind());
+    }
     return toView(saved);
+  }
+
+  /**
+   * ADR-021 decision 7 plus the "absent keeps" rule: an imprint never carries a consent sentence,
+   * and an update that does not mention the sentence must not delete it. See
+   * {@link ConsentTextService#resolveForUpdate}.
+   */
+  private String resolveConsentTextForUpdate(
+      LegalText text, Map<String, String> consentText, boolean publish) {
+    return text.getKind() == LegalTextKind.DPP
+        ? consentTextService.resolveForUpdate(text.getConsentText(), consentText, publish)
+        : null;
   }
 
   /**

--- a/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/LegalTextAdminService.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/LegalTextAdminService.java
@@ -10,6 +10,7 @@ import de.caritas.cob.agencyservice.api.repository.agencytopic.AgencyTopicReposi
 import de.caritas.cob.agencyservice.api.repository.agencytopic.PublicationStatus;
 import de.caritas.cob.agencyservice.api.repository.legaltext.LegalText;
 import de.caritas.cob.agencyservice.api.repository.legaltext.LegalTextKind;
+import de.caritas.cob.agencyservice.api.repository.legaltext.LegalTextLevel;
 import de.caritas.cob.agencyservice.api.repository.legaltext.LegalTextRepository;
 import de.caritas.cob.agencyservice.api.tenant.TenantContext;
 import de.caritas.cob.agencyservice.api.util.AuthenticatedUser;
@@ -42,6 +43,7 @@ public class LegalTextAdminService {
   private final @NonNull LegalContentSanitizer legalContentSanitizer;
   private final @NonNull AuthenticatedUser authenticatedUser;
   private final @NonNull UserAdminService userAdminService;
+  private final @NonNull LegalTextVersionService legalTextVersionService;
 
   /**
    * Lists the caller tenant's legal texts of one kind, each with its department usage count.
@@ -79,7 +81,9 @@ public class LegalTextAdminService {
             .createDate(now)
             .updateDate(now)
             .build();
-    return toView(legalTextRepository.save(text));
+    var saved = legalTextRepository.save(text);
+    recordPublicationIfPublished(saved, publish);
+    return toView(saved);
   }
 
   /**
@@ -102,7 +106,29 @@ public class LegalTextAdminService {
       text.setPublicationStatus(publish ? PublicationStatus.PUBLISHED : PublicationStatus.DRAFT);
     }
     text.setUpdateDate(LocalDateTime.now());
-    return toView(legalTextRepository.save(text));
+    var saved = legalTextRepository.save(text);
+    recordPublicationIfPublished(saved, saved.getPublicationStatus() == PublicationStatus.PUBLISHED);
+    return toView(saved);
+  }
+
+  /**
+   * ADR-021 decision 3 for the ADR-014 shared objects. A shared text is the document in force for
+   * every department referencing it, so its wording needs the same provable history as an inline
+   * one; leaving it out would mean a Träger loses its evidence precisely by doing the tidy thing
+   * and maintaining one document instead of N copies.
+   *
+   * <p>An update that leaves the text {@code DRAFT} records nothing, and re-saving an unchanged
+   * published wording is deduplicated inside {@link LegalTextVersionService}.
+   */
+  private void recordPublicationIfPublished(LegalText text, boolean published) {
+    if (published) {
+      legalTextVersionService.recordPublication(
+          LegalTextLevel.SHARED,
+          text.getId(),
+          text.getKind(),
+          text.getTenantId(),
+          text.getContent());
+    }
   }
 
   /**

--- a/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/LegalTextAdminService.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/LegalTextAdminService.java
@@ -44,6 +44,7 @@ public class LegalTextAdminService {
   private final @NonNull AuthenticatedUser authenticatedUser;
   private final @NonNull UserAdminService userAdminService;
   private final @NonNull LegalTextVersionService legalTextVersionService;
+  private final @NonNull ConsentTextService consentTextService;
 
   /**
    * Lists the caller tenant's legal texts of one kind, each with its department usage count.
@@ -67,7 +68,11 @@ public class LegalTextAdminService {
   /** Creates a legal text owned by the caller's tenant (full agency admins only). */
   @Transactional
   public LegalTextAdminView createLegalText(
-      LegalTextKind kind, String label, Map<String, String> content, boolean publish) {
+      LegalTextKind kind,
+      String label,
+      Map<String, String> content,
+      Map<String, String> consentText,
+      boolean publish) {
     assertFullAgencyAdmin();
     assertValidLabel(label);
     var now = LocalDateTime.now();
@@ -77,6 +82,7 @@ public class LegalTextAdminService {
             .kind(kind)
             .label(label)
             .content(legalContentSanitizer.sanitizeToJson(content))
+            .consentText(resolveConsentText(kind, consentText, publish))
             .publicationStatus(publish ? PublicationStatus.PUBLISHED : PublicationStatus.DRAFT)
             .createDate(now)
             .updateDate(now)
@@ -93,15 +99,26 @@ public class LegalTextAdminService {
    */
   @Transactional
   public LegalTextAdminView updateLegalText(
-      Long legalTextId, String label, Map<String, String> content, Boolean publish) {
+      Long legalTextId,
+      String label,
+      Map<String, String> content,
+      Map<String, String> consentText,
+      Boolean publish) {
     assertFullAgencyAdmin();
     LegalText text =
         legalTextRepository.findById(legalTextId).orElseThrow(NotFoundException::new);
     assertCallerTenantOwnsText(text);
     assertValidLabel(label);
 
+    // A null publish flag keeps the current status, so the token validator has to be told what the
+    // resulting status will be - otherwise updating an already published text could slip a consent
+    // sentence without {{legal_links}} past the gate.
+    var willBePublished =
+        publish != null ? publish : text.getPublicationStatus() == PublicationStatus.PUBLISHED;
+
     text.setLabel(label);
     text.setContent(legalContentSanitizer.sanitizeToJson(content));
+    text.setConsentText(resolveConsentText(text.getKind(), consentText, willBePublished));
     if (publish != null) {
       text.setPublicationStatus(publish ? PublicationStatus.PUBLISHED : PublicationStatus.DRAFT);
     }
@@ -127,7 +144,8 @@ public class LegalTextAdminService {
           text.getId(),
           text.getKind(),
           text.getTenantId(),
-          text.getContent());
+          text.getContent(),
+          text.getConsentText());
     }
   }
 
@@ -198,8 +216,21 @@ public class LegalTextAdminService {
         text.getKind(),
         text.getLabel(),
         text.getContent(),
+        text.getConsentText(),
         text.getPublicationStatus(),
         usage);
+  }
+
+  /**
+   * ADR-021 decision 7: only the DPP is consent-bearing. An imprint is an information duty, so a
+   * consent sentence submitted alongside one is dropped rather than stored — storing it would
+   * create a second, unreachable consent wording that nothing renders and nothing validates.
+   */
+  private String resolveConsentText(
+      LegalTextKind kind, Map<String, String> consentText, boolean publish) {
+    return kind == LegalTextKind.DPP
+        ? consentTextService.sanitizeAndValidate(consentText, publish)
+        : null;
   }
 
   private void assertValidLabel(String label) {

--- a/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/LegalTextAdminView.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/LegalTextAdminView.java
@@ -12,5 +12,6 @@ public record LegalTextAdminView(
     LegalTextKind kind,
     String label,
     String content,
+    String consentText,
     PublicationStatus publicationStatus,
     long usageCount) {}

--- a/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/LegalTextTokens.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/LegalTextTokens.java
@@ -73,9 +73,37 @@ public final class LegalTextTokens {
   }
 
   /**
+   * HTML-escapes a value that is about to be substituted into already-sanitised legal HTML.
+   *
+   * <p>Substitution happens <em>after</em> {@code LegalContentSanitizer} has run, so the value
+   * never passes the OWASP allowlist. An agency name is admin-authored, but admin-authored is not
+   * the same as safe: legal content is rendered into the page as HTML (CONTEXT-legal-documents
+   * records {@code AnonymousConsentGate} doing so via {@code dangerouslySetInnerHTML}), so an
+   * unescaped name containing markup would be stored XSS reaching every help-seeker of that
+   * Beratungsstelle. Escaping here is the only point where that can still be prevented.
+   *
+   * <p>Explicit and exhaustive rather than delegated: the five characters below are the complete
+   * set that can break out of HTML text or an attribute value, and keeping the list visible is
+   * worth more here than reusing a general-purpose escaper.
+   */
+  public static String escapeForHtml(String value) {
+    if (value == null || value.isEmpty()) {
+      return value;
+    }
+    return value
+        .replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+        .replace("\"", "&quot;")
+        .replace("'", "&#39;");
+  }
+
+  /**
    * Replaces the given tokens with their values. A plain literal replacement: no expression
-   * language, no method calls, nothing a Träger can steer. Values are used as given — callers pass
-   * data they already trust or have sanitised.
+   * language, no method calls, nothing a Träger can steer.
+   *
+   * <p>Values are inserted verbatim — callers substituting into HTML must pass them through
+   * {@link #escapeForHtml} first.
    *
    * <p>Tokens absent from {@code values} are left standing. That is how {@code
    * &#123;&#123;legal_links&#125;&#125;} survives the server side and reaches the client, which is

--- a/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/LegalTextTokens.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/LegalTextTokens.java
@@ -1,0 +1,97 @@
+package de.caritas.cob.agencyservice.api.admin.service.legal;
+
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+/**
+ * The closed set of {@code {{key}}} placeholders ORISO understands in Träger-authored legal text
+ * (ADR-021 decisions 5 and 6), plus the two operations the product needs on them: surviving
+ * sanitisation, and being substituted.
+ *
+ * <h2>Why the dialect is {@code {{key}}} and not {@code ${key}}</h2>
+ *
+ * <p>The existing DPP placeholders ({@code responsible}, {@code dataProtectionOfficer}) are
+ * rendered by Freemarker, where {@code ${...}} can invoke methods on the objects in the data model.
+ * That is acceptable for platform-authored templates and unacceptable for text a Träger types into
+ * an editor. A literal {@code {{key}}} replacement cannot reach any object by construction, so
+ * Träger-authored text never goes near {@link
+ * de.caritas.cob.agencyservice.api.service.TemplateRenderer}. The two dialects coexist on purpose;
+ * unifying them is deliberately deferred (ADR-021 decision 6).
+ *
+ * <h2>The sanitiser collision — measured 2026-08-16</h2>
+ *
+ * <p>OWASP's {@code java-html-sanitizer} rewrites any {@code &#123;&#123;} in a text node to
+ * {@code &#123;<!-- -->&#123;}. That is a deliberate defence: it stops sanitised HTML from being
+ * re-interpreted as a mustache template by a client-side engine (AngularJS and friends). The side
+ * effect is that {@code &#123;&#123;legal_links&#125;&#125;} typed correctly by an admin comes back
+ * out broken — it would fail the publication validator on valid input, and render as visible braces
+ * to a help-seeker.
+ *
+ * <p>{@link #restoreKnownTokens} therefore un-breaks <b>only the tokens on this allowlist</b>, and
+ * only in their exact {@code &#123;&#123;key&#125;&#125;} form. Undoing the comment injection
+ * wholesale would hand every Träger the ability to smuggle an arbitrary mustache expression into
+ * whatever renders the text; restoring three known keys does not, because the substitution of those
+ * three is something the platform performs itself.
+ */
+public final class LegalTextTokens {
+
+  /** The mandatory token: the clickable links the client substitutes (ADR-021 decision 2). */
+  public static final String LEGAL_LINKS = "legal_links";
+
+  /** Beratungsstelle name — substituted server-side (ADR-021 decision 5). */
+  public static final String BERATUNGSSTELLE = "Beratungsstelle";
+
+  /** Fachbereich / topic name — substituted server-side (ADR-021 decision 5). */
+  public static final String THEMA = "Thema";
+
+  /** Rendered form of the token that must be present in any published consent text. */
+  public static final String LEGAL_LINKS_TOKEN = token(LEGAL_LINKS);
+
+  private static final List<String> KNOWN_KEYS = List.of(LEGAL_LINKS, BERATUNGSSTELLE, THEMA);
+
+  /** Exactly what the OWASP sanitizer leaves behind, for the known keys only. */
+  private static final Pattern SPLIT_BY_SANITIZER =
+      Pattern.compile("\\{<!-- -->\\{(" + String.join("|", KNOWN_KEYS) + ")}}");
+
+  private LegalTextTokens() {}
+
+  /** {@code {{key}}} — the one place the syntax is spelled out. */
+  public static String token(String key) {
+    return "{{" + key + "}}";
+  }
+
+  /**
+   * Repairs the {@code &#123;<!-- -->&#123;} the OWASP sanitizer produces, for the known keys only.
+   * Any other mustache stays split, which is exactly the protection the sanitizer intended.
+   */
+  public static String restoreKnownTokens(String sanitizedHtml) {
+    if (sanitizedHtml == null || sanitizedHtml.isEmpty()) {
+      return sanitizedHtml;
+    }
+    return SPLIT_BY_SANITIZER.matcher(sanitizedHtml).replaceAll(match -> "{{" + match.group(1) + "}}");
+  }
+
+  /**
+   * Replaces the given tokens with their values. A plain literal replacement: no expression
+   * language, no method calls, nothing a Träger can steer. Values are used as given — callers pass
+   * data they already trust or have sanitised.
+   *
+   * <p>Tokens absent from {@code values} are left standing. That is how {@code
+   * &#123;&#123;legal_links&#125;&#125;} survives the server side and reaches the client, which is
+   * the only party that knows the deployment's link targets.
+   */
+  public static String substitute(String text, Map<String, String> values) {
+    if (text == null || text.isEmpty() || values == null || values.isEmpty()) {
+      return text;
+    }
+    var result = text;
+    for (var entry : values.entrySet()) {
+      if (entry.getValue() != null) {
+        // String#replace is a literal replacement - no regex, so no group references in the value.
+        result = result.replace(token(entry.getKey()), entry.getValue());
+      }
+    }
+    return result;
+  }
+}

--- a/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/LegalTextVersionAdminService.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/LegalTextVersionAdminService.java
@@ -1,0 +1,109 @@
+package de.caritas.cob.agencyservice.api.admin.service.legal;
+
+import de.caritas.cob.agencyservice.api.exception.httpresponses.NotFoundException;
+import de.caritas.cob.agencyservice.api.repository.agency.AgencyRepository;
+import de.caritas.cob.agencyservice.api.repository.agencytopic.AgencyTopicRepository;
+import de.caritas.cob.agencyservice.api.repository.legaltext.LegalTextKind;
+import de.caritas.cob.agencyservice.api.repository.legaltext.LegalTextLevel;
+import de.caritas.cob.agencyservice.api.repository.legaltext.LegalTextVersion;
+import de.caritas.cob.agencyservice.api.repository.legaltext.LegalTextVersionRepository;
+import java.util.List;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Read side of the ADR-021 publication history for the admin panel: list the versions of one
+ * document, and fetch one of them verbatim.
+ *
+ * <p>Every entry point resolves the owning agency first and runs the same two guards as the
+ * publish endpoints ({@link LegalAdminAccessGuard}). A version id alone is not a capability: {@link
+ * #getVersion} re-derives the owner from the stored row and authorises against <em>that</em>, so
+ * guessing ids cannot walk out of the caller's agencies or Träger.
+ */
+@Service
+@RequiredArgsConstructor
+public class LegalTextVersionAdminService {
+
+  private final @NonNull LegalTextVersionService legalTextVersionService;
+  private final @NonNull LegalTextVersionRepository legalTextVersionRepository;
+  private final @NonNull AgencyTopicRepository agencyTopicRepository;
+  private final @NonNull AgencyRepository agencyRepository;
+  private final @NonNull LegalAdminAccessGuard accessGuard;
+
+  /** The publication history of one department's (Fachbereich) DPP or imprint, newest first. */
+  @Transactional(readOnly = true)
+  public List<LegalTextVersionView> listDepartmentVersions(
+      Long agencyId, Long topicId, LegalTextKind kind) {
+    accessGuard.assertRestrictedAdminOwnsAgency(agencyId);
+    var department =
+        agencyTopicRepository
+            .findByAgency_IdAndTopicId(agencyId, topicId)
+            .orElseThrow(NotFoundException::new);
+    accessGuard.assertCallerTenantMatches(department.getAgency());
+    return toViews(
+        legalTextVersionService.listVersions(
+            LegalTextLevel.DEPARTMENT, department.getId(), kind));
+  }
+
+  /** The publication history of one Beratungsstelle's agency-wide DPP or imprint, newest first. */
+  @Transactional(readOnly = true)
+  public List<LegalTextVersionView> listAgencyVersions(Long agencyId, LegalTextKind kind) {
+    accessGuard.assertRestrictedAdminOwnsAgency(agencyId);
+    var agency = agencyRepository.findById(agencyId).orElseThrow(NotFoundException::new);
+    accessGuard.assertCallerTenantMatches(agency);
+    return toViews(legalTextVersionService.listVersions(LegalTextLevel.AGENCY, agencyId, kind));
+  }
+
+  /**
+   * One archived version, verbatim. Authorisation is derived from the stored owner, so the version
+   * id is not a bearer token for someone else's document.
+   */
+  @Transactional(readOnly = true)
+  public LegalTextVersionView getVersion(Long versionId) {
+    var version = legalTextVersionRepository.findById(versionId).orElseThrow(NotFoundException::new);
+    authoriseOwner(version);
+    return toView(version);
+  }
+
+  /**
+   * Resolves the agency behind a version row and applies the standard guards. A {@link
+   * LegalTextLevel#SHARED} version belongs to no single agency — it is a tenant-wide ADR-014
+   * object, so it is authorised the way the library itself is: by owning Träger.
+   */
+  private void authoriseOwner(LegalTextVersion version) {
+    switch (version.getOwnerLevel()) {
+      case DEPARTMENT -> {
+        var department =
+            agencyTopicRepository.findById(version.getOwnerId()).orElseThrow(NotFoundException::new);
+        accessGuard.assertRestrictedAdminOwnsAgency(department.getAgency().getId());
+        accessGuard.assertCallerTenantMatches(department.getAgency());
+      }
+      case AGENCY -> {
+        var agency =
+            agencyRepository.findById(version.getOwnerId()).orElseThrow(NotFoundException::new);
+        accessGuard.assertRestrictedAdminOwnsAgency(agency.getId());
+        accessGuard.assertCallerTenantMatches(agency);
+      }
+      case SHARED -> accessGuard.assertCallerTenantIs(version.getTenantId());
+      default -> throw new NotFoundException();
+    }
+  }
+
+  private List<LegalTextVersionView> toViews(List<LegalTextVersion> versions) {
+    return versions.stream().map(LegalTextVersionAdminService::toView).toList();
+  }
+
+  private static LegalTextVersionView toView(LegalTextVersion version) {
+    return new LegalTextVersionView(
+        version.getId(),
+        version.getKind(),
+        version.getOwnerLevel(),
+        version.getOwnerId(),
+        version.getContent(),
+        version.getPublishedAt(),
+        version.getPublishedBy(),
+        version.getSupersededAt());
+  }
+}

--- a/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/LegalTextVersionAdminService.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/LegalTextVersionAdminService.java
@@ -102,6 +102,7 @@ public class LegalTextVersionAdminService {
         version.getOwnerLevel(),
         version.getOwnerId(),
         version.getContent(),
+        version.getConsentText(),
         version.getPublishedAt(),
         version.getPublishedBy(),
         version.getSupersededAt());

--- a/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/LegalTextVersionAdminService.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/LegalTextVersionAdminService.java
@@ -86,7 +86,13 @@ public class LegalTextVersionAdminService {
         accessGuard.assertRestrictedAdminOwnsAgency(agency.getId());
         accessGuard.assertCallerTenantMatches(agency);
       }
-      case SHARED -> accessGuard.assertCallerTenantIs(version.getTenantId());
+      case SHARED -> {
+        // A shared text spans agencies a restricted admin does not administer, so the tenant check
+        // alone would let one read tenant-wide wording and publisher identities by guessing ids —
+        // exactly what the library CRUD refuses them.
+        accessGuard.assertFullAgencyAdmin();
+        accessGuard.assertCallerTenantIs(version.getTenantId());
+      }
       default -> throw new NotFoundException();
     }
   }

--- a/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/LegalTextVersionService.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/LegalTextVersionService.java
@@ -51,19 +51,34 @@ public class LegalTextVersionService {
    * (see the class comment). Supersedes the previous current version with the same timestamp the
    * new one carries, so the history has no gap and no overlap.
    *
-   * @return the newly written snapshot, or {@link Optional#empty()} when the wording was unchanged
-   *     or empty (an empty document is not a version of anything)
+   * <p>ADR-021 decision 4: the consent sentence travels with the policy. Changing only the consent
+   * wording is still a new version — its body may be byte-identical, and that is exactly what makes
+   * "which consent belonged to which policy" answerable by "the same version" instead of by
+   * correlating timestamps.
+   *
+   * @return the newly written snapshot, or {@link Optional#empty()} when policy and consent wording
+   *     were both unchanged, or the policy is empty (an empty document is not a version of
+   *     anything)
    */
   @Transactional
   public Optional<LegalTextVersion> recordPublication(
-      LegalTextLevel ownerLevel, Long ownerId, LegalTextKind kind, Long tenantId, String content) {
+      LegalTextLevel ownerLevel,
+      Long ownerId,
+      LegalTextKind kind,
+      Long tenantId,
+      String content,
+      String consentText) {
     if (ownerId == null || isBlank(content)) {
       return Optional.empty();
     }
     var open =
         legalTextVersionRepository.findByOwnerLevelAndOwnerIdAndKindAndSupersededAtIsNull(
             ownerLevel, ownerId, kind);
-    if (open.stream().anyMatch(version -> Objects.equals(version.getContent(), content))) {
+    if (open.stream()
+        .anyMatch(
+            version ->
+                Objects.equals(version.getContent(), content)
+                    && Objects.equals(version.getConsentText(), consentText))) {
       return Optional.empty();
     }
 
@@ -79,6 +94,7 @@ public class LegalTextVersionService {
                 .ownerLevel(ownerLevel)
                 .ownerId(ownerId)
                 .content(content)
+                .consentText(consentText)
                 .publishedAt(now)
                 .publishedBy(authenticatedUser.getUserId())
                 .build()));

--- a/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/LegalTextVersionService.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/LegalTextVersionService.java
@@ -1,0 +1,103 @@
+package de.caritas.cob.agencyservice.api.admin.service.legal;
+
+import de.caritas.cob.agencyservice.api.repository.legaltext.LegalTextKind;
+import de.caritas.cob.agencyservice.api.repository.legaltext.LegalTextLevel;
+import de.caritas.cob.agencyservice.api.repository.legaltext.LegalTextVersion;
+import de.caritas.cob.agencyservice.api.repository.legaltext.LegalTextVersionRepository;
+import de.caritas.cob.agencyservice.api.util.AuthenticatedUser;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Write side of the ADR-021 decision 3 publication history: turns "this wording is now in force"
+ * into an immutable snapshot.
+ *
+ * <p>Callers are the publish paths themselves, so this service performs <b>no</b> authorisation of
+ * its own — every caller has already run its IDOR and cross-tenant guards, and adding a second,
+ * differently-shaped check here would only create a way for the two to disagree.
+ *
+ * <h2>What counts as a publish</h2>
+ *
+ * <p>On the department level (level 4) and for the shared ADR-014 objects, a publish is explicit:
+ * the admin ticks publish, the row becomes {@code PUBLISHED}, a snapshot is written. A draft-save
+ * writes nothing — that is exactly the distinction #212 asks for, and it is why {@code update_date}
+ * could never serve as a publication date.
+ *
+ * <p><b>The agency level (level 3) has no publication status at all</b> — CONTEXT-legal-documents
+ * states it as "what is stored, applies". A stored agency-wide text is therefore in force the
+ * moment it is saved, and <em>a save is a publish at that level</em>: {@code AgencyAdminService}
+ * calls this service on every agency update whose legal content changed. Waiting for a publish flag
+ * that the level does not have would leave level 3 permanently historyless.
+ *
+ * <p>That makes deduplication load-bearing rather than cosmetic: an agency update about opening
+ * hours resends the unchanged legal texts, and without {@link #recordPublication} skipping an
+ * unchanged wording every such edit would forge a new "version" of a document nobody touched.
+ */
+@Service
+@RequiredArgsConstructor
+public class LegalTextVersionService {
+
+  private final @NonNull LegalTextVersionRepository legalTextVersionRepository;
+  private final @NonNull AuthenticatedUser authenticatedUser;
+
+  /**
+   * Records a published wording, unless it is byte-identical to the version currently in force
+   * (see the class comment). Supersedes the previous current version with the same timestamp the
+   * new one carries, so the history has no gap and no overlap.
+   *
+   * @return the newly written snapshot, or {@link Optional#empty()} when the wording was unchanged
+   *     or empty (an empty document is not a version of anything)
+   */
+  @Transactional
+  public Optional<LegalTextVersion> recordPublication(
+      LegalTextLevel ownerLevel, Long ownerId, LegalTextKind kind, Long tenantId, String content) {
+    if (ownerId == null || isBlank(content)) {
+      return Optional.empty();
+    }
+    var open =
+        legalTextVersionRepository.findByOwnerLevelAndOwnerIdAndKindAndSupersededAtIsNull(
+            ownerLevel, ownerId, kind);
+    if (open.stream().anyMatch(version -> Objects.equals(version.getContent(), content))) {
+      return Optional.empty();
+    }
+
+    var now = LocalDateTime.now();
+    open.forEach(version -> version.setSupersededAt(now));
+    legalTextVersionRepository.saveAll(open);
+
+    return Optional.of(
+        legalTextVersionRepository.save(
+            LegalTextVersion.builder()
+                .tenantId(tenantId)
+                .kind(kind)
+                .ownerLevel(ownerLevel)
+                .ownerId(ownerId)
+                .content(content)
+                .publishedAt(now)
+                .publishedBy(authenticatedUser.getUserId())
+                .build()));
+  }
+
+  /** The full history of one document, newest first. */
+  @Transactional(readOnly = true)
+  public List<LegalTextVersion> listVersions(
+      LegalTextLevel ownerLevel, Long ownerId, LegalTextKind kind) {
+    return legalTextVersionRepository
+        .findByOwnerLevelAndOwnerIdAndKindOrderByPublishedAtDescIdDesc(ownerLevel, ownerId, kind);
+  }
+
+  /**
+   * An absent document. {@code LegalContentSanitizer} serialises "no translations" to the empty
+   * JSON object, so {@code "{}"} is as empty as {@code null} here — snapshotting it would put a
+   * blank "version" into a history whose whole purpose is to reproduce real wordings.
+   */
+  private boolean isBlank(String content) {
+    return content == null || content.isBlank() || "{}".equals(content.trim());
+  }
+}

--- a/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/LegalTextVersionService.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/LegalTextVersionService.java
@@ -100,6 +100,33 @@ public class LegalTextVersionService {
                 .build()));
   }
 
+  /**
+   * Closes the version currently in force without opening a new one, for the case where a document
+   * stops applying rather than being replaced: unpublishing a text back to DRAFT.
+   *
+   * <p>Without this, the last snapshot keeps {@code supersededAt == null}, which the history API
+   * documents as "still in force" — while public resolution has already fallen through to another
+   * level. A history that says a withdrawn policy is current is worse than no history.
+   *
+   * @return true when a version was actually closed
+   */
+  @Transactional
+  public boolean supersedeCurrent(LegalTextLevel ownerLevel, Long ownerId, LegalTextKind kind) {
+    if (ownerId == null) {
+      return false;
+    }
+    var open =
+        legalTextVersionRepository.findByOwnerLevelAndOwnerIdAndKindAndSupersededAtIsNull(
+            ownerLevel, ownerId, kind);
+    if (open.isEmpty()) {
+      return false;
+    }
+    var now = LocalDateTime.now();
+    open.forEach(version -> version.setSupersededAt(now));
+    legalTextVersionRepository.saveAll(open);
+    return true;
+  }
+
   /** The full history of one document, newest first. */
   @Transactional(readOnly = true)
   public List<LegalTextVersion> listVersions(

--- a/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/LegalTextVersionView.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/LegalTextVersionView.java
@@ -1,0 +1,24 @@
+package de.caritas.cob.agencyservice.api.admin.service.legal;
+
+import de.caritas.cob.agencyservice.api.repository.legaltext.LegalTextKind;
+import de.caritas.cob.agencyservice.api.repository.legaltext.LegalTextLevel;
+import java.time.LocalDateTime;
+
+/**
+ * One entry of the ADR-021 publication history as the admin panel reads it: the verbatim wording
+ * plus the three facts #212 asks for — which level and kind it belongs to, who published it and
+ * when, and until when it was in force ({@code supersededAt == null} = still in force).
+ *
+ * <p>{@code publishedBy} is {@code null} where no authenticated publisher was recorded. That is an
+ * honest unknown, not a placeholder: pre-existing rows carry no history at all rather than a date
+ * guessed from {@code update_date}, which may well be a draft-save timestamp.
+ */
+public record LegalTextVersionView(
+    Long id,
+    LegalTextKind kind,
+    LegalTextLevel ownerLevel,
+    Long ownerId,
+    String content,
+    LocalDateTime publishedAt,
+    String publishedBy,
+    LocalDateTime supersededAt) {}

--- a/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/LegalTextVersionView.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/admin/service/legal/LegalTextVersionView.java
@@ -19,6 +19,7 @@ public record LegalTextVersionView(
     LegalTextLevel ownerLevel,
     Long ownerId,
     String content,
+    String consentText,
     LocalDateTime publishedAt,
     String publishedBy,
     LocalDateTime supersededAt) {}

--- a/src/main/java/de/caritas/cob/agencyservice/api/controller/AgencyController.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/controller/AgencyController.java
@@ -10,6 +10,7 @@ import de.caritas.cob.agencyservice.api.model.DepartmentLegalDTO;
 import de.caritas.cob.agencyservice.api.model.FullAgencyResponseDTO;
 import de.caritas.cob.agencyservice.api.service.AgencyService;
 import de.caritas.cob.agencyservice.api.service.DepartmentLegalService;
+import de.caritas.cob.agencyservice.api.service.legal.ResolvedLegalText;
 import de.caritas.cob.agencyservice.api.service.TopicEnrichmentService;
 import de.caritas.cob.agencyservice.generated.api.controller.AgenciesApi;
 import io.swagger.annotations.Api;
@@ -135,9 +136,30 @@ public class AgencyController implements AgenciesApi {
     var view = departmentLegalService.getPublishedDepartmentLegal(agencyId, topicId);
     var response =
         new DepartmentLegalDTO()
-            .dpp(new DepartmentLegalContentDTO().content(view.dppContent()))
-            .imprint(new DepartmentLegalContentDTO().content(view.imprintContent()));
+            .dpp(toContentDto(view.dpp()))
+            .imprint(toContentDto(view.imprint()));
     return new ResponseEntity<>(response, HttpStatus.OK);
+  }
+
+  /**
+   * Maps one resolved text onto the public response. The level and the version id travel with the
+   * wording: the level because a legal document without one is not a statement anyone can act on
+   * (ADR-021 decision 1), and the version id because it is what ORISO-UserService pins a recorded
+   * consent to ({@code session.consented_legal_version_id}, ADR-022 decision 2).
+   */
+  private DepartmentLegalContentDTO toContentDto(ResolvedLegalText resolved) {
+    if (resolved == null) {
+      return new DepartmentLegalContentDTO();
+    }
+    return new DepartmentLegalContentDTO()
+        .content(resolved.content())
+        .consentText(resolved.consentText())
+        .sourceLevel(
+            resolved.sourceLevel() == null
+                ? null
+                : DepartmentLegalContentDTO.SourceLevelEnum.fromValue(
+                    resolved.sourceLevel().name()))
+        .versionId(resolved.versionId());
   }
 
   /**

--- a/src/main/java/de/caritas/cob/agencyservice/api/repository/agency/Agency.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/repository/agency/Agency.java
@@ -219,6 +219,13 @@ public class Agency implements TenantAware {
   @JdbcTypeCode(Types.LONGVARCHAR)
   private String contentDpp;
 
+  /**
+   * ADR-021 decision 4: the agency-wide consent sentence, a field of {@link #contentDpp}. This
+   * level carries no publication status - what is stored, applies - so saving it is publishing it.
+   */
+  @Column(name = "consent_text", columnDefinition = "longtext")
+  private String consentText;
+
   /** Agency-wide imprint; see {@link #contentDpp}. */
   @Column(name = "content_imprint", columnDefinition = "longtext")
   @JdbcTypeCode(Types.LONGVARCHAR)

--- a/src/main/java/de/caritas/cob/agencyservice/api/repository/agencytopic/AgencyTopic.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/repository/agencytopic/AgencyTopic.java
@@ -91,6 +91,17 @@ public class AgencyTopic {
   @Column(name = "publication_status", nullable = false)
   private PublicationStatus publicationStatus = PublicationStatus.DRAFT;
 
+  /**
+   * ADR-021 decision 4: the consent sentence a help-seeker ticks is a FIELD OF THE DPP, not a legal
+   * text of its own - so it shares {@link #publicationStatus} and the DPP's version history, and
+   * "which consent belonged to which policy" is answered by "the same version".
+   *
+   * <p>JSON language to text map, like {@link #contentDpp}. Tokens use the {@code {{key}}} dialect
+   * and must never pass through Freemarker (ADR-021 decision 6).
+   */
+  @Column(name = "consent_text")
+  private String consentText;
+
   /** This department's (Fachbereich) own imprint (Impressum) text. */
   @Column(name = "content_imprint")
   private String contentImprint;

--- a/src/main/java/de/caritas/cob/agencyservice/api/repository/legaltext/LegalText.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/repository/legaltext/LegalText.java
@@ -58,6 +58,14 @@ public class LegalText {
   @Column(name = "content")
   private String content;
 
+  /**
+   * ADR-021 decision 4: the consent sentence belonging to this text, when it is a DPP. Shares this
+   * object's {@link #publicationStatus} and version history — one document, one history.
+   * {@code null} for imprints, which are never consent-bearing (ADR-021 decision 7).
+   */
+  @Column(name = "consent_text")
+  private String consentText;
+
   @Builder.Default
   @Enumerated(EnumType.STRING)
   @Column(name = "publication_status", nullable = false)

--- a/src/main/java/de/caritas/cob/agencyservice/api/repository/legaltext/LegalTextLevel.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/repository/legaltext/LegalTextLevel.java
@@ -1,0 +1,21 @@
+package de.caritas.cob.agencyservice.api.repository.legaltext;
+
+/**
+ * Which level of the ADR-021 ladder a stored legal text belongs to. AgencyService owns the lower
+ * three of the four levels; the Träger (tenant) and platform-operator levels live in
+ * ORISO-TenantService and are resolved, not stored, here.
+ *
+ * <p>Every history row names its level explicitly: ADR-021 decision 1 forbids referring to "the
+ * privacy policy" without saying which level it is.
+ */
+public enum LegalTextLevel {
+
+  /** Level 4, Fachbereich: {@code agency_topic.id}. The normal case. */
+  DEPARTMENT,
+
+  /** Level 3, Beratungsstelle: {@code agency.id}. */
+  AGENCY,
+
+  /** The ADR-014 shared legal-text object: {@code legal_text.id}. */
+  SHARED
+}

--- a/src/main/java/de/caritas/cob/agencyservice/api/repository/legaltext/LegalTextVersion.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/repository/legaltext/LegalTextVersion.java
@@ -74,6 +74,14 @@ public class LegalTextVersion {
   @Column(name = "content", columnDefinition = "longtext")
   private String content;
 
+  /**
+   * The consent sentence as published alongside {@link #content} (ADR-021 decision 4). Changing
+   * only the consent wording still means publishing a new DPP version whose body may be identical
+   * — that is the point: one version pointer covers both.
+   */
+  @Column(name = "consent_text", columnDefinition = "longtext")
+  private String consentText;
+
   @Column(name = "published_at", nullable = false)
   private LocalDateTime publishedAt;
 

--- a/src/main/java/de/caritas/cob/agencyservice/api/repository/legaltext/LegalTextVersion.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/repository/legaltext/LegalTextVersion.java
@@ -1,0 +1,90 @@
+package de.caritas.cob.agencyservice.api.repository.legaltext;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * One immutable snapshot of a legal text as it was published (ADR-021 decision 3). Blueprint:
+ * ORISO-TenantService's {@code tenant_dpa_version}, generalised over {@link LegalTextKind} and
+ * {@link LegalTextLevel} so DPP, imprint and future kinds share one mechanism instead of one
+ * special case per document.
+ *
+ * <p><b>Identity is the surrogate {@link #id}, never {@link #publishedAt}.</b> The AVV work keyed
+ * its versions by the activation timestamp and had to truncate it to seconds to survive the
+ * MariaDB {@code DATETIME(0)} round trip; every consumer then had to reproduce that truncation
+ * exactly or silently miss. Nothing here depends on timestamp equality.
+ *
+ * <p>Rows are append-only. Republishing sets {@link #supersededAt} on the previous current row and
+ * inserts a new one; nothing ever edits a stored wording, because the point of the table is to be
+ * able to produce the wording that was in force on a given date.
+ */
+@Entity
+@Table(name = "legal_text_version")
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@Builder
+public class LegalTextVersion {
+
+  @Id
+  @SequenceGenerator(
+      name = "legal_text_version_id_seq",
+      allocationSize = 1,
+      sequenceName = "sequence_legal_text_version")
+  @GeneratedValue(
+      strategy = GenerationType.SEQUENCE,
+      generator = "legal_text_version_id_seq")
+  @Column(name = "id", updatable = false, nullable = false)
+  private Long id;
+
+  /** Owning Träger, copied from the owner at publish time. {@code null} in single-tenant mode. */
+  @Column(name = "tenant_id")
+  private Long tenantId;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "kind", nullable = false)
+  private LegalTextKind kind;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "owner_level", nullable = false)
+  private LegalTextLevel ownerLevel;
+
+  /**
+   * The id of the row this snapshot belongs to, interpreted per {@link #ownerLevel}:
+   * {@code agency_topic.id}, {@code agency.id} or {@code legal_text.id}.
+   */
+  @Column(name = "owner_id", nullable = false)
+  private Long ownerId;
+
+  /** The wording as published: the JSON language→HTML map string, stored verbatim. */
+  @Column(name = "content", columnDefinition = "longtext")
+  private String content;
+
+  @Column(name = "published_at", nullable = false)
+  private LocalDateTime publishedAt;
+
+  /**
+   * Keycloak user id of the publisher, or {@code null} when the publish had no authenticated user.
+   * Never guessed — an unknown publisher is recorded as unknown (#212).
+   */
+  @Column(name = "published_by")
+  private String publishedBy;
+
+  /** {@code null} = the version currently in force for this owner and kind. */
+  @Column(name = "superseded_at")
+  private LocalDateTime supersededAt;
+}

--- a/src/main/java/de/caritas/cob/agencyservice/api/repository/legaltext/LegalTextVersionRepository.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/repository/legaltext/LegalTextVersionRepository.java
@@ -1,0 +1,28 @@
+package de.caritas.cob.agencyservice.api.repository.legaltext;
+
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/** Read/append access to the ADR-021 legal-text publication history. */
+public interface LegalTextVersionRepository extends JpaRepository<LegalTextVersion, Long> {
+
+  /** The full history of one document, newest first (the order the version picker expects). */
+  List<LegalTextVersion> findByOwnerLevelAndOwnerIdAndKindOrderByPublishedAtDescIdDesc(
+      LegalTextLevel ownerLevel, Long ownerId, LegalTextKind kind);
+
+  /**
+   * The version currently in force for one document, i.e. the one not yet superseded. Ordered by
+   * id so a same-second republish (MariaDB {@code datetime} has no sub-second precision) still has
+   * a deterministic winner.
+   */
+  Optional<LegalTextVersion> findFirstByOwnerLevelAndOwnerIdAndKindAndSupersededAtIsNullOrderByIdDesc(
+      LegalTextLevel ownerLevel, Long ownerId, LegalTextKind kind);
+
+  /**
+   * Every not-yet-superseded row of one document. Normally at most one; the list form exists so
+   * superseding is idempotent if a historical bug ever left two rows open.
+   */
+  List<LegalTextVersion> findByOwnerLevelAndOwnerIdAndKindAndSupersededAtIsNull(
+      LegalTextLevel ownerLevel, Long ownerId, LegalTextKind kind);
+}

--- a/src/main/java/de/caritas/cob/agencyservice/api/service/AgencyService.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/service/AgencyService.java
@@ -26,6 +26,7 @@ import de.caritas.cob.agencyservice.api.repository.agencytopic.PublicationStatus
 import de.caritas.cob.agencyservice.api.repository.legaltext.LegalText;
 import de.caritas.cob.agencyservice.api.tenant.TenantContext;
 import de.caritas.cob.agencyservice.consultingtypeservice.generated.web.model.ExtendedConsultingTypeResponseDTO;
+import de.caritas.cob.agencyservice.api.service.legal.LegalTextInheritanceResolver;
 import de.caritas.cob.agencyservice.tenantservice.generated.web.model.RestrictedTenantDTO;
 import de.caritas.cob.agencyservice.api.service.matrix.MatrixProvisioningService;
 import de.caritas.cob.agencyservice.api.service.matrix.AgencyMatrixPasswordCipher;
@@ -73,6 +74,8 @@ public class AgencyService {
   private final @NonNull AgencySettingsService agencySettingsService;
 
   private final @NonNull AgencyAdminControlsService agencyAdminControlsService;
+
+  private final @NonNull LegalTextInheritanceResolver legalTextInheritanceResolver;
 
   private final @NonNull AgencyEffectivePermissionSettingsApplier
       effectivePermissionSettingsApplier;
@@ -551,26 +554,22 @@ public class AgencyService {
     return departmentValue != null ? departmentValue : agencyValue;
   }
 
+  /**
+   * Whether a data protection policy is in force for this department at all.
+   *
+   * <p>Measured defect, fixed here (CONTEXT-legal-documents, "known traps"): this used to be
+   * computed from the department level only, while {@code DepartmentLegalService} already fell back
+   * to the agency-wide text. A department could therefore report {@code hasPublishedDpp: false}
+   * while {@code /legal} returned content, and a client trusting the flag hid a document that
+   * existed. Both now ask the same resolver, so the flag cannot disagree with the endpoint.
+   */
   private boolean hasPublishedDpp(AgencyTopic agencyTopic) {
-    LegalText referenced = agencyTopic.getDpp();
-    if (referenced != null) {
-      return hasPublishedContent(referenced.getContent(), referenced.getPublicationStatus());
-    }
-    return hasPublishedContent(agencyTopic.getContentDpp(), agencyTopic.getPublicationStatus());
+    return legalTextInheritanceResolver.resolveDpp(agencyTopic).isPresent();
   }
 
+  /** Same fix for the imprint half — an inherited imprint is reachable and must be reported so. */
   private boolean hasPublishedImprint(AgencyTopic agencyTopic) {
-    LegalText referenced = agencyTopic.getImprint();
-    if (referenced != null) {
-      return hasPublishedContent(referenced.getContent(), referenced.getPublicationStatus());
-    }
-    return hasPublishedContent(
-        agencyTopic.getContentImprint(), agencyTopic.getPublicationStatusImprint());
-  }
-
-  private boolean hasPublishedContent(String content, PublicationStatus status) {
-    var hasContent = content != null && !content.isBlank();
-    return PublicationStatus.PUBLISHED == status && hasContent;
+    return legalTextInheritanceResolver.resolveImprint(agencyTopic).isPresent();
   }
 
   private DemographicsDTO getDemographics(Agency agency) {

--- a/src/main/java/de/caritas/cob/agencyservice/api/service/DepartmentLegalService.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/service/DepartmentLegalService.java
@@ -4,7 +4,6 @@ import de.caritas.cob.agencyservice.api.exception.httpresponses.NotFoundExceptio
 import de.caritas.cob.agencyservice.api.repository.agency.Agency;
 import de.caritas.cob.agencyservice.api.repository.agencytopic.AgencyTopic;
 import de.caritas.cob.agencyservice.api.repository.agencytopic.AgencyTopicRepository;
-import de.caritas.cob.agencyservice.api.repository.agencytopic.PublicationStatus;
 import de.caritas.cob.agencyservice.api.service.legal.LegalTextInheritanceResolver;
 import de.caritas.cob.agencyservice.api.service.legal.PublicLegalTextRenderer;
 import lombok.NonNull;
@@ -75,11 +74,5 @@ public class DepartmentLegalService {
     if (agency == null || agency.getDeleteDate() != null) {
       throw new NotFoundException();
     }
-  }
-
-  /** Kept for callers that only care whether a raw stored text counts as published. */
-  static boolean isPublished(String content, PublicationStatus status) {
-    var hasContent = content != null && !content.isBlank();
-    return PublicationStatus.PUBLISHED == status && hasContent;
   }
 }

--- a/src/main/java/de/caritas/cob/agencyservice/api/service/DepartmentLegalService.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/service/DepartmentLegalService.java
@@ -6,6 +6,7 @@ import de.caritas.cob.agencyservice.api.repository.agencytopic.AgencyTopic;
 import de.caritas.cob.agencyservice.api.repository.agencytopic.AgencyTopicRepository;
 import de.caritas.cob.agencyservice.api.repository.agencytopic.PublicationStatus;
 import de.caritas.cob.agencyservice.api.service.legal.LegalTextInheritanceResolver;
+import de.caritas.cob.agencyservice.api.service.legal.PublicLegalTextRenderer;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -32,6 +33,7 @@ public class DepartmentLegalService {
 
   private final @NonNull AgencyTopicRepository agencyTopicRepository;
   private final @NonNull LegalTextInheritanceResolver legalTextInheritanceResolver;
+  private final @NonNull PublicLegalTextRenderer publicLegalTextRenderer;
 
   /**
    * Loads the legal texts in force for the department, resolved across all four ADR-021 levels.
@@ -48,9 +50,12 @@ public class DepartmentLegalService {
 
     assertAgencyIsNotDeleted(department.getAgency());
 
+    // ADR-021 decision 5: substitute what the server owns, leave {{legal_links}} for the client.
     return new DepartmentLegalView(
-        legalTextInheritanceResolver.resolveDpp(department),
-        legalTextInheritanceResolver.resolveImprint(department));
+        publicLegalTextRenderer.render(
+            legalTextInheritanceResolver.resolveDpp(department), department),
+        publicLegalTextRenderer.render(
+            legalTextInheritanceResolver.resolveImprint(department), department));
   }
 
   /**

--- a/src/main/java/de/caritas/cob/agencyservice/api/service/DepartmentLegalService.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/service/DepartmentLegalService.java
@@ -5,27 +5,36 @@ import de.caritas.cob.agencyservice.api.repository.agency.Agency;
 import de.caritas.cob.agencyservice.api.repository.agencytopic.AgencyTopic;
 import de.caritas.cob.agencyservice.api.repository.agencytopic.AgencyTopicRepository;
 import de.caritas.cob.agencyservice.api.repository.agencytopic.PublicationStatus;
-import de.caritas.cob.agencyservice.api.repository.legaltext.LegalText;
+import de.caritas.cob.agencyservice.api.service.legal.LegalTextInheritanceResolver;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
- * Public (unauthenticated) read side of ADR-003's department legal texts: exposes a department's
- * (Fachbereich = agency × topic) data privacy policy and imprint to end users, but only once they
- * are {@link PublicationStatus#PUBLISHED}. Draft or never-authored texts resolve to {@code null}
- * content — a draft is a provisional working basis recorded in the audit trail, never a document
- * shown to clients.
+ * Public (unauthenticated) read side of the department's (Fachbereich = agency × topic) legal
+ * texts: what a help-seeker is shown before and at Gate 2.
+ *
+ * <p>Since ADR-021 decision 9 the resolution is not this class's own logic any more — it delegates
+ * to {@link LegalTextInheritanceResolver}, which walks the whole ladder department → agency →
+ * Träger → platform operator in one place. Before that, this class stopped at the agency level and
+ * the two upper rungs were reimplemented on the clients (Admin {@code mergeTranslatedContent},
+ * Frontend {@code pickConsentPrivacyContent}), so which document a help-seeker saw depended on
+ * which client rendered it.
+ *
+ * <p>Draft or never-authored texts still resolve past the department level rather than to nothing —
+ * a draft is a provisional working basis, never a document shown to clients, and a Fachbereich
+ * still drafting must not blank out a legally required document.
  */
 @Service
 @RequiredArgsConstructor
 public class DepartmentLegalService {
 
   private final @NonNull AgencyTopicRepository agencyTopicRepository;
+  private final @NonNull LegalTextInheritanceResolver legalTextInheritanceResolver;
 
   /**
-   * Loads the department's published legal texts.
+   * Loads the legal texts in force for the department, resolved across all four ADR-021 levels.
    *
    * @throws NotFoundException when the (agency, topic) pairing does not exist or the agency is
    *     deleted
@@ -40,51 +49,21 @@ public class DepartmentLegalService {
     assertAgencyIsNotDeleted(department.getAgency());
 
     return new DepartmentLegalView(
-        resolveDpp(department), resolveImprint(department));
+        legalTextInheritanceResolver.resolveDpp(department),
+        legalTextInheritanceResolver.resolveImprint(department));
   }
 
   /**
-   * ADR-014 resolution order: a referenced shared legal-text object, once assigned, fully replaces
-   * the legacy inline column — including its DRAFT state. Only reference-less rows fall back to the
-   * inline content.
+   * Whether the department has a data protection policy in force at all, across the whole chain.
    *
-   * <p><b>Unassign semantics (this release):</b> clearing {@code dpp_id}/{@code imprint_id} makes a
-   * department reference-less again, so it falls back to its own inline {@code content_dpp}/{@code
-   * content_imprint}. The backfill deliberately keeps the inline columns for one release as this
-   * read-fallback and as the rollback anchor; they are not cleared on unassign.
-   *
-   * <p>Whatever the department resolves to, an unpublished or absent result then inherits the
-   * agency-wide text (#222) — the middle level of the chain tenant → agency → department. The
-   * tenant remains the last fallback and is still resolved client-side (see ADR-014 / #134).
+   * <p>This is the flag the registration search reports as {@code hasPublishedDpp}. It used to be
+   * computed from the department level alone while this service already fell back to the
+   * agency-wide text, so a department could report {@code false} while {@code /legal} returned
+   * content — the client then hid a document that existed.
    */
-  private String resolveDpp(AgencyTopic department) {
-    LegalText referenced = department.getDpp();
-    var own =
-        referenced != null
-            ? publishedContentOrNull(referenced.getContent(), referenced.getPublicationStatus())
-            : publishedContentOrNull(department.getContentDpp(), department.getPublicationStatus());
-    return own != null ? own : agencyWideOrNull(department.getAgency().getContentDpp());
-  }
-
-  private String resolveImprint(AgencyTopic department) {
-    LegalText referenced = department.getImprint();
-    var own =
-        referenced != null
-            ? publishedContentOrNull(referenced.getContent(), referenced.getPublicationStatus())
-            : publishedContentOrNull(
-                department.getContentImprint(), department.getPublicationStatusImprint());
-    return own != null ? own : agencyWideOrNull(department.getAgency().getContentImprint());
-  }
-
-  /**
-   * The inherited middle level of the ADR-014 chain tenant → agency → department. It carries no
-   * publication status of its own: a Beratungsstelle's stored text is the text in force, so any
-   * department that has not published its own keeps showing it. That is deliberate — a department
-   * still drafting must not blank out a legally required document, so a DRAFT falls through to
-   * here rather than resolving to nothing.
-   */
-  private String agencyWideOrNull(String agencyWideContent) {
-    return agencyWideContent == null || agencyWideContent.isBlank() ? null : agencyWideContent;
+  @Transactional(readOnly = true)
+  public boolean hasResolvableDpp(AgencyTopic department) {
+    return legalTextInheritanceResolver.resolveDpp(department).isPresent();
   }
 
   private void assertAgencyIsNotDeleted(Agency agency) {
@@ -93,8 +72,9 @@ public class DepartmentLegalService {
     }
   }
 
-  private String publishedContentOrNull(String content, PublicationStatus status) {
+  /** Kept for callers that only care whether a raw stored text counts as published. */
+  static boolean isPublished(String content, PublicationStatus status) {
     var hasContent = content != null && !content.isBlank();
-    return PublicationStatus.PUBLISHED == status && hasContent ? content : null;
+    return PublicationStatus.PUBLISHED == status && hasContent;
   }
 }

--- a/src/main/java/de/caritas/cob/agencyservice/api/service/DepartmentLegalView.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/service/DepartmentLegalView.java
@@ -1,8 +1,20 @@
 package de.caritas.cob.agencyservice.api.service;
 
+import de.caritas.cob.agencyservice.api.service.legal.ResolvedLegalText;
+
 /**
- * Public read view of a department's (Fachbereich = agency × topic) legal texts. Both fields carry
- * the stored JSON language→HTML map string when the respective text is PUBLISHED, and {@code null}
- * when it is a draft or was never authored — drafts are never exposed to users.
+ * Public read view of a department's (Fachbereich = agency × topic) legal texts, each resolved
+ * across the full ADR-021 ladder. Both carry the level they came from and — where AgencyService
+ * owns the history for that level — the version id the wording corresponds to.
  */
-public record DepartmentLegalView(String dppContent, String imprintContent) {}
+public record DepartmentLegalView(ResolvedLegalText dpp, ResolvedLegalText imprint) {
+
+  /** Convenience for callers that only want the wording. */
+  public String dppContent() {
+    return dpp == null ? null : dpp.content();
+  }
+
+  public String imprintContent() {
+    return imprint == null ? null : imprint.content();
+  }
+}

--- a/src/main/java/de/caritas/cob/agencyservice/api/service/legal/LegalTextInheritanceResolver.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/service/legal/LegalTextInheritanceResolver.java
@@ -1,0 +1,261 @@
+package de.caritas.cob.agencyservice.api.service.legal;
+
+import de.caritas.cob.agencyservice.api.repository.agency.Agency;
+import de.caritas.cob.agencyservice.api.repository.agencytopic.AgencyTopic;
+import de.caritas.cob.agencyservice.api.repository.agencytopic.PublicationStatus;
+import de.caritas.cob.agencyservice.api.repository.legaltext.LegalText;
+import de.caritas.cob.agencyservice.api.repository.legaltext.LegalTextKind;
+import de.caritas.cob.agencyservice.api.repository.legaltext.LegalTextLevel;
+import de.caritas.cob.agencyservice.api.repository.legaltext.LegalTextVersionRepository;
+import de.caritas.cob.agencyservice.api.service.ApplicationSettingsService;
+import de.caritas.cob.agencyservice.api.service.TenantService;
+import de.caritas.cob.agencyservice.api.util.JsonConverter;
+import de.caritas.cob.agencyservice.tenantservice.generated.web.model.RestrictedTenantDTO;
+import java.util.Map;
+import java.util.function.Function;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+/**
+ * ADR-021 decision 9: the whole department → agency → Träger → platform-operator chain resolved in
+ * <b>one place, on the server</b>.
+ *
+ * <p>Before this, only the lower half was server-side ({@code DepartmentLegalService} did
+ * department → agency) and the upper half was reimplemented twice on clients — Admin's {@code
+ * mergeTranslatedContent} and Frontend's {@code pickConsentPrivacyContent}. Two independent
+ * implementations of a legal-document fallback is a defect source in its own right, and the consent
+ * sentence would otherwise have inherited it: the sentence a help-seeker ticks would be picked by
+ * whichever client happened to render it.
+ *
+ * <h2>The four rungs</h2>
+ *
+ * <ol>
+ *   <li><b>Fachbereich</b> ({@code agency_topic}) — its own text, but only once PUBLISHED. A draft
+ *       falls through rather than blanking out a legally required document. Per ADR-014 a
+ *       referenced shared {@code legal_text} object, once assigned, fully replaces the inline
+ *       column including its DRAFT state.
+ *   <li><b>Beratungsstelle</b> ({@code agency}) — no publication status at all: what is stored,
+ *       applies.
+ *   <li><b>Träger</b> / <b>platform operator</b> — both live in ORISO-TenantService and are read
+ *       through the existing {@link TenantService} client rather than a new one. Which of the two
+ *       answers is decided by {@code legalContentChangesBySingleTenantAdminsAllowed}: when it is
+ *       on, a Träger <em>replaces</em> the platform text; when it is off, the platform's own
+ *       document governs and the Träger's is not consulted. That is the same rule {@code
+ *       CentralDataProtectionTemplateService} already applies to the DPP template, kept identical
+ *       on purpose — two different answers to "whose text governs" is exactly the bug class this
+ *       ADR closes.
+ * </ol>
+ *
+ * <h2>Failure behaviour</h2>
+ *
+ * <p>The upper two rungs are a cross-service call. If TenantService is unreachable the resolution
+ * degrades to what AgencyService knows locally and logs it; it never turns a help-seeker's request
+ * for a privacy policy into a 500. An unreachable Träger document is a gap the caller can detect
+ * (level {@link LegalTextSourceLevel#NONE}) and handle, whereas a failed request is not.
+ */
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class LegalTextInheritanceResolver {
+
+  private final @NonNull LegalTextVersionRepository legalTextVersionRepository;
+  private final @NonNull TenantService tenantService;
+  private final @NonNull ApplicationSettingsService applicationSettingsService;
+
+  @Value("${feature.multitenancy.with.single.domain.enabled}")
+  private boolean multitenancyWithSingleDomain;
+
+  /**
+   * Resolves the data protection policy in force for a department, together with the consent
+   * sentence stored with it.
+   */
+  public ResolvedLegalText resolveDpp(AgencyTopic department) {
+    return resolve(department, LegalTextKind.DPP);
+  }
+
+  /**
+   * Resolves the imprint in force for a department. The consent field is always {@code null} here:
+   * an imprint is an information duty, never a consent gate (ADR-021 decision 7).
+   */
+  public ResolvedLegalText resolveImprint(AgencyTopic department) {
+    return resolve(department, LegalTextKind.IMPRINT);
+  }
+
+  private ResolvedLegalText resolve(AgencyTopic department, LegalTextKind kind) {
+    if (department == null) {
+      return ResolvedLegalText.none();
+    }
+    var fromDepartment = fromDepartment(department, kind);
+    if (fromDepartment != null) {
+      return fromDepartment;
+    }
+    var agency = department.getAgency();
+    var fromAgency = fromAgency(agency, kind);
+    if (fromAgency != null) {
+      return fromAgency;
+    }
+    return fromTenantChain(agency, kind);
+  }
+
+  /**
+   * Rung 4. A referenced shared object wins over the inline column entirely (ADR-014), so its own
+   * publication status decides; a reference-less department falls back to its inline text.
+   */
+  private ResolvedLegalText fromDepartment(AgencyTopic department, LegalTextKind kind) {
+    LegalText referenced = kind == LegalTextKind.DPP ? department.getDpp() : department.getImprint();
+    if (referenced != null) {
+      if (!isPublished(referenced.getContent(), referenced.getPublicationStatus())) {
+        return null;
+      }
+      return new ResolvedLegalText(
+          referenced.getContent(),
+          consentOf(kind, referenced.getConsentText()),
+          LegalTextSourceLevel.DEPARTMENT,
+          currentVersionId(LegalTextLevel.SHARED, referenced.getId(), kind));
+    }
+
+    var content =
+        kind == LegalTextKind.DPP ? department.getContentDpp() : department.getContentImprint();
+    var status =
+        kind == LegalTextKind.DPP
+            ? department.getPublicationStatus()
+            : department.getPublicationStatusImprint();
+    if (!isPublished(content, status)) {
+      return null;
+    }
+    return new ResolvedLegalText(
+        content,
+        consentOf(kind, department.getConsentText()),
+        LegalTextSourceLevel.DEPARTMENT,
+        currentVersionId(LegalTextLevel.DEPARTMENT, department.getId(), kind));
+  }
+
+  /** Rung 3. No publication status here — a stored Beratungsstelle text is the text in force. */
+  private ResolvedLegalText fromAgency(Agency agency, LegalTextKind kind) {
+    if (agency == null) {
+      return null;
+    }
+    var content = kind == LegalTextKind.DPP ? agency.getContentDpp() : agency.getContentImprint();
+    if (isBlank(content)) {
+      return null;
+    }
+    return new ResolvedLegalText(
+        content,
+        consentOf(kind, agency.getConsentText()),
+        LegalTextSourceLevel.AGENCY,
+        currentVersionId(LegalTextLevel.AGENCY, agency.getId(), kind));
+  }
+
+  /**
+   * Rungs 2 and 1. Which one answers is the {@code legalContentChangesBySingleTenantAdminsAllowed}
+   * decision described in the class comment.
+   *
+   * <p>The tenant API exposes both a resolved string and the raw {@code <lang>Languages} map. The
+   * map is preferred because every level below stores a language→HTML map, and handing callers two
+   * different shapes depending on which rung answered would push the multilingual pick back onto
+   * the client — the very split this decision removes.
+   */
+  private ResolvedLegalText fromTenantChain(Agency agency, LegalTextKind kind) {
+    RestrictedTenantDTO tenant = loadGoverningTenant(agency);
+    if (tenant == null || tenant.getContent() == null) {
+      return ResolvedLegalText.none();
+    }
+    var level =
+        multitenancyWithSingleDomain && !isTenantLevelLegalContentOverrideAllowed()
+            ? LegalTextSourceLevel.PLATFORM
+            : LegalTextSourceLevel.TENANT;
+
+    var languageMap =
+        kind == LegalTextKind.DPP
+            ? tenant.getContent().getPrivacyLanguages()
+            : tenant.getContent().getImpressumLanguages();
+    if (languageMap != null && !languageMap.isEmpty()) {
+      return new ResolvedLegalText(JsonConverter.convertToJson(languageMap), null, level, null);
+    }
+
+    var single =
+        kind == LegalTextKind.DPP
+            ? tenant.getContent().getPrivacy()
+            : tenant.getContent().getImpressum();
+    if (isBlank(single)) {
+      return ResolvedLegalText.none();
+    }
+    // A tenant that only ever stored one language still has to come back in the map shape.
+    return new ResolvedLegalText(
+        JsonConverter.convertToJson(Map.of("de", single)), null, level, null);
+  }
+
+  /**
+   * The Träger's own document when it may replace the platform's, the platform's own otherwise.
+   * Mirrors {@code CentralDataProtectionTemplateService} deliberately.
+   */
+  private RestrictedTenantDTO loadGoverningTenant(Agency agency) {
+    return callTenantService(
+        ignored -> {
+          if (multitenancyWithSingleDomain && !isTenantLevelLegalContentOverrideAllowed()) {
+            return tenantService.getMainTenant();
+          }
+          if (agency != null && agency.getTenantId() != null) {
+            return tenantService.getRestrictedTenantDataByTenantId(agency.getTenantId());
+          }
+          return tenantService.getRestrictedTenantDataForSingleTenant();
+        },
+        agency);
+  }
+
+  /**
+   * A legal-text read must never fail because a neighbouring service is down. The caller sees a gap
+   * it can react to; a 500 on the public {@code /legal} path would just be an outage.
+   */
+  private RestrictedTenantDTO callTenantService(
+      Function<Agency, RestrictedTenantDTO> call, Agency agency) {
+    try {
+      return call.apply(agency);
+    } catch (Exception e) {
+      log.warn(
+          "Could not resolve the Träger/platform legal text for agency {}: {}",
+          agency == null ? null : agency.getId(),
+          e.getMessage());
+      return null;
+    }
+  }
+
+  /**
+   * Only consulted in single-domain multitenancy, where levels 1 and 2 are distinguishable at all.
+   * An unavailable settings service is treated as "no override": defaulting the other way would
+   * silently promote a Träger's text over the platform's on a transient failure.
+   */
+  private boolean isTenantLevelLegalContentOverrideAllowed() {
+    var settings = applicationSettingsService.getApplicationSettings();
+    var toggle =
+        settings == null ? null : settings.getLegalContentChangesBySingleTenantAdminsAllowed();
+    return toggle != null && Boolean.TRUE.equals(toggle.getValue());
+  }
+
+  /** ADR-021 decision 7: an imprint never carries a consent sentence. */
+  private String consentOf(LegalTextKind kind, String storedConsent) {
+    return kind == LegalTextKind.DPP ? storedConsent : null;
+  }
+
+  private Long currentVersionId(LegalTextLevel level, Long ownerId, LegalTextKind kind) {
+    if (ownerId == null) {
+      return null;
+    }
+    return legalTextVersionRepository
+        .findFirstByOwnerLevelAndOwnerIdAndKindAndSupersededAtIsNullOrderByIdDesc(
+            level, ownerId, kind)
+        .map(version -> version.getId())
+        .orElse(null);
+  }
+
+  private boolean isPublished(String content, PublicationStatus status) {
+    return PublicationStatus.PUBLISHED == status && !isBlank(content);
+  }
+
+  private boolean isBlank(String value) {
+    return value == null || value.isBlank();
+  }
+}

--- a/src/main/java/de/caritas/cob/agencyservice/api/service/legal/LegalTextSourceLevel.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/service/legal/LegalTextSourceLevel.java
@@ -1,0 +1,27 @@
+package de.caritas.cob.agencyservice.api.service.legal;
+
+/**
+ * Which rung of the ADR-021 ladder a resolved legal text actually came from.
+ *
+ * <p>ADR-021 decision 1: "the privacy policy" without a level is not a valid statement. Every
+ * resolution therefore reports where its answer came from, so a caller — and a support engineer
+ * reading a bug report — can tell a Fachbereich's own document from an inherited one without
+ * guessing.
+ */
+public enum LegalTextSourceLevel {
+
+  /** Level 4, Fachbereich (agency × topic) — the normal case at Gate 2. */
+  DEPARTMENT,
+
+  /** Level 3, Beratungsstelle — the agency-wide text every department inherits. */
+  AGENCY,
+
+  /** Level 2, Träger — {@code tenant.content_privacy} / {@code content_impressum}. */
+  TENANT,
+
+  /** Level 1, platform operator — the "main tenant" under single-domain multitenancy. */
+  PLATFORM,
+
+  /** Nothing is authored anywhere on the chain. */
+  NONE
+}

--- a/src/main/java/de/caritas/cob/agencyservice/api/service/legal/PublicLegalTextRenderer.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/service/legal/PublicLegalTextRenderer.java
@@ -1,5 +1,7 @@
 package de.caritas.cob.agencyservice.api.service.legal;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import de.caritas.cob.agencyservice.api.admin.service.legal.LegalTextTokens;
 import de.caritas.cob.agencyservice.api.repository.agencytopic.AgencyTopic;
 import de.caritas.cob.agencyservice.api.service.TopicService;
@@ -44,6 +46,12 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class PublicLegalTextRenderer {
 
+  private static final String META_KEY_SUFFIX = "__meta";
+  private static final TypeReference<LinkedHashMap<String, String>> LANGUAGE_MAP =
+      new TypeReference<>() {};
+
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
   /**
    * Optional: the topics feature is toggleable, and this must not become a hard dependency of the
    * public legal path.
@@ -54,11 +62,17 @@ public class PublicLegalTextRenderer {
   /**
    * Substitutes the server-owned tokens in a resolved text and its consent sentence.
    *
-   * <p>The stored form is a JSON language→HTML map string and the substitution is applied to that
-   * string as a whole. That is safe because the tokens are literal and only ever occur inside
-   * values — a language key is a code like {@code de}, never prose — and it avoids a
-   * parse/serialise round trip that would re-order keys and re-escape entities on a hot public
-   * path.
+   * <p>The stored form is a JSON language→HTML map string, and substitution runs <b>inside the
+   * parsed values</b>, never over the serialised string. Replacing text in the JSON representation
+   * looks tempting and is wrong twice over: a perfectly ordinary name like {@code Caritas "Mitte"}
+   * would break out of its JSON string and hand clients an unparseable document, and a name
+   * containing markup would land in already-sanitised HTML without ever meeting the sanitiser.
+   * Values are therefore {@linkplain LegalTextTokens#escapeForHtml HTML-escaped} and the map is
+   * re-serialised properly.
+   *
+   * <p>{@code __meta} keys carry translation metadata as JSON, not prose, and are passed through
+   * untouched — substituting into them would corrupt the payload the same way sanitising them
+   * would.
    */
   public ResolvedLegalText render(ResolvedLegalText resolved, AgencyTopic department) {
     if (resolved == null || department == null) {
@@ -69,22 +83,59 @@ public class PublicLegalTextRenderer {
       return resolved;
     }
     return new ResolvedLegalText(
-        LegalTextTokens.substitute(resolved.content(), values),
-        LegalTextTokens.substitute(resolved.consentText(), values),
+        substituteInLanguageMap(resolved.content(), values),
+        substituteInLanguageMap(resolved.consentText(), values),
         resolved.sourceLevel(),
         resolved.versionId());
   }
 
-  /** Only tokens the server can actually answer; the rest is the client's half. */
+  /**
+   * Parses the language→text map, substitutes inside each value, and serialises it again.
+   *
+   * <p>A stored map that does not parse is returned unchanged rather than partially rewritten: a
+   * legal document that is already damaged must not additionally be handed to a help-seeker with
+   * half-substituted placeholders, and this is a public read path that must not fail.
+   */
+  private String substituteInLanguageMap(String storedJson, Map<String, String> values) {
+    if (storedJson == null || storedJson.isBlank()) {
+      return storedJson;
+    }
+    final Map<String, String> byLanguage;
+    try {
+      byLanguage = objectMapper.readValue(storedJson, LANGUAGE_MAP);
+    } catch (Exception e) {
+      log.warn("Stored legal content is not a readable language map; serving it unsubstituted");
+      return storedJson;
+    }
+    var substituted = new LinkedHashMap<String, String>();
+    byLanguage.forEach(
+        (language, text) ->
+            substituted.put(
+                language,
+                language != null && language.endsWith(META_KEY_SUFFIX)
+                    ? text
+                    : LegalTextTokens.substitute(text, values)));
+    try {
+      return objectMapper.writeValueAsString(substituted);
+    } catch (Exception e) {
+      log.warn("Could not re-serialise the substituted legal content; serving it unsubstituted");
+      return storedJson;
+    }
+  }
+
+  /**
+   * Only tokens the server can actually answer; the rest is the client's half. Values are escaped
+   * here, at the one place they enter sanitised HTML.
+   */
   private Map<String, String> serverOwnedValues(AgencyTopic department) {
     var values = new LinkedHashMap<String, String>();
     var agency = department.getAgency();
     if (agency != null && agency.getName() != null) {
-      values.put(LegalTextTokens.BERATUNGSSTELLE, agency.getName());
+      values.put(LegalTextTokens.BERATUNGSSTELLE, LegalTextTokens.escapeForHtml(agency.getName()));
     }
     var topicName = resolveTopicName(department.getTopicId());
     if (topicName != null) {
-      values.put(LegalTextTokens.THEMA, topicName);
+      values.put(LegalTextTokens.THEMA, LegalTextTokens.escapeForHtml(topicName));
     }
     return values;
   }

--- a/src/main/java/de/caritas/cob/agencyservice/api/service/legal/PublicLegalTextRenderer.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/service/legal/PublicLegalTextRenderer.java
@@ -1,0 +1,116 @@
+package de.caritas.cob.agencyservice.api.service.legal;
+
+import de.caritas.cob.agencyservice.api.admin.service.legal.LegalTextTokens;
+import de.caritas.cob.agencyservice.api.repository.agencytopic.AgencyTopic;
+import de.caritas.cob.agencyservice.api.service.TopicService;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+/**
+ * ADR-021 decision 5: placeholder substitution is split by who owns the data. The server fills in
+ * what it knows — the Beratungsstelle and the Fachbereich — and deliberately leaves {@code
+ * {{legal_links}}} standing, because the link targets come from the frontend deployment
+ * configuration ({@code LegalLinksProvider} / {@code settings.legalLinks}) and the backend does not
+ * know them.
+ *
+ * <p>This closes the gap CONTEXT-legal-documents records against
+ * {@code /agencies/{id}/topics/{tid}/legal}: it returned raw, unrendered text, so a placeholder
+ * could reach a help-seeker verbatim. (The same defect class as
+ * {@code DepartmentLegalSection.tsx:104} showing an unsubstituted {@code ${responsible}}.)
+ *
+ * <h2>Never Freemarker</h2>
+ *
+ * <p>Substitution here is {@link LegalTextTokens#substitute}, a literal string replacement.
+ * Träger-authored text must never pass through {@code TemplateRenderer}: Freemarker's {@code
+ * ${...}} can invoke methods on the objects in the data model, which would make tenant-authored
+ * content a template-injection surface (ADR-021 decision 6). A {@code {{key}}} replacement cannot
+ * do that by construction.
+ *
+ * <h2>Unknown tokens are left standing, never blanked</h2>
+ *
+ * <p>The Fachbereich name lives in ORISO-TopicService, and that client sends the caller's bearer
+ * token — which the public, unauthenticated legal endpoint does not have. When the name cannot be
+ * resolved the token is left intact rather than replaced with an empty string: the client knows
+ * which topic it navigated to and can finish the substitution, exactly as it already does for
+ * {@code {{legal_links}}}. Emitting "zum Thema  " would be a silent corruption of a legal sentence;
+ * leaving a token is a visible, recoverable state.
+ */
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class PublicLegalTextRenderer {
+
+  /**
+   * Optional: the topics feature is toggleable, and this must not become a hard dependency of the
+   * public legal path.
+   */
+  @Autowired(required = false)
+  private TopicService topicService;
+
+  /**
+   * Substitutes the server-owned tokens in a resolved text and its consent sentence.
+   *
+   * <p>The stored form is a JSON language→HTML map string and the substitution is applied to that
+   * string as a whole. That is safe because the tokens are literal and only ever occur inside
+   * values — a language key is a code like {@code de}, never prose — and it avoids a
+   * parse/serialise round trip that would re-order keys and re-escape entities on a hot public
+   * path.
+   */
+  public ResolvedLegalText render(ResolvedLegalText resolved, AgencyTopic department) {
+    if (resolved == null || department == null) {
+      return resolved;
+    }
+    var values = serverOwnedValues(department);
+    if (values.isEmpty()) {
+      return resolved;
+    }
+    return new ResolvedLegalText(
+        LegalTextTokens.substitute(resolved.content(), values),
+        LegalTextTokens.substitute(resolved.consentText(), values),
+        resolved.sourceLevel(),
+        resolved.versionId());
+  }
+
+  /** Only tokens the server can actually answer; the rest is the client's half. */
+  private Map<String, String> serverOwnedValues(AgencyTopic department) {
+    var values = new LinkedHashMap<String, String>();
+    var agency = department.getAgency();
+    if (agency != null && agency.getName() != null) {
+      values.put(LegalTextTokens.BERATUNGSSTELLE, agency.getName());
+    }
+    var topicName = resolveTopicName(department.getTopicId());
+    if (topicName != null) {
+      values.put(LegalTextTokens.THEMA, topicName);
+    }
+    return values;
+  }
+
+  private String resolveTopicName(Long topicId) {
+    if (topicService == null || topicId == null) {
+      return null;
+    }
+    try {
+      var topics = topicService.getAllTopics();
+      if (topics == null) {
+        return null;
+      }
+      return topics.stream()
+          .filter(topic -> topicId.equals(topic.getId()))
+          .map(topic -> topic.getName())
+          .filter(name -> name != null && !name.isBlank())
+          .findFirst()
+          .orElse(null);
+    } catch (Exception e) {
+      log.debug(
+          "Could not resolve the Fachbereich name for topic {}; leaving its placeholder for the"
+              + " client to substitute: {}",
+          topicId,
+          e.getMessage());
+      return null;
+    }
+  }
+}

--- a/src/main/java/de/caritas/cob/agencyservice/api/service/legal/ResolvedLegalText.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/service/legal/ResolvedLegalText.java
@@ -1,0 +1,31 @@
+package de.caritas.cob.agencyservice.api.service.legal;
+
+/**
+ * The outcome of one walk up the ADR-021 ladder: the wording that is actually in force, the level it
+ * came from, and — where AgencyService owns a publication history for that level — the id of the
+ * version it corresponds to.
+ *
+ * @param content the stored JSON language→HTML map string, or {@code null} when nothing is authored
+ *     anywhere on the chain
+ * @param consentText the consent sentence stored with the policy (ADR-021 decision 4); always
+ *     {@code null} for imprints, which are never consent-bearing (decision 7)
+ * @param sourceLevel which rung answered — never omitted, because "the privacy policy" without a
+ *     level is not a valid statement (decision 1)
+ * @param versionId the {@code legal_text_version} row this wording corresponds to, or {@code null}
+ *     for the Träger and platform levels, whose history lives in ORISO-TenantService rather than
+ *     here. This is the identifier a consuming service pins a recorded consent to (ORISO-UserService
+ *     {@code session.consented_legal_version_id}, ADR-022 decision 2) — without it, "is this room
+ *     cleared for the current version" cannot be answered at all.
+ */
+public record ResolvedLegalText(
+    String content, String consentText, LegalTextSourceLevel sourceLevel, Long versionId) {
+
+  /** Nothing authored on any level. */
+  public static ResolvedLegalText none() {
+    return new ResolvedLegalText(null, null, LegalTextSourceLevel.NONE, null);
+  }
+
+  public boolean isPresent() {
+    return content != null && !content.isBlank();
+  }
+}

--- a/src/main/resources/db/changelog/agencyservice-master.xml
+++ b/src/main/resources/db/changelog/agencyservice-master.xml
@@ -84,6 +84,10 @@
        agency_topic (opening hours, phone extension, floor/location). Additive, all nullable;
        null = inherit the Beratungsstelle value. -->
   <include file="db/changelog/changeset/0030_agency_topic_details/0030_changeSet.xml"/>
+  <!-- ADR-021 decision 3 (#250, #212): generic legal-text publication history. Immutable
+       snapshots keyed by a surrogate id (never by the publication timestamp), so "which wording
+       was in force on date X, published by whom" is answerable for the first time. -->
+  <include file="db/changelog/changeset/0031_legal_text_version/0031_changeSet.xml"/>
 
   <!--
     L1 gap detection (2026-07-04): the consolidated changelog was run against a fresh MariaDB

--- a/src/main/resources/db/changelog/agencyservice-master.xml
+++ b/src/main/resources/db/changelog/agencyservice-master.xml
@@ -88,6 +88,11 @@
        snapshots keyed by a surrogate id (never by the publication timestamp), so "which wording
        was in force on date X, published by whom" is answerable for the first time. -->
   <include file="db/changelog/changeset/0031_legal_text_version/0031_changeSet.xml"/>
+  <!-- ADR-021 decision 4 (#250): the consent sentence a help-seeker ticks becomes a field of the
+       data protection policy — one document, one publication status, one history. The
+       cookie/authentication notice is deliberately NOT stored: it is a fixed addendum the client
+       renders, so no Träger can edit away the platform's mandatory disclosure. -->
+  <include file="db/changelog/changeset/0032_legal_consent_text/0032_changeSet.xml"/>
 
   <!--
     L1 gap detection (2026-07-04): the consolidated changelog was run against a fresh MariaDB

--- a/src/main/resources/db/changelog/changeset/0031_legal_text_version/0031_changeSet.xml
+++ b/src/main/resources/db/changelog/changeset/0031_legal_text_version/0031_changeSet.xml
@@ -1,0 +1,15 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd">
+    <!-- ADR-021 decision 3: generic legal-text publication history (DPP, imprint, future kinds)
+         on the department, agency and shared-object levels. Purely additive: nothing reads or
+         writes it until a publish happens, and existing rows get no backfilled history because a
+         guessed publication date would be worse than an honest gap (see #212). -->
+    <changeSet author="oriso" id="createLegalTextVersion">
+        <sqlFile path="db/changelog/changeset/0031_legal_text_version/createLegalTextVersion.sql" stripComments="true"/>
+        <rollback>
+            <sqlFile path="db/changelog/changeset/0031_legal_text_version/createLegalTextVersion-rollback.sql" stripComments="true"/>
+        </rollback>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changeset/0031_legal_text_version/createLegalTextVersion-rollback.sql
+++ b/src/main/resources/db/changelog/changeset/0031_legal_text_version/createLegalTextVersion-rollback.sql
@@ -1,0 +1,2 @@
+DROP SEQUENCE IF EXISTS `agencyservice`.`sequence_legal_text_version`;
+DROP TABLE IF EXISTS `agencyservice`.`legal_text_version`;

--- a/src/main/resources/db/changelog/changeset/0031_legal_text_version/createLegalTextVersion.sql
+++ b/src/main/resources/db/changelog/changeset/0031_legal_text_version/createLegalTextVersion.sql
@@ -1,0 +1,35 @@
+-- ADR-021 decision 3: a generic, immutable publication history for legal texts, on every level
+-- and for every kind. Blueprint: ORISO-TenantService `tenant_dpa_version` (changeset 0018),
+-- generalised by (kind, owner_level, owner_id) so the DPP, the imprint and any future kind share
+-- one table, one endpoint and one editor wiring.
+--
+-- Identity is a SURROGATE id, never the publication timestamp. The AVV work had to truncate its
+-- version key to seconds because MariaDB `datetime` (DATETIME(0)) drops sub-second precision on
+-- the round trip, and an equality match on that key silently failed. A snapshot here is addressed
+-- by its own id, so no caller ever has to reconstruct a timestamp.
+CREATE TABLE IF NOT EXISTS `agencyservice`.`legal_text_version` (
+    `id` bigint(21) NOT NULL,
+    `tenant_id` bigint(21) NULL,
+    `kind` varchar(20) NOT NULL,
+    -- DEPARTMENT (agency_topic.id) | AGENCY (agency.id) | SHARED (legal_text.id)
+    `owner_level` varchar(20) NOT NULL,
+    `owner_id` bigint(21) NOT NULL,
+    `content` longtext NULL,
+    `published_at` datetime NOT NULL,
+    -- Keycloak user id of the publisher; NULL where the publish had no authenticated user
+    -- (technical/migration path). Never guessed.
+    `published_by` varchar(255) NULL,
+    -- NULL = this is the version currently in force for its owner. Set when a newer one is
+    -- published, so "which wording was in force on date X" is answerable without a self-join.
+    `superseded_at` datetime NULL,
+    PRIMARY KEY (`id`),
+    KEY `idx_legal_text_version_owner` (`owner_level`, `owner_id`, `kind`, `published_at`),
+    KEY `idx_legal_text_version_current` (`owner_level`, `owner_id`, `kind`, `superseded_at`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+
+CREATE SEQUENCE IF NOT EXISTS `agencyservice`.`sequence_legal_text_version`
+INCREMENT BY 1
+MINVALUE = 0
+NOMAXVALUE
+START WITH 0
+CACHE 10;

--- a/src/main/resources/db/changelog/changeset/0032_legal_consent_text/0032_changeSet.xml
+++ b/src/main/resources/db/changelog/changeset/0032_legal_consent_text/0032_changeSet.xml
@@ -1,0 +1,14 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd">
+    <!-- ADR-021 decision 4: the consent sentence a help-seeker ticks becomes a field of the data
+         protection policy on every level that stores one, plus on the version snapshot. Purely
+         additive and nullable: a Träger that authors none keeps the platform's default sentence. -->
+    <changeSet author="oriso" id="addLegalConsentText">
+        <sqlFile path="db/changelog/changeset/0032_legal_consent_text/addLegalConsentText.sql" stripComments="true"/>
+        <rollback>
+            <sqlFile path="db/changelog/changeset/0032_legal_consent_text/addLegalConsentText-rollback.sql" stripComments="true"/>
+        </rollback>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changeset/0032_legal_consent_text/addLegalConsentText-rollback.sql
+++ b/src/main/resources/db/changelog/changeset/0032_legal_consent_text/addLegalConsentText-rollback.sql
@@ -1,0 +1,4 @@
+ALTER TABLE `agencyservice`.`agency_topic` DROP COLUMN IF EXISTS `consent_text`;
+ALTER TABLE `agencyservice`.`agency` DROP COLUMN IF EXISTS `consent_text`;
+ALTER TABLE `agencyservice`.`legal_text` DROP COLUMN IF EXISTS `consent_text`;
+ALTER TABLE `agencyservice`.`legal_text_version` DROP COLUMN IF EXISTS `consent_text`;

--- a/src/main/resources/db/changelog/changeset/0032_legal_consent_text/addLegalConsentText.sql
+++ b/src/main/resources/db/changelog/changeset/0032_legal_consent_text/addLegalConsentText.sql
@@ -1,0 +1,24 @@
+-- ADR-021 decision 4: the consent sentence is a FIELD OF THE DATA PROTECTION POLICY, not a legal
+-- text kind of its own. It therefore lives next to every column that already stores a DPP, and
+-- shares that DPP's publication status and its version history.
+--
+-- One history instead of two: "which consent wording belonged to which policy" is answered by
+-- "the same version", not reconstructed by correlating timestamps. Timestamp correlation was
+-- already a defect source in the AVV work (second precision vs. MariaDB DATETIME(0)).
+--
+-- Not stored here, deliberately: the cookie/authentication notice. It is a fixed, non-editable
+-- addendum the client renders beneath the sentence (ADR-021 decision 2) - persisting it per Träger
+-- would let a Träger edit away the platform's own mandatory disclosure.
+--
+-- Same shape as the DPP itself: a JSON language -> text map.
+ALTER TABLE `agencyservice`.`agency_topic`
+  ADD COLUMN IF NOT EXISTS `consent_text` longtext NULL;
+
+ALTER TABLE `agencyservice`.`agency`
+  ADD COLUMN IF NOT EXISTS `consent_text` longtext NULL;
+
+ALTER TABLE `agencyservice`.`legal_text`
+  ADD COLUMN IF NOT EXISTS `consent_text` longtext NULL;
+
+ALTER TABLE `agencyservice`.`legal_text_version`
+  ADD COLUMN IF NOT EXISTS `consent_text` longtext NULL;

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/controller/AgencyAdminControllerDepartmentDetailsTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/controller/AgencyAdminControllerDepartmentDetailsTest.java
@@ -11,6 +11,7 @@ import de.caritas.cob.agencyservice.api.admin.service.allocation.AgencyIdAllocat
 import de.caritas.cob.agencyservice.api.admin.service.department.DepartmentDetailsService;
 import de.caritas.cob.agencyservice.api.admin.service.department.DepartmentDetailsView;
 import de.caritas.cob.agencyservice.api.admin.service.legal.DepartmentDataProtectionService;
+import de.caritas.cob.agencyservice.api.admin.service.legal.LegalTextVersionAdminService;
 import de.caritas.cob.agencyservice.api.admin.service.legal.DepartmentImprintService;
 import de.caritas.cob.agencyservice.api.admin.service.legal.LegalTextAdminService;
 import de.caritas.cob.agencyservice.api.admin.validation.AgencyValidator;
@@ -34,6 +35,7 @@ class AgencyAdminControllerDepartmentDetailsTest {
   @Mock private DepartmentDetailsService departmentDetailsService;
   @Mock private DepartmentImprintService departmentImprintService;
   @Mock private LegalTextAdminService legalTextAdminService;
+  @Mock private LegalTextVersionAdminService legalTextVersionAdminService;
   @Mock private AgencyIdAllocationService agencyIdAllocationService;
 
   @InjectMocks private AgencyAdminController controller;

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/controller/AgencyAdminControllerDepartmentDppTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/controller/AgencyAdminControllerDepartmentDppTest.java
@@ -11,6 +11,7 @@ import de.caritas.cob.agencyservice.api.admin.service.agencyadmincontrol.AgencyA
 import de.caritas.cob.agencyservice.api.admin.service.agencypostcoderange.AgencyPostcodeRangeAdminService;
 import de.caritas.cob.agencyservice.api.admin.service.department.DepartmentDetailsService;
 import de.caritas.cob.agencyservice.api.admin.service.legal.DepartmentDataProtectionService;
+import de.caritas.cob.agencyservice.api.admin.service.legal.LegalTextVersionAdminService;
 import de.caritas.cob.agencyservice.api.admin.service.legal.DepartmentDataProtectionView;
 import de.caritas.cob.agencyservice.api.admin.service.legal.DepartmentImprintService;
 import de.caritas.cob.agencyservice.api.admin.service.legal.LegalTextAdminService;
@@ -39,6 +40,7 @@ class AgencyAdminControllerDepartmentDppTest {
   @Mock private DepartmentDetailsService departmentDetailsService;
   @Mock private DepartmentImprintService departmentImprintService;
   @Mock private LegalTextAdminService legalTextAdminService;
+  @Mock private LegalTextVersionAdminService legalTextVersionAdminService;
   @Mock private AgencyIdAllocationService agencyIdAllocationService;
 
   @InjectMocks private AgencyAdminController controller;

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/controller/AgencyAdminControllerDepartmentDppTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/controller/AgencyAdminControllerDepartmentDppTest.java
@@ -2,6 +2,7 @@ package de.caritas.cob.agencyservice.api.admin.controller;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.when;
 
 import de.caritas.cob.agencyservice.api.admin.service.AgencyAdminService;
@@ -49,7 +50,7 @@ class AgencyAdminControllerDepartmentDppTest {
   void publishDepartmentDataProtection_Should_delegate_andMapStatusTo200() {
     var body = new DepartmentDataProtectionDTO().content(Map.of("de", "<p>DSE</p>")).publish(true);
     when(departmentDataProtectionService.publishDepartmentDataPrivacy(
-            eq(7L), eq(42L), eq(Map.of("de", "<p>DSE</p>")), eq(true)))
+            eq(7L), eq(42L), eq(Map.of("de", "<p>DSE</p>")), eq(Map.of()), eq(true)))
         .thenReturn(PublicationStatus.PUBLISHED);
 
     var response = controller.publishDepartmentDataProtection(7L, 42L, body);
@@ -65,13 +66,17 @@ class AgencyAdminControllerDepartmentDppTest {
     when(departmentDataProtectionService.getDepartmentDataPrivacy(7L, 42L))
         .thenReturn(
             new DepartmentDataProtectionView(
-                "{\"de\":\"<p>x</p>\"}", PublicationStatus.PUBLISHED));
+                "{\"de\":\"<p>x</p>\"}",
+                "{\"de\":\"Ich habe die {{legal_links}} gelesen.\"}",
+                PublicationStatus.PUBLISHED));
 
     var response = controller.getDepartmentDataProtection(7L, 42L);
 
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
     assertThat(response.getBody()).isNotNull();
     assertThat(response.getBody().getContent()).isEqualTo("{\"de\":\"<p>x</p>\"}");
+    // ADR-021 decision 4: the consent sentence is read back through the policy, not separately.
+    assertThat(response.getBody().getConsentText()).contains("{{legal_links}}");
     assertThat(response.getBody().getPublicationStatus())
         .isEqualTo(DepartmentDataProtectionContentDTO.PublicationStatusEnum.PUBLISHED);
   }
@@ -81,7 +86,7 @@ class AgencyAdminControllerDepartmentDppTest {
     // publish flag omitted -> Boolean null -> service receives false (draft-save)
     var body = new DepartmentDataProtectionDTO().content(Map.of("de", "<p>Entwurf</p>"));
     when(departmentDataProtectionService.publishDepartmentDataPrivacy(
-            eq(7L), eq(42L), eq(Map.of("de", "<p>Entwurf</p>")), eq(false)))
+            eq(7L), eq(42L), eq(Map.of("de", "<p>Entwurf</p>")), eq(Map.of()), eq(false)))
         .thenReturn(PublicationStatus.DRAFT);
 
     var response = controller.publishDepartmentDataProtection(7L, 42L, body);

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/controller/AgencyAdminControllerDepartmentImprintTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/controller/AgencyAdminControllerDepartmentImprintTest.java
@@ -11,6 +11,7 @@ import de.caritas.cob.agencyservice.api.admin.service.agencyadmincontrol.AgencyA
 import de.caritas.cob.agencyservice.api.admin.service.agencypostcoderange.AgencyPostcodeRangeAdminService;
 import de.caritas.cob.agencyservice.api.admin.service.department.DepartmentDetailsService;
 import de.caritas.cob.agencyservice.api.admin.service.legal.DepartmentDataProtectionService;
+import de.caritas.cob.agencyservice.api.admin.service.legal.LegalTextVersionAdminService;
 import de.caritas.cob.agencyservice.api.admin.service.legal.DepartmentImprintService;
 import de.caritas.cob.agencyservice.api.admin.service.legal.LegalTextAdminService;
 import de.caritas.cob.agencyservice.api.admin.service.legal.DepartmentImprintView;
@@ -39,6 +40,7 @@ class AgencyAdminControllerDepartmentImprintTest {
   @Mock private DepartmentDetailsService departmentDetailsService;
   @Mock private DepartmentImprintService departmentImprintService;
   @Mock private LegalTextAdminService legalTextAdminService;
+  @Mock private LegalTextVersionAdminService legalTextVersionAdminService;
   @Mock private AgencyIdAllocationService agencyIdAllocationService;
 
   @InjectMocks private AgencyAdminController controller;

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/controller/AgencyAdminControllerLegalTextTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/controller/AgencyAdminControllerLegalTextTest.java
@@ -13,6 +13,7 @@ import de.caritas.cob.agencyservice.api.admin.service.agencyadmincontrol.AgencyA
 import de.caritas.cob.agencyservice.api.admin.service.agencypostcoderange.AgencyPostcodeRangeAdminService;
 import de.caritas.cob.agencyservice.api.admin.service.department.DepartmentDetailsService;
 import de.caritas.cob.agencyservice.api.admin.service.legal.DepartmentDataProtectionService;
+import de.caritas.cob.agencyservice.api.admin.service.legal.LegalTextVersionAdminService;
 import de.caritas.cob.agencyservice.api.admin.service.legal.DepartmentImprintService;
 import de.caritas.cob.agencyservice.api.admin.service.legal.LegalTextAdminService;
 import de.caritas.cob.agencyservice.api.admin.service.legal.LegalTextAdminView;
@@ -45,6 +46,7 @@ class AgencyAdminControllerLegalTextTest {
   @Mock private DepartmentDetailsService departmentDetailsService;
   @Mock private DepartmentImprintService departmentImprintService;
   @Mock private LegalTextAdminService legalTextAdminService;
+  @Mock private LegalTextVersionAdminService legalTextVersionAdminService;
   @Mock private AgencyIdAllocationService agencyIdAllocationService;
 
   @InjectMocks private AgencyAdminController controller;

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/controller/AgencyAdminControllerLegalTextTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/controller/AgencyAdminControllerLegalTextTest.java
@@ -57,6 +57,7 @@ class AgencyAdminControllerLegalTextTest {
         LegalTextKind.DPP,
         "Standard-DSE",
         "{\"de\":\"<p>x</p>\"}",
+        "{\"de\":\"Ich habe die {{legal_links}} gelesen.\"}",
         PublicationStatus.PUBLISHED,
         usage);
   }
@@ -82,7 +83,11 @@ class AgencyAdminControllerLegalTextTest {
   @Test
   void createLegalText_Should_delegateWithPublishFlag() {
     when(legalTextAdminService.createLegalText(
-            eq(LegalTextKind.DPP), eq("Neu"), eq(Map.of("de", "<p>x</p>")), eq(true)))
+            eq(LegalTextKind.DPP),
+            eq("Neu"),
+            eq(Map.of("de", "<p>x</p>")),
+            eq(Map.of()),
+            eq(true)))
         .thenReturn(view(2L, 0L));
 
     var body =
@@ -101,7 +106,7 @@ class AgencyAdminControllerLegalTextTest {
   void updateLegalText_Should_passNullPublish_ToPreserveCurrentStatus() {
     // omitted publish flag = keep the current publication status (review regression)
     when(legalTextAdminService.updateLegalText(
-            eq(1L), eq("Umbenannt"), eq(Map.of("de", "<p>y</p>")), isNull()))
+            eq(1L), eq("Umbenannt"), eq(Map.of("de", "<p>y</p>")), eq(Map.of()), isNull()))
         .thenReturn(view(1L, 2L));
 
     var body =
@@ -115,7 +120,7 @@ class AgencyAdminControllerLegalTextTest {
   @Test
   void updateLegalText_Should_passExplicitPublishFlag() {
     when(legalTextAdminService.updateLegalText(
-            eq(1L), eq("Umbenannt"), eq(Map.of("de", "<p>y</p>")), eq(Boolean.TRUE)))
+            eq(1L), eq("Umbenannt"), eq(Map.of("de", "<p>y</p>")), eq(Map.of()), eq(Boolean.TRUE)))
         .thenReturn(view(1L, 2L));
 
     var body =

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/controller/AgencyAdminControllerLegalVersionsTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/controller/AgencyAdminControllerLegalVersionsTest.java
@@ -1,0 +1,103 @@
+package de.caritas.cob.agencyservice.api.admin.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import de.caritas.cob.agencyservice.api.admin.service.AgencyAdminService;
+import de.caritas.cob.agencyservice.api.admin.service.agency.AgencyAdminSearchService;
+import de.caritas.cob.agencyservice.api.admin.service.agencyadmincontrol.AgencyAdminControlsFacade;
+import de.caritas.cob.agencyservice.api.admin.service.agencypostcoderange.AgencyPostcodeRangeAdminService;
+import de.caritas.cob.agencyservice.api.admin.service.allocation.AgencyIdAllocationService;
+import de.caritas.cob.agencyservice.api.admin.service.department.DepartmentDetailsService;
+import de.caritas.cob.agencyservice.api.admin.service.legal.DepartmentDataProtectionService;
+import de.caritas.cob.agencyservice.api.admin.service.legal.DepartmentImprintService;
+import de.caritas.cob.agencyservice.api.admin.service.legal.LegalTextAdminService;
+import de.caritas.cob.agencyservice.api.admin.service.legal.LegalTextVersionAdminService;
+import de.caritas.cob.agencyservice.api.admin.service.legal.LegalTextVersionView;
+import de.caritas.cob.agencyservice.api.admin.validation.AgencyValidator;
+import de.caritas.cob.agencyservice.api.model.LegalTextVersionDTO;
+import de.caritas.cob.agencyservice.api.repository.legaltext.LegalTextKind;
+import de.caritas.cob.agencyservice.api.repository.legaltext.LegalTextLevel;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+
+/** ADR-021 decision 3 endpoints: delegation + DTO mapping of the publication history. */
+@ExtendWith(MockitoExtension.class)
+class AgencyAdminControllerLegalVersionsTest {
+
+  @Mock private AgencyAdminSearchService agencyAdminSearchService;
+  @Mock private AgencyPostcodeRangeAdminService agencyPostcodeRangeAdminService;
+  @Mock private AgencyAdminService agencyAdminService;
+  @Mock private AgencyValidator agencyValidator;
+  @Mock private AgencyAdminControlsFacade agencyAdminControlsFacade;
+  @Mock private DepartmentDataProtectionService departmentDataProtectionService;
+  @Mock private DepartmentDetailsService departmentDetailsService;
+  @Mock private DepartmentImprintService departmentImprintService;
+  @Mock private LegalTextAdminService legalTextAdminService;
+  @Mock private LegalTextVersionAdminService legalTextVersionAdminService;
+  @Mock private AgencyIdAllocationService agencyIdAllocationService;
+
+  @InjectMocks private AgencyAdminController controller;
+
+  private LegalTextVersionView view(LegalTextLevel level, LocalDateTime supersededAt) {
+    return new LegalTextVersionView(
+        100L,
+        LegalTextKind.DPP,
+        level,
+        4711L,
+        "{\"de\":\"<p>Fassung</p>\"}",
+        LocalDateTime.of(2026, 5, 1, 9, 0),
+        "admin-uuid",
+        supersededAt);
+  }
+
+  @Test
+  void getDepartmentLegalTextVersions_Should_delegate_andMapEveryField() {
+    when(legalTextVersionAdminService.listDepartmentVersions(7L, 42L, LegalTextKind.DPP))
+        .thenReturn(List.of(view(LegalTextLevel.DEPARTMENT, LocalDateTime.of(2026, 9, 1, 0, 0))));
+
+    var response = controller.getDepartmentLegalTextVersions(7L, 42L, "DPP");
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody()).singleElement().satisfies(dto -> {
+      assertThat(dto.getId()).isEqualTo(100L);
+      assertThat(dto.getKind()).isEqualTo(LegalTextVersionDTO.KindEnum.DPP);
+      assertThat(dto.getOwnerLevel()).isEqualTo(LegalTextVersionDTO.OwnerLevelEnum.DEPARTMENT);
+      assertThat(dto.getOwnerId()).isEqualTo(4711L);
+      assertThat(dto.getContent()).contains("Fassung");
+      assertThat(dto.getPublishedAt()).isEqualTo("2026-05-01T09:00");
+      assertThat(dto.getPublishedBy()).isEqualTo("admin-uuid");
+      assertThat(dto.getSupersededAt()).isEqualTo("2026-09-01T00:00");
+    });
+  }
+
+  @Test
+  void getAgencyLegalTextVersions_Should_delegate_andReportStillInForceAsNullSupersededAt() {
+    when(legalTextVersionAdminService.listAgencyVersions(7L, LegalTextKind.IMPRINT))
+        .thenReturn(List.of(view(LegalTextLevel.AGENCY, null)));
+
+    var response = controller.getAgencyLegalTextVersions(7L, "IMPRINT");
+
+    assertThat(response.getBody()).singleElement().satisfies(dto ->
+        assertThat(dto.getSupersededAt()).isNull());
+  }
+
+  @Test
+  void getLegalTextVersion_Should_returnTheArchivedWordingVerbatim() {
+    when(legalTextVersionAdminService.getVersion(100L))
+        .thenReturn(view(LegalTextLevel.SHARED, LocalDateTime.of(2026, 9, 1, 0, 0)));
+
+    var response = controller.getLegalTextVersion(100L);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody().getContent()).isEqualTo("{\"de\":\"<p>Fassung</p>\"}");
+    assertThat(response.getBody().getOwnerLevel())
+        .isEqualTo(LegalTextVersionDTO.OwnerLevelEnum.SHARED);
+  }
+}

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/controller/AgencyAdminControllerLegalVersionsTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/controller/AgencyAdminControllerLegalVersionsTest.java
@@ -52,6 +52,7 @@ class AgencyAdminControllerLegalVersionsTest {
         level,
         4711L,
         "{\"de\":\"<p>Fassung</p>\"}",
+        "{\"de\":\"Ich habe die {{legal_links}} gelesen.\"}",
         LocalDateTime.of(2026, 5, 1, 9, 0),
         "admin-uuid",
         supersededAt);

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/service/AgencyAdminServiceTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/service/AgencyAdminServiceTest.java
@@ -30,6 +30,7 @@ import de.caritas.cob.agencyservice.api.admin.validation.DeleteAgencyValidator;
 import de.caritas.cob.agencyservice.api.exception.httpresponses.ConflictException;
 import de.caritas.cob.agencyservice.api.exception.httpresponses.NotFoundException;
 import de.caritas.cob.agencyservice.api.admin.service.legal.LegalContentSanitizer;
+import de.caritas.cob.agencyservice.api.admin.service.legal.LegalTextVersionService;
 import de.caritas.cob.agencyservice.api.model.AgencyAdminResponseDTO;
 import de.caritas.cob.agencyservice.api.model.AgencyLegalContentDTO;
 import de.caritas.cob.agencyservice.api.model.AgencyTypeRequestDTO;
@@ -87,6 +88,9 @@ class AgencyAdminServiceTest {
 
   @Mock
   LegalContentSanitizer legalContentSanitizer;
+
+  @Mock
+  LegalTextVersionService legalTextVersionService;
 
   @Mock
   AgencyTopicRepository agencyTopicRepository;

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/service/AgencyAdminServiceTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/service/AgencyAdminServiceTest.java
@@ -1,5 +1,7 @@
 package de.caritas.cob.agencyservice.api.admin.service;
 
+import de.caritas.cob.agencyservice.api.repository.legaltext.LegalTextLevel;
+import de.caritas.cob.agencyservice.api.repository.legaltext.LegalTextKind;
 import static de.caritas.cob.agencyservice.api.exception.httpresponses.HttpStatusExceptionReason.AGENCY_ID_NOT_AVAILABLE;
 import static de.caritas.cob.agencyservice.api.exception.httpresponses.HttpStatusExceptionReason.AGENCY_IS_ALREADY_DEFAULT_AGENCY;
 import static de.caritas.cob.agencyservice.api.exception.httpresponses.HttpStatusExceptionReason.AGENCY_IS_ALREADY_TEAM_AGENCY;
@@ -10,6 +12,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -490,6 +494,55 @@ class AgencyAdminServiceTest {
     assertEquals("{\"de\":\"<p>DSE</p>\"}", agencyArgumentCaptor.getValue().getContentDpp());
     assertEquals(
         "{\"de\":\"<p>Impressum</p>\"}", agencyArgumentCaptor.getValue().getContentImprint());
+  }
+
+  @Test
+  void updateAgency_Should_recordNoVersion_When_theLegalWordingDidNotChange() {
+    var agency = this.easyRandom.nextObject(Agency.class);
+    clearDataProtection(agency);
+    agency.setCounsellingRelations(null);
+    when(agencyRepository.findById(AGENCY_ID)).thenReturn(Optional.of(agency));
+    when(agencyRepository.save(any())).thenReturn(agency);
+
+    var updateAgencyDTO = this.easyRandom.nextObject(UpdateAgencyDTO.class);
+    updateAgencyDTO.setContent(null);
+
+    agencyAdminService.updateAgency(AGENCY_ID, updateAgencyDTO);
+
+    // Changeset 0031 deliberately backfills no history, so an agency that already had legal texts
+    // has NO open version to deduplicate against. Without the change check, the first unrelated
+    // update - a phone number, the opening hours - would snapshot the untouched old wording stamped
+    // with the current time and assert the policy came into force at that moment.
+    verifyNoInteractions(legalTextVersionService);
+  }
+
+  @Test
+  void updateAgency_Should_recordAVersion_When_theLegalWordingChanged() {
+    var agency = this.easyRandom.nextObject(Agency.class);
+    clearDataProtection(agency);
+    agency.setCounsellingRelations(null);
+    agency.setId(AGENCY_ID);
+    agency.setContentDpp("{\"de\":\"<p>alt</p>\"}");
+    when(agencyRepository.findById(AGENCY_ID)).thenReturn(Optional.of(agency));
+    when(agencyRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+    when(legalContentSanitizer.sanitizeToJson(Map.of("de", "<p>neu</p>")))
+        .thenReturn("{\"de\":\"<p>neu</p>\"}");
+
+    var updateAgencyDTO = this.easyRandom.nextObject(UpdateAgencyDTO.class);
+    updateAgencyDTO.setContent(new AgencyLegalContentDTO().privacy(Map.of("de", "<p>neu</p>")));
+
+    agencyAdminService.updateAgency(AGENCY_ID, updateAgencyDTO);
+
+    // The agency level has no publication status, so a save IS the publish - but only when the
+    // wording actually moved.
+    verify(legalTextVersionService)
+        .recordPublication(
+            eq(LegalTextLevel.AGENCY),
+            eq(AGENCY_ID),
+            eq(LegalTextKind.DPP),
+            any(),
+            eq("{\"de\":\"<p>neu</p>\"}"),
+            any());
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/service/AgencyAdminServiceTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/service/AgencyAdminServiceTest.java
@@ -29,6 +29,7 @@ import de.caritas.cob.agencyservice.api.admin.service.agency.DemographicsConvert
 import de.caritas.cob.agencyservice.api.admin.validation.DeleteAgencyValidator;
 import de.caritas.cob.agencyservice.api.exception.httpresponses.ConflictException;
 import de.caritas.cob.agencyservice.api.exception.httpresponses.NotFoundException;
+import de.caritas.cob.agencyservice.api.admin.service.legal.ConsentTextService;
 import de.caritas.cob.agencyservice.api.admin.service.legal.LegalContentSanitizer;
 import de.caritas.cob.agencyservice.api.admin.service.legal.LegalTextVersionService;
 import de.caritas.cob.agencyservice.api.model.AgencyAdminResponseDTO;
@@ -91,6 +92,9 @@ class AgencyAdminServiceTest {
 
   @Mock
   LegalTextVersionService legalTextVersionService;
+
+  @Mock
+  ConsentTextService consentTextService;
 
   @Mock
   AgencyTopicRepository agencyTopicRepository;

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/service/legal/ConsentTextServiceTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/service/legal/ConsentTextServiceTest.java
@@ -96,6 +96,61 @@ class ConsentTextServiceTest {
   }
 
   @Test
+  void resolveForUpdate_Should_keepTheStoredSentence_When_theFieldIsOmitted() {
+    var stored = "{\"de\":\"Ich habe die {{legal_links}} gelesen.\"}";
+
+    // The generated request models initialise map properties to an EMPTY MAP, so an Admin build
+    // that predates this field is indistinguishable from one clearing it. Treating that as a
+    // deletion would silently wipe the Träger's consent sentence on a label-only update.
+    assertThat(service.resolveForUpdate(stored, null, true)).isEqualTo(stored);
+    assertThat(service.resolveForUpdate(stored, Map.of(), true)).isEqualTo(stored);
+  }
+
+  @Test
+  void resolveForUpdate_Should_allowClearing_ByAnExplicitEmptyValue() {
+    var stored = "{\"de\":\"Ich habe die {{legal_links}} gelesen.\"}";
+
+    // Clearing is expressed the way the repo already expresses it for the policy body: send the
+    // language key with empty content.
+    assertThat(service.resolveForUpdate(stored, mapOf("de", ""), true)).isNull();
+  }
+
+  @Test
+  void resolveForUpdate_Should_replaceTheStoredSentence_When_aNewOneIsSent() {
+    var stored = "{\"de\":\"alt {{legal_links}}\"}";
+
+    assertThat(service.resolveForUpdate(stored, Map.of("de", "neu {{legal_links}}"), true))
+        .contains("neu");
+  }
+
+  @Test
+  void resolveForUpdate_Should_stillValidateARetainedSentence_OnPublish() {
+    var storedWithoutToken = "{\"de\":\"Ich stimme zu.\"}";
+
+    // Otherwise omitting the field would be a way to publish a sentence that never passed the gate.
+    assertThatExceptionOfType(BadRequestException.class)
+        .isThrownBy(() -> service.resolveForUpdate(storedWithoutToken, Map.of(), true))
+        .withMessageContaining("{{legal_links}}");
+
+    // ... but a draft-save may keep it.
+    assertThat(service.resolveForUpdate(storedWithoutToken, Map.of(), false))
+        .isEqualTo(storedWithoutToken);
+  }
+
+  @Test
+  void resolveForUpdate_Should_notBlockOnAnUnreadableStoredValue() {
+    // Such a value predates the validator; refusing to publish would block the admin on something
+    // they cannot fix from the editor.
+    assertThat(service.resolveForUpdate("not json", Map.of(), true)).isEqualTo("not json");
+  }
+
+  private static Map<String, String> mapOf(String key, String value) {
+    var map = new HashMap<String, String>();
+    map.put(key, value);
+    return map;
+  }
+
+  @Test
   void metaKeys_Should_beSkippedByTheTokenCheck() {
     var withMeta = new HashMap<String, String>();
     withMeta.put("de", "Ich habe die {{legal_links}} gelesen.");

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/service/legal/ConsentTextServiceTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/service/legal/ConsentTextServiceTest.java
@@ -1,0 +1,108 @@
+package de.caritas.cob.agencyservice.api.admin.service.legal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import de.caritas.cob.agencyservice.api.exception.httpresponses.BadRequestException;
+import de.caritas.cob.agencyservice.api.validation.InputSanitizer;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/**
+ * ADR-021 decision 2: a Träger's consent sentence replaces the platform's rather than being
+ * appended to it, and what keeps the platform's mandatory disclosures reachable is this validator —
+ * not a legal stacking rule.
+ */
+class ConsentTextServiceTest {
+
+  private final ConsentTextService service =
+      new ConsentTextService(new LegalContentSanitizer(new InputSanitizer()));
+
+  @Test
+  void publish_Should_beRejected_When_theMandatoryTokenIsMissing() {
+    var withoutToken = Map.of("de", "Ich bin einverstanden.");
+
+    var thrown =
+        assertThatExceptionOfType(BadRequestException.class)
+            .isThrownBy(() -> service.sanitizeAndValidate(withoutToken, true));
+
+    // A 400 the editor can render, never a 500: forgetting a placeholder is an ordinary mistake,
+    // and the message has to name the language and the missing token.
+    thrown.withMessageContaining("de").withMessageContaining("{{legal_links}}");
+  }
+
+  @Test
+  void publish_Should_beRejected_When_onlyOneTranslationCarriesTheToken() {
+    var mixed = new HashMap<String, String>();
+    mixed.put("de", "Ich habe die {{legal_links}} gelesen.");
+    mixed.put("en", "I agree.");
+
+    // Checking one language only would let a Träger ship a compliant German sentence next to an
+    // English one that leads nowhere.
+    assertThatExceptionOfType(BadRequestException.class)
+        .isThrownBy(() -> service.sanitizeAndValidate(mixed, true))
+        .withMessageContaining("en");
+  }
+
+  @Test
+  void publish_Should_storeTheSentence_When_theTokenIsPresent() {
+    var stored =
+        service.sanitizeAndValidate(
+            Map.of("de", "Ich habe die {{legal_links}} der {{Beratungsstelle}} gelesen."), true);
+
+    assertThat(stored).contains("{{legal_links}}").contains("{{Beratungsstelle}}");
+  }
+
+  /**
+   * The regression this pairs with: the OWASP sanitizer splits {@code &#123;&#123;} with an HTML
+   * comment. Without {@link LegalTextTokens#restoreKnownTokens} the stored sentence would come back
+   * broken even though the admin typed it correctly.
+   */
+  @Test
+  void storedSentence_Should_surviveSanitisationWithItsTokensIntact() {
+    var stored =
+        service.sanitizeAndValidate(
+            Map.of("de", "<p>Ich habe die {{legal_links}} gelesen.</p>"), true);
+
+    assertThat(stored).contains("{{legal_links}}").doesNotContain("<!-- -->");
+  }
+
+  @Test
+  void publish_Should_stripDangerousMarkup_butKeepFormattingAndLinks() {
+    var stored =
+        service.sanitizeAndValidate(
+            Map.of("de", "<p onclick=\"x()\"><b>Ja</b> {{legal_links}}<script>bad()</script></p>"),
+            true);
+
+    assertThat(stored).contains("<b>Ja</b>").contains("{{legal_links}}");
+    assertThat(stored).doesNotContain("script").doesNotContain("onclick");
+  }
+
+  @Test
+  void draftSave_Should_notEnforceTheToken() {
+    // A half-written sentence must be storable; the gate is publication, not typing.
+    var stored = service.sanitizeAndValidate(Map.of("de", "Ich bin"), false);
+
+    assertThat(stored).contains("Ich bin");
+  }
+
+  @Test
+  void noConsentText_Should_stayAbsent_ratherThanBecomingAnEmptyDocument() {
+    // Authoring none is allowed: the platform's default sentence then applies.
+    assertThat(service.sanitizeAndValidate(null, true)).isNull();
+    assertThat(service.sanitizeAndValidate(Map.of(), true)).isNull();
+    assertThat(service.sanitizeAndValidate(Map.of("de", "   "), true)).isNull();
+  }
+
+  @Test
+  void metaKeys_Should_beSkippedByTheTokenCheck() {
+    var withMeta = new HashMap<String, String>();
+    withMeta.put("de", "Ich habe die {{legal_links}} gelesen.");
+    withMeta.put("de__meta", "{\"mt\":true,\"src\":\"de\",\"at\":\"2026-08-16T00:00:00\"}");
+
+    // Translation metadata carries JSON, not prose - demanding a placeholder in it would reject
+    // every machine-translated consent sentence.
+    assertThat(service.sanitizeAndValidate(withMeta, true)).contains("de__meta");
+  }
+}

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/service/legal/DepartmentDataProtectionServiceTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/service/legal/DepartmentDataProtectionServiceTest.java
@@ -3,6 +3,8 @@ package de.caritas.cob.agencyservice.api.admin.service.legal;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -18,6 +20,7 @@ import de.caritas.cob.agencyservice.api.repository.agencytopic.AgencyTopicReposi
 import de.caritas.cob.agencyservice.api.repository.agencytopic.PublicationStatus;
 import de.caritas.cob.agencyservice.api.repository.legaltext.LegalText;
 import de.caritas.cob.agencyservice.api.repository.legaltext.LegalTextKind;
+import de.caritas.cob.agencyservice.api.repository.legaltext.LegalTextLevel;
 import de.caritas.cob.agencyservice.api.tenant.TenantContext;
 import de.caritas.cob.agencyservice.api.util.AuthenticatedUser;
 import de.caritas.cob.agencyservice.api.validation.InputSanitizer;
@@ -38,6 +41,7 @@ class DepartmentDataProtectionServiceTest {
   @Mock private AgencyTopicRepository agencyTopicRepository;
   @Mock private AuthenticatedUser authenticatedUser;
   @Mock private UserAdminService userAdminService;
+  @Mock private LegalTextVersionService legalTextVersionService;
 
   private DepartmentDataProtectionService service;
 
@@ -50,7 +54,8 @@ class DepartmentDataProtectionServiceTest {
             agencyTopicRepository,
             new LegalContentSanitizer(new InputSanitizer()),
             authenticatedUser,
-            userAdminService);
+            userAdminService,
+            legalTextVersionService);
   }
 
   @AfterEach
@@ -207,6 +212,28 @@ class DepartmentDataProtectionServiceTest {
     // dangerous markup removed, text kept
     assertThat(storedJson).contains("Datenschutz").doesNotContain("script").doesNotContain("onclick");
     assertThat(saved.getValue().getUpdateDate()).isNotNull();
+  }
+
+  @Test
+  void publish_Should_recordAnImmutableVersion_ForTheDepartmentLevel() {
+    when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(false);
+    var department = existingDepartment();
+    department.setId(4711L);
+    department.setAgency(Agency.builder().id(7L).name("BS").consultingTypeId(1).tenantId(3L).build());
+
+    service.publishDepartmentDataPrivacy(7L, 42L, Map.of("de", "<p>neu</p>"), true);
+
+    // ADR-021 decision 3: the snapshot is keyed by the department row, not by the agency, and it
+    // carries the sanitized wording that was actually stored.
+    var content = ArgumentCaptor.forClass(String.class);
+    verify(legalTextVersionService)
+        .recordPublication(
+            eq(LegalTextLevel.DEPARTMENT),
+            eq(4711L),
+            eq(LegalTextKind.DPP),
+            eq(3L),
+            content.capture());
+    assertThat(content.getValue()).contains("neu");
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/service/legal/DepartmentDataProtectionServiceTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/service/legal/DepartmentDataProtectionServiceTest.java
@@ -277,6 +277,44 @@ class DepartmentDataProtectionServiceTest {
   }
 
   @Test
+  void publish_Should_keepTheStoredConsentText_When_theFieldIsOmitted() {
+    when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(false);
+    final var department = existingDepartment();
+    department.setConsentText("{\"de\":\"Ich habe die {{legal_links}} gelesen.\"}");
+
+    service.publishDepartmentDataPrivacy(7L, 42L, Map.of("de", "<p>neu</p>"), null, true);
+
+    // An Admin build that predates this field publishes a policy body without it; wiping the
+    // Träger's sentence on that request would be a silent legal regression.
+    assertThat(department.getConsentText()).contains("{{legal_links}}");
+  }
+
+  @Test
+  void unpublish_Should_closeTheOpenVersion_ratherThanLeavingItInForce() {
+    when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(false);
+    final var department = existingDepartment();
+    department.setId(4711L);
+    department.setPublicationStatus(PublicationStatus.PUBLISHED);
+
+    service.publishDepartmentDataPrivacy(7L, 42L, Map.of("de", "<p>zurueckgezogen</p>"), null, false);
+
+    // Public resolution now falls through to the agency level, so a snapshot still reading as
+    // "in force" would make the history assert the opposite of what help-seekers are shown.
+    verify(legalTextVersionService)
+        .supersedeCurrent(LegalTextLevel.DEPARTMENT, 4711L, LegalTextKind.DPP);
+  }
+
+  @Test
+  void draftSave_Should_notCloseAnything_When_nothingWasPublishedBefore() {
+    when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(false);
+    existingDepartment();
+
+    service.publishDepartmentDataPrivacy(7L, 42L, Map.of("de", "<p>Entwurf</p>"), null, false);
+
+    verifyNoInteractions(legalTextVersionService);
+  }
+
+  @Test
   void draftSave_Should_storeAnIncompleteConsentText() {
     when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(false);
     var department = existingDepartment();

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/service/legal/DepartmentDataProtectionServiceTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/service/legal/DepartmentDataProtectionServiceTest.java
@@ -42,6 +42,8 @@ class DepartmentDataProtectionServiceTest {
   @Mock private AuthenticatedUser authenticatedUser;
   @Mock private UserAdminService userAdminService;
   @Mock private LegalTextVersionService legalTextVersionService;
+  private final ConsentTextService consentTextService =
+      new ConsentTextService(new LegalContentSanitizer(new InputSanitizer()));
 
   private DepartmentDataProtectionService service;
 
@@ -55,7 +57,8 @@ class DepartmentDataProtectionServiceTest {
             new LegalContentSanitizer(new InputSanitizer()),
             authenticatedUser,
             userAdminService,
-            legalTextVersionService);
+            legalTextVersionService,
+            consentTextService);
   }
 
   @AfterEach
@@ -109,7 +112,7 @@ class DepartmentDataProtectionServiceTest {
     department.setDpp(referenced);
 
     var status =
-        service.publishDepartmentDataPrivacy(7L, 42L, Map.of("de", "<p>neu</p>"), true);
+        service.publishDepartmentDataPrivacy(7L, 42L, Map.of("de", "<p>neu</p>"), null, true);
 
     assertThat(status).isEqualTo(PublicationStatus.PUBLISHED);
 
@@ -134,7 +137,7 @@ class DepartmentDataProtectionServiceTest {
     department.setDpp(referenced);
 
     var status =
-        service.publishDepartmentDataPrivacy(7L, 42L, Map.of("de", "<p>entwurf</p>"), false);
+        service.publishDepartmentDataPrivacy(7L, 42L, Map.of("de", "<p>entwurf</p>"), null, false);
 
     assertThat(status).isEqualTo(PublicationStatus.DRAFT);
 
@@ -194,11 +197,9 @@ class DepartmentDataProtectionServiceTest {
     existingDepartment();
 
     var status =
-        service.publishDepartmentDataPrivacy(
-            7L,
+        service.publishDepartmentDataPrivacy(7L,
             42L,
-            Map.of("de", "<p onclick=\"steal()\">Datenschutz <script>bad()</script></p>"),
-            true);
+            Map.of("de", "<p onclick=\"steal()\">Datenschutz <script>bad()</script></p>"), null, true);
 
     // a full admin is never scoped-checked against agency ids
     verifyNoInteractions(userAdminService);
@@ -221,7 +222,7 @@ class DepartmentDataProtectionServiceTest {
     department.setId(4711L);
     department.setAgency(Agency.builder().id(7L).name("BS").consultingTypeId(1).tenantId(3L).build());
 
-    service.publishDepartmentDataPrivacy(7L, 42L, Map.of("de", "<p>neu</p>"), true);
+    service.publishDepartmentDataPrivacy(7L, 42L, Map.of("de", "<p>neu</p>"), null, true);
 
     // ADR-021 decision 3: the snapshot is keyed by the department row, not by the agency, and it
     // carries the sanitized wording that was actually stored.
@@ -232,8 +233,59 @@ class DepartmentDataProtectionServiceTest {
             eq(4711L),
             eq(LegalTextKind.DPP),
             eq(3L),
-            content.capture());
+            content.capture(), any());
     assertThat(content.getValue()).contains("neu");
+  }
+
+  @Test
+  void publish_Should_storeTheConsentTextWithThePolicy() {
+    when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(false);
+    final var department = existingDepartment();
+
+    service.publishDepartmentDataPrivacy(
+        7L,
+        42L,
+        Map.of("de", "<p>DSE</p>"),
+        Map.of("de", "Ich habe die {{legal_links}} gelesen."),
+        true);
+
+    // ADR-021 decision 4: one document, one publication status - the sentence lives on the
+    // department row next to the policy, not as a legal text of its own.
+    var saved = ArgumentCaptor.forClass(AgencyTopic.class);
+    verify(agencyTopicRepository).save(saved.capture());
+    assertThat(saved.getValue().getConsentText()).contains("{{legal_links}}");
+    assertThat(saved.getValue().getPublicationStatus()).isEqualTo(PublicationStatus.PUBLISHED);
+    assertThat(department.getConsentText()).contains("{{legal_links}}");
+  }
+
+  @Test
+  void publish_Should_beRejected_When_theConsentTextLacksTheMandatoryToken() {
+    when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(false);
+    var department = existingDepartment();
+
+    assertThatExceptionOfType(BadRequestException.class)
+        .isThrownBy(
+            () ->
+                service.publishDepartmentDataPrivacy(
+                    7L, 42L, Map.of("de", "<p>DSE</p>"), Map.of("de", "Ich stimme zu."), true));
+
+    // Validation runs before anything is written: a rejected publish must leave the stored
+    // document exactly as it was, not half-updated.
+    verify(agencyTopicRepository, never()).save(any());
+    assertThat(department.getContentDpp()).isNull();
+    assertThat(department.getConsentText()).isNull();
+  }
+
+  @Test
+  void draftSave_Should_storeAnIncompleteConsentText() {
+    when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(false);
+    var department = existingDepartment();
+
+    service.publishDepartmentDataPrivacy(
+        7L, 42L, Map.of("de", "<p>Entwurf</p>"), Map.of("de", "Ich bin"), false);
+
+    // The gate is publication, not typing.
+    assertThat(department.getConsentText()).contains("Ich bin");
   }
 
   @Test
@@ -242,7 +294,7 @@ class DepartmentDataProtectionServiceTest {
     existingDepartment();
 
     var status =
-        service.publishDepartmentDataPrivacy(7L, 42L, Map.of("de", "<p>Entwurf</p>"), false);
+        service.publishDepartmentDataPrivacy(7L, 42L, Map.of("de", "<p>Entwurf</p>"), null, false);
 
     assertThat(status).isEqualTo(PublicationStatus.DRAFT);
   }
@@ -255,7 +307,7 @@ class DepartmentDataProtectionServiceTest {
     existingDepartment();
 
     var status =
-        service.publishDepartmentDataPrivacy(7L, 42L, Map.of("de", "<p>ok</p>"), true);
+        service.publishDepartmentDataPrivacy(7L, 42L, Map.of("de", "<p>ok</p>"), null, true);
 
     assertThat(status).isEqualTo(PublicationStatus.PUBLISHED);
     verify(agencyTopicRepository).save(any());
@@ -270,7 +322,7 @@ class DepartmentDataProtectionServiceTest {
     assertThatExceptionOfType(AgencyAccessDeniedException.class)
         .isThrownBy(
             () ->
-                service.publishDepartmentDataPrivacy(7L, 42L, Map.of("de", "<p>x</p>"), true));
+                service.publishDepartmentDataPrivacy(7L, 42L, Map.of("de", "<p>x</p>"), null, true));
 
     // IDOR guard runs before any load or write
     verify(agencyTopicRepository, never()).findByAgency_IdAndTopicId(any(), any());
@@ -285,7 +337,7 @@ class DepartmentDataProtectionServiceTest {
     assertThatExceptionOfType(NotFoundException.class)
         .isThrownBy(
             () ->
-                service.publishDepartmentDataPrivacy(7L, 99L, Map.of("de", "<p>x</p>"), true));
+                service.publishDepartmentDataPrivacy(7L, 99L, Map.of("de", "<p>x</p>"), null, true));
     verify(agencyTopicRepository, never()).save(any());
   }
 
@@ -332,7 +384,7 @@ class DepartmentDataProtectionServiceTest {
     assertThatExceptionOfType(AgencyAccessDeniedException.class)
         .isThrownBy(
             () ->
-                service.publishDepartmentDataPrivacy(7L, 42L, Map.of("de", "<p>x</p>"), true));
+                service.publishDepartmentDataPrivacy(7L, 42L, Map.of("de", "<p>x</p>"), null, true));
     verify(agencyTopicRepository, never()).save(any());
   }
 
@@ -343,7 +395,7 @@ class DepartmentDataProtectionServiceTest {
     existingDepartmentInTenant(1L);
 
     var status =
-        service.publishDepartmentDataPrivacy(7L, 42L, Map.of("de", "<p>ok</p>"), true);
+        service.publishDepartmentDataPrivacy(7L, 42L, Map.of("de", "<p>ok</p>"), null, true);
 
     assertThat(status).isEqualTo(PublicationStatus.PUBLISHED);
     verify(agencyTopicRepository).save(any());
@@ -354,9 +406,7 @@ class DepartmentDataProtectionServiceTest {
     when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(false);
     var department = existingDepartment();
 
-    service.publishDepartmentDataPrivacy(
-        7L, 42L, Map.of("de", "<strong>Wichtig</strong> <a href=\"https://caritas.de\">Info</a>"),
-        true);
+    service.publishDepartmentDataPrivacy(7L, 42L, Map.of("de", "<strong>Wichtig</strong> <a href=\"https://caritas.de\">Info</a>"), null, true);
 
     // guards against a regression to the strip-everything sanitize() policy
     var stored = department.getContentDpp();
@@ -369,8 +419,7 @@ class DepartmentDataProtectionServiceTest {
     when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(false);
     var department = existingDepartment();
 
-    service.publishDepartmentDataPrivacy(
-        7L, 42L, Map.of("de", "<p>Datenschutz</p>", "en", "<p>Privacy</p>"), true);
+    service.publishDepartmentDataPrivacy(7L, 42L, Map.of("de", "<p>Datenschutz</p>", "en", "<p>Privacy</p>"), null, true);
 
     var stored = department.getContentDpp();
     assertThat(stored).contains("\"de\":").contains("Datenschutz");
@@ -382,12 +431,12 @@ class DepartmentDataProtectionServiceTest {
     when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(false);
     var department = existingDepartment();
 
-    service.publishDepartmentDataPrivacy(7L, 42L, Map.of("de", "<p>final</p>"), true);
+    service.publishDepartmentDataPrivacy(7L, 42L, Map.of("de", "<p>final</p>"), null, true);
     assertThat(department.getPublicationStatus()).isEqualTo(PublicationStatus.PUBLISHED);
 
     // a second call as draft overwrites the content and reverts the status
     var status =
-        service.publishDepartmentDataPrivacy(7L, 42L, Map.of("de", "<p>revised</p>"), false);
+        service.publishDepartmentDataPrivacy(7L, 42L, Map.of("de", "<p>revised</p>"), null, false);
 
     assertThat(status).isEqualTo(PublicationStatus.DRAFT);
     assertThat(department.getPublicationStatus()).isEqualTo(PublicationStatus.DRAFT);
@@ -399,7 +448,7 @@ class DepartmentDataProtectionServiceTest {
     when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(false);
     var department = existingDepartment();
 
-    var status = service.publishDepartmentDataPrivacy(7L, 42L, null, true);
+    var status = service.publishDepartmentDataPrivacy(7L, 42L, null, null, true);
 
     assertThat(status).isEqualTo(PublicationStatus.PUBLISHED);
     assertThat(department.getContentDpp()).isEqualTo("{}");
@@ -412,7 +461,7 @@ class DepartmentDataProtectionServiceTest {
     var content = new java.util.HashMap<String, String>();
     content.put("de", null);
 
-    service.publishDepartmentDataPrivacy(7L, 42L, content, true);
+    service.publishDepartmentDataPrivacy(7L, 42L, content, null, true);
 
     assertThat(department.getContentDpp()).isEqualTo("{\"de\":\"\"}");
   }
@@ -426,8 +475,7 @@ class DepartmentDataProtectionServiceTest {
     // passed through verbatim after a strict schema validation instead
     var metaJson = "{\"mt\":true,\"src\":\"de\",\"at\":\"2026-07-04T10:00:00Z\"}";
 
-    service.publishDepartmentDataPrivacy(
-        7L, 42L, Map.of("de", "<p>Datenschutz</p>", "de__meta", metaJson), true);
+    service.publishDepartmentDataPrivacy(7L, 42L, Map.of("de", "<p>Datenschutz</p>", "de__meta", metaJson), null, true);
 
     var stored = department.getContentDpp();
     assertThat(stored).contains("\"de__meta\":");
@@ -442,8 +490,7 @@ class DepartmentDataProtectionServiceTest {
     existingDepartment();
 
     var status =
-        service.publishDepartmentDataPrivacy(
-            7L, 42L, Map.of("de__meta", "{\"mt\":true,\"src\":\"de\",\"at\":\"2026-07-04\"}"), true);
+        service.publishDepartmentDataPrivacy(7L, 42L, Map.of("de__meta", "{\"mt\":true,\"src\":\"de\",\"at\":\"2026-07-04\"}"), null, true);
 
     assertThat(status).isEqualTo(PublicationStatus.PUBLISHED);
     verify(agencyTopicRepository).save(any());
@@ -457,8 +504,7 @@ class DepartmentDataProtectionServiceTest {
     assertThatExceptionOfType(BadRequestException.class)
         .isThrownBy(
             () ->
-                service.publishDepartmentDataPrivacy(
-                    7L, 42L, Map.of("de__meta", "not-json{"), true));
+                service.publishDepartmentDataPrivacy(7L, 42L, Map.of("de__meta", "not-json{"), null, true));
     verify(agencyTopicRepository, never()).save(any());
   }
 
@@ -469,7 +515,7 @@ class DepartmentDataProtectionServiceTest {
 
     assertThatExceptionOfType(BadRequestException.class)
         .isThrownBy(
-            () -> service.publishDepartmentDataPrivacy(7L, 42L, Map.of("de__meta", ""), true));
+            () -> service.publishDepartmentDataPrivacy(7L, 42L, Map.of("de__meta", ""), null, true));
     verify(agencyTopicRepository, never()).save(any());
   }
 
@@ -481,8 +527,7 @@ class DepartmentDataProtectionServiceTest {
     assertThatExceptionOfType(BadRequestException.class)
         .isThrownBy(
             () ->
-                service.publishDepartmentDataPrivacy(
-                    7L, 42L, Map.of("de__meta", "[\"de\",\"en\"]"), true));
+                service.publishDepartmentDataPrivacy(7L, 42L, Map.of("de__meta", "[\"de\",\"en\"]"), null, true));
     verify(agencyTopicRepository, never()).save(any());
   }
 
@@ -494,8 +539,7 @@ class DepartmentDataProtectionServiceTest {
     assertThatExceptionOfType(BadRequestException.class)
         .isThrownBy(
             () ->
-                service.publishDepartmentDataPrivacy(
-                    7L, 42L, Map.of("de__meta", "\"just-a-string\""), true));
+                service.publishDepartmentDataPrivacy(7L, 42L, Map.of("de__meta", "\"just-a-string\""), null, true));
     verify(agencyTopicRepository, never()).save(any());
   }
 
@@ -507,8 +551,7 @@ class DepartmentDataProtectionServiceTest {
     assertThatExceptionOfType(BadRequestException.class)
         .isThrownBy(
             () ->
-                service.publishDepartmentDataPrivacy(
-                    7L, 42L, Map.of("de__meta", "{\"mt\":true,\"unexpected\":\"x\"}"), true));
+                service.publishDepartmentDataPrivacy(7L, 42L, Map.of("de__meta", "{\"mt\":true,\"unexpected\":\"x\"}"), null, true));
     verify(agencyTopicRepository, never()).save(any());
   }
 
@@ -520,8 +563,7 @@ class DepartmentDataProtectionServiceTest {
     assertThatExceptionOfType(BadRequestException.class)
         .isThrownBy(
             () ->
-                service.publishDepartmentDataPrivacy(
-                    7L, 42L, Map.of("de__meta", "{\"mt\":\"true\"}"), true));
+                service.publishDepartmentDataPrivacy(7L, 42L, Map.of("de__meta", "{\"mt\":\"true\"}"), null, true));
     verify(agencyTopicRepository, never()).save(any());
   }
 
@@ -533,8 +575,7 @@ class DepartmentDataProtectionServiceTest {
     assertThatExceptionOfType(BadRequestException.class)
         .isThrownBy(
             () ->
-                service.publishDepartmentDataPrivacy(
-                    7L, 42L, Map.of("de__meta", "{\"src\":\"   \"}"), true));
+                service.publishDepartmentDataPrivacy(7L, 42L, Map.of("de__meta", "{\"src\":\"   \"}"), null, true));
     verify(agencyTopicRepository, never()).save(any());
   }
 }

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/service/legal/DepartmentImprintServiceTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/service/legal/DepartmentImprintServiceTest.java
@@ -224,7 +224,7 @@ class DepartmentImprintServiceTest {
             eq(4711L),
             eq(LegalTextKind.IMPRINT),
             eq(3L),
-            anyString());
+            anyString(), any());
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/service/legal/DepartmentImprintServiceTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/service/legal/DepartmentImprintServiceTest.java
@@ -3,6 +3,8 @@ package de.caritas.cob.agencyservice.api.admin.service.legal;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -18,6 +20,7 @@ import de.caritas.cob.agencyservice.api.repository.agencytopic.AgencyTopicReposi
 import de.caritas.cob.agencyservice.api.repository.agencytopic.PublicationStatus;
 import de.caritas.cob.agencyservice.api.repository.legaltext.LegalText;
 import de.caritas.cob.agencyservice.api.repository.legaltext.LegalTextKind;
+import de.caritas.cob.agencyservice.api.repository.legaltext.LegalTextLevel;
 import de.caritas.cob.agencyservice.api.tenant.TenantContext;
 import de.caritas.cob.agencyservice.api.util.AuthenticatedUser;
 import de.caritas.cob.agencyservice.api.validation.InputSanitizer;
@@ -38,6 +41,7 @@ class DepartmentImprintServiceTest {
   @Mock private AgencyTopicRepository agencyTopicRepository;
   @Mock private AuthenticatedUser authenticatedUser;
   @Mock private UserAdminService userAdminService;
+  @Mock private LegalTextVersionService legalTextVersionService;
 
   private DepartmentImprintService service;
 
@@ -50,7 +54,8 @@ class DepartmentImprintServiceTest {
             agencyTopicRepository,
             new LegalContentSanitizer(new InputSanitizer()),
             authenticatedUser,
-            userAdminService);
+            userAdminService,
+            legalTextVersionService);
   }
 
   @AfterEach
@@ -200,6 +205,26 @@ class DepartmentImprintServiceTest {
     // dangerous markup removed, text kept
     assertThat(storedJson).contains("Impressum").doesNotContain("script").doesNotContain("onclick");
     assertThat(saved.getValue().getUpdateDate()).isNotNull();
+  }
+
+  @Test
+  void publish_Should_recordAnImmutableVersion_ForTheDepartmentLevel() {
+    when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(false);
+    var department = existingDepartment();
+    department.setId(4711L);
+    department.setAgency(Agency.builder().id(7L).name("BS").consultingTypeId(1).tenantId(3L).build());
+
+    service.publishDepartmentImprint(7L, 42L, Map.of("de", "<p>neu</p>"), true);
+
+    // The imprint is an information duty, never a consent gate (ADR-021 decision 7) - but "which
+    // imprint was reachable when" still has to be answerable, so it gets the same history.
+    verify(legalTextVersionService)
+        .recordPublication(
+            eq(LegalTextLevel.DEPARTMENT),
+            eq(4711L),
+            eq(LegalTextKind.IMPRINT),
+            eq(3L),
+            anyString());
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/service/legal/LegalContentSanitizerTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/service/legal/LegalContentSanitizerTest.java
@@ -92,4 +92,38 @@ class LegalContentSanitizerTest {
     assertThat(json).contains("\"de\":\"\"");
     assertThat(json).doesNotContain("ignored");
   }
+
+  /**
+   * ADR-021 decision 6: the consent dialect is {@code {{key}}}, and the tokens have to reach the
+   * substituting layer intact. The OWASP sanitizer escapes HTML metacharacters in text nodes, so
+   * whether braces survive is a property that has to be asserted, not assumed — an escaped
+   * {@code &#123;&#123;legal_links&#125;&#125;} would fail the publication validator on text the
+   * admin typed correctly, and would render as literal braces to the help-seeker.
+   */
+  @Test
+  void sanitizeToJson_Should_leaveConsentTokensIntact() {
+    var json =
+        sanitizer.sanitizeToJson(
+            Map.of(
+                "de",
+                "<p>Ich habe die {{legal_links}} der {{Beratungsstelle}} zum Thema {{Thema}}"
+                    + " gelesen.</p>"));
+
+    assertThat(json).contains("{{legal_links}}");
+    assertThat(json).contains("{{Beratungsstelle}}");
+    assertThat(json).contains("{{Thema}}");
+  }
+
+  /**
+   * The Freemarker dialect must never appear in Träger-authored text (ADR-021 decision 6):
+   * {@code ${...}} can invoke object methods in Freemarker, which is why the consent path uses a
+   * plain replacement instead. The sanitizer is not the guard against that — it passes such text
+   * through unchanged — so this test documents the actual behaviour rather than a false promise.
+   */
+  @Test
+  void sanitizeToJson_Should_notItselfNeutraliseFreemarkerSyntax() {
+    var json = sanitizer.sanitizeToJson(Map.of("de", "<p>${responsible}</p>"));
+
+    assertThat(json).contains("${responsible}");
+  }
 }

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/service/legal/LegalTextAdminServiceTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/service/legal/LegalTextAdminServiceTest.java
@@ -44,6 +44,7 @@ class LegalTextAdminServiceTest {
   @Mock private AgencyTopicRepository agencyTopicRepository;
   @Mock private AuthenticatedUser authenticatedUser;
   @Mock private UserAdminService userAdminService;
+  @Mock private LegalTextVersionService legalTextVersionService;
 
   private LegalTextAdminService service;
 
@@ -56,7 +57,8 @@ class LegalTextAdminServiceTest {
             agencyTopicRepository,
             new LegalContentSanitizer(new InputSanitizer()),
             authenticatedUser,
-            userAdminService);
+            userAdminService,
+            legalTextVersionService);
   }
 
   @AfterEach

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/service/legal/LegalTextAdminServiceTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/service/legal/LegalTextAdminServiceTest.java
@@ -45,6 +45,8 @@ class LegalTextAdminServiceTest {
   @Mock private AuthenticatedUser authenticatedUser;
   @Mock private UserAdminService userAdminService;
   @Mock private LegalTextVersionService legalTextVersionService;
+  private final ConsentTextService consentTextService =
+      new ConsentTextService(new LegalContentSanitizer(new InputSanitizer()));
 
   private LegalTextAdminService service;
 
@@ -58,7 +60,8 @@ class LegalTextAdminServiceTest {
             new LegalContentSanitizer(new InputSanitizer()),
             authenticatedUser,
             userAdminService,
-            legalTextVersionService);
+            legalTextVersionService,
+            consentTextService);
   }
 
   @AfterEach
@@ -131,11 +134,9 @@ class LegalTextAdminServiceTest {
         .thenAnswer(invocation -> invocation.getArgument(0));
 
     var view =
-        service.createLegalText(
-            LegalTextKind.DPP,
+        service.createLegalText(LegalTextKind.DPP,
             "Standard-DSE",
-            Map.of("de", "<p onclick=\"x()\">DSE <script>bad()</script></p>"),
-            true);
+            Map.of("de", "<p onclick=\"x()\">DSE <script>bad()</script></p>"), null, true);
 
     var saved = ArgumentCaptor.forClass(LegalText.class);
     verify(legalTextRepository).save(saved.capture());
@@ -155,7 +156,7 @@ class LegalTextAdminServiceTest {
   void create_Should_rejectBlankLabel() {
     assertThatExceptionOfType(BadRequestException.class)
         .isThrownBy(
-            () -> service.createLegalText(LegalTextKind.DPP, "  ", Map.of("de", "x"), false));
+            () -> service.createLegalText(LegalTextKind.DPP, "  ", Map.of("de", "x"), null, false));
     verify(legalTextRepository, never()).save(any());
   }
 
@@ -171,7 +172,7 @@ class LegalTextAdminServiceTest {
         .thenAnswer(invocation -> invocation.getArgument(0));
     when(agencyTopicRepository.countByDpp_Id(1L)).thenReturn(2L);
 
-    var view = service.updateLegalText(1L, "Neu", Map.of("de", "<p>neu</p>"), true);
+    var view = service.updateLegalText(1L, "Neu", Map.of("de", "<p>neu</p>"), null, true);
 
     assertThat(existing.getLabel()).isEqualTo("Neu");
     assertThat(existing.getContent()).contains("neu");
@@ -187,7 +188,7 @@ class LegalTextAdminServiceTest {
         .thenReturn(Optional.of(text(1L, 9L, LegalTextKind.DPP)));
 
     assertThatExceptionOfType(AgencyAccessDeniedException.class)
-        .isThrownBy(() -> service.updateLegalText(1L, "x", Map.of("de", "x"), false));
+        .isThrownBy(() -> service.updateLegalText(1L, "x", Map.of("de", "x"), null, false));
     verify(legalTextRepository, never()).save(any());
   }
 
@@ -196,7 +197,7 @@ class LegalTextAdminServiceTest {
     when(legalTextRepository.findById(99L)).thenReturn(Optional.empty());
 
     assertThatExceptionOfType(NotFoundException.class)
-        .isThrownBy(() -> service.updateLegalText(99L, "x", Map.of("de", "x"), false));
+        .isThrownBy(() -> service.updateLegalText(99L, "x", Map.of("de", "x"), null, false));
   }
 
   // --- library CRUD is full-admin only (review: a restricted admin must not be able to change
@@ -216,7 +217,7 @@ class LegalTextAdminServiceTest {
 
     assertThatExceptionOfType(AgencyAccessDeniedException.class)
         .isThrownBy(
-            () -> service.createLegalText(LegalTextKind.DPP, "x", Map.of("de", "x"), false));
+            () -> service.createLegalText(LegalTextKind.DPP, "x", Map.of("de", "x"), null, false));
     verify(legalTextRepository, never()).save(any());
   }
 
@@ -225,7 +226,7 @@ class LegalTextAdminServiceTest {
     when(authenticatedUser.hasRestrictedAgencyPriviliges()).thenReturn(true);
 
     assertThatExceptionOfType(AgencyAccessDeniedException.class)
-        .isThrownBy(() -> service.updateLegalText(1L, "x", Map.of("de", "x"), false));
+        .isThrownBy(() -> service.updateLegalText(1L, "x", Map.of("de", "x"), null, false));
     verify(legalTextRepository, never()).save(any());
   }
 
@@ -242,7 +243,7 @@ class LegalTextAdminServiceTest {
         .thenAnswer(invocation -> invocation.getArgument(0));
     when(agencyTopicRepository.countByDpp_Id(1L)).thenReturn(1L);
 
-    service.updateLegalText(1L, "Nur Label", Map.of("de", "<p>x</p>"), null);
+    service.updateLegalText(1L, "Nur Label", Map.of("de", "<p>x</p>"), null, null);
 
     assertThat(existing.getPublicationStatus()).isEqualTo(PublicationStatus.PUBLISHED);
   }

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/service/legal/LegalTextTokensTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/service/legal/LegalTextTokensTest.java
@@ -1,0 +1,95 @@
+package de.caritas.cob.agencyservice.api.admin.service.legal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import de.caritas.cob.agencyservice.api.validation.InputSanitizer;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/**
+ * ADR-021 decision 6 in code: the {@code {{key}}} dialect, and its collision with the OWASP
+ * sanitizer.
+ */
+class LegalTextTokensTest {
+
+  private final InputSanitizer inputSanitizer = new InputSanitizer();
+
+  /**
+   * The measurement behind the whole {@link LegalTextTokens#restoreKnownTokens} mechanism. OWASP's
+   * {@code java-html-sanitizer} splits {@code &#123;&#123;} with an HTML comment so that sanitised
+   * output cannot be re-interpreted as a mustache template downstream. Pinning it here means the
+   * day the library changes that behaviour, this test says so instead of the repair silently
+   * becoming dead code.
+   */
+  @Test
+  void owaspSanitizer_Should_splitDoubleBraces_whichIsWhyTheRepairExists() {
+    var sanitized = inputSanitizer.sanitizeAllowingFormattingAndLinks("<p>{{legal_links}}</p>");
+
+    assertThat(sanitized).doesNotContain("{{legal_links}}");
+    assertThat(sanitized).contains("{<!-- -->{legal_links}}");
+  }
+
+  @Test
+  void restoreKnownTokens_Should_repairEveryProductToken() {
+    var sanitized =
+        inputSanitizer.sanitizeAllowingFormattingAndLinks(
+            "<p>{{legal_links}} {{Beratungsstelle}} {{Thema}}</p>");
+
+    var restored = LegalTextTokens.restoreKnownTokens(sanitized);
+
+    assertThat(restored).contains("{{legal_links}}", "{{Beratungsstelle}}", "{{Thema}}");
+  }
+
+  /**
+   * The repair is an allowlist, not a blanket undo. Restoring every mustache would hand a Träger
+   * the ability to smuggle an arbitrary client-side template expression through admin-authored
+   * legal text — which is exactly what the sanitizer's comment injection exists to stop.
+   */
+  @Test
+  void restoreKnownTokens_Should_leaveUnknownMustachesSplit() {
+    var sanitized =
+        inputSanitizer.sanitizeAllowingFormattingAndLinks("<p>{{constructor.name}} {{7*7}}</p>");
+
+    var restored = LegalTextTokens.restoreKnownTokens(sanitized);
+
+    assertThat(restored).doesNotContain("{{constructor.name}}");
+    assertThat(restored).doesNotContain("{{7*7}}");
+  }
+
+  @Test
+  void substitute_Should_replaceOnlyTheGivenTokens_andLeaveTheRestStanding() {
+    var text = "Ich habe die {{legal_links}} der {{Beratungsstelle}} zum Thema {{Thema}} gelesen.";
+
+    var result =
+        LegalTextTokens.substitute(
+            text,
+            Map.of(
+                LegalTextTokens.BERATUNGSSTELLE, "Caritas Freiburg",
+                LegalTextTokens.THEMA, "Suchtberatung"));
+
+    assertThat(result).contains("Caritas Freiburg").contains("Suchtberatung");
+    // ADR-021 decision 5: the client owns the link targets, so its token survives the server.
+    assertThat(result).contains("{{legal_links}}");
+  }
+
+  /**
+   * The substitution is a literal replacement, not a template evaluation. A value that happens to
+   * look like a token or a regex group reference is inserted as text and nothing re-reads it.
+   */
+  @Test
+  void substitute_Should_treatValuesAsLiteralText() {
+    var result =
+        LegalTextTokens.substitute(
+            "Hallo {{Beratungsstelle}}",
+            Map.of(LegalTextTokens.BERATUNGSSTELLE, "$1 {{Thema}} ${responsible}"));
+
+    assertThat(result).isEqualTo("Hallo $1 {{Thema}} ${responsible}");
+  }
+
+  @Test
+  void substitute_Should_tolerateNullsAndEmptyInput() {
+    assertThat(LegalTextTokens.substitute(null, Map.of("a", "b"))).isNull();
+    assertThat(LegalTextTokens.substitute("x", null)).isEqualTo("x");
+    assertThat(LegalTextTokens.substitute("x", Map.of())).isEqualTo("x");
+  }
+}

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/service/legal/LegalTextVersionAdminServiceTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/service/legal/LegalTextVersionAdminServiceTest.java
@@ -1,0 +1,148 @@
+package de.caritas.cob.agencyservice.api.admin.service.legal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import de.caritas.cob.agencyservice.api.exception.httpresponses.AgencyAccessDeniedException;
+import de.caritas.cob.agencyservice.api.exception.httpresponses.NotFoundException;
+import de.caritas.cob.agencyservice.api.repository.agency.Agency;
+import de.caritas.cob.agencyservice.api.repository.agency.AgencyRepository;
+import de.caritas.cob.agencyservice.api.repository.agencytopic.AgencyTopic;
+import de.caritas.cob.agencyservice.api.repository.agencytopic.AgencyTopicRepository;
+import de.caritas.cob.agencyservice.api.repository.legaltext.LegalTextKind;
+import de.caritas.cob.agencyservice.api.repository.legaltext.LegalTextLevel;
+import de.caritas.cob.agencyservice.api.repository.legaltext.LegalTextVersion;
+import de.caritas.cob.agencyservice.api.repository.legaltext.LegalTextVersionRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * ADR-021 decision 3 read side. The wording of a published document is not secret, but which
+ * Beratungsstelle runs what — and what its drafts looked like — is, so the history endpoints run
+ * the same guards as the publish endpoints they mirror.
+ */
+@ExtendWith(MockitoExtension.class)
+class LegalTextVersionAdminServiceTest {
+
+  @Mock private LegalTextVersionService legalTextVersionService;
+  @Mock private LegalTextVersionRepository legalTextVersionRepository;
+  @Mock private AgencyTopicRepository agencyTopicRepository;
+  @Mock private AgencyRepository agencyRepository;
+  @Mock private LegalAdminAccessGuard accessGuard;
+
+  @InjectMocks private LegalTextVersionAdminService service;
+
+  private Agency agency() {
+    return Agency.builder().id(7L).name("BS").consultingTypeId(1).tenantId(3L).build();
+  }
+
+  private LegalTextVersion version(LegalTextLevel level, Long ownerId) {
+    return LegalTextVersion.builder()
+        .id(100L)
+        .kind(LegalTextKind.DPP)
+        .ownerLevel(level)
+        .ownerId(ownerId)
+        .tenantId(3L)
+        .content("{\"de\":\"<p>Fassung</p>\"}")
+        .publishedAt(LocalDateTime.of(2026, 5, 1, 9, 0))
+        .publishedBy("admin-uuid")
+        .build();
+  }
+
+  @Test
+  void listDepartmentVersions_Should_guard_andDelegateOnTheDepartmentRowId() {
+    var department = AgencyTopic.builder().id(4711L).topicId(42L).agency(agency()).build();
+    when(agencyTopicRepository.findByAgency_IdAndTopicId(7L, 42L))
+        .thenReturn(Optional.of(department));
+    when(legalTextVersionService.listVersions(LegalTextLevel.DEPARTMENT, 4711L, LegalTextKind.DPP))
+        .thenReturn(List.of(version(LegalTextLevel.DEPARTMENT, 4711L)));
+
+    var views = service.listDepartmentVersions(7L, 42L, LegalTextKind.DPP);
+
+    verify(accessGuard).assertRestrictedAdminOwnsAgency(7L);
+    verify(accessGuard).assertCallerTenantMatches(department.getAgency());
+    assertThat(views).singleElement().satisfies(view -> {
+      assertThat(view.id()).isEqualTo(100L);
+      assertThat(view.publishedBy()).isEqualTo("admin-uuid");
+      assertThat(view.supersededAt()).isNull();
+      assertThat(view.content()).contains("Fassung");
+    });
+  }
+
+  @Test
+  void listDepartmentVersions_Should_throwNotFound_When_departmentMissing() {
+    when(agencyTopicRepository.findByAgency_IdAndTopicId(7L, 99L)).thenReturn(Optional.empty());
+
+    assertThatExceptionOfType(NotFoundException.class)
+        .isThrownBy(() -> service.listDepartmentVersions(7L, 99L, LegalTextKind.DPP));
+  }
+
+  @Test
+  void listAgencyVersions_Should_guard_andDelegateOnTheAgencyId() {
+    when(agencyRepository.findById(7L)).thenReturn(Optional.of(agency()));
+    when(legalTextVersionService.listVersions(LegalTextLevel.AGENCY, 7L, LegalTextKind.IMPRINT))
+        .thenReturn(List.of());
+
+    assertThat(service.listAgencyVersions(7L, LegalTextKind.IMPRINT)).isEmpty();
+
+    verify(accessGuard).assertRestrictedAdminOwnsAgency(7L);
+  }
+
+  @Test
+  void getVersion_Should_authoriseAgainstTheStoredOwner_notAgainstTheCaller() {
+    var stored = version(LegalTextLevel.DEPARTMENT, 4711L);
+    var department = AgencyTopic.builder().id(4711L).topicId(42L).agency(agency()).build();
+    when(legalTextVersionRepository.findById(100L)).thenReturn(Optional.of(stored));
+    when(agencyTopicRepository.findById(4711L)).thenReturn(Optional.of(department));
+
+    var view = service.getVersion(100L);
+
+    // A version id must not be a bearer token for someone else's document: the owner is re-derived
+    // from the row and the standard guards run against that.
+    verify(accessGuard).assertRestrictedAdminOwnsAgency(7L);
+    verify(accessGuard).assertCallerTenantMatches(department.getAgency());
+    assertThat(view.content()).isEqualTo("{\"de\":\"<p>Fassung</p>\"}");
+  }
+
+  @Test
+  void getVersion_Should_rejectAForeignAgencysVersion() {
+    var stored = version(LegalTextLevel.AGENCY, 7L);
+    when(legalTextVersionRepository.findById(100L)).thenReturn(Optional.of(stored));
+    when(agencyRepository.findById(7L)).thenReturn(Optional.of(agency()));
+    doThrow(new AgencyAccessDeniedException())
+        .when(accessGuard)
+        .assertCallerTenantMatches(any(Agency.class));
+
+    assertThatExceptionOfType(AgencyAccessDeniedException.class)
+        .isThrownBy(() -> service.getVersion(100L));
+  }
+
+  @Test
+  void getVersion_Should_authoriseASharedVersionByOwningTenant() {
+    var stored = version(LegalTextLevel.SHARED, 55L);
+    when(legalTextVersionRepository.findById(100L)).thenReturn(Optional.of(stored));
+
+    service.getVersion(100L);
+
+    // A shared ADR-014 text belongs to a Träger, not to one agency, so it is guarded like the
+    // library itself.
+    verify(accessGuard).assertCallerTenantIs(3L);
+  }
+
+  @Test
+  void getVersion_Should_throwNotFound_When_versionMissing() {
+    when(legalTextVersionRepository.findById(404L)).thenReturn(Optional.empty());
+
+    assertThatExceptionOfType(NotFoundException.class).isThrownBy(() -> service.getVersion(404L));
+  }
+}

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/service/legal/LegalTextVersionAdminServiceTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/service/legal/LegalTextVersionAdminServiceTest.java
@@ -135,8 +135,21 @@ class LegalTextVersionAdminServiceTest {
     service.getVersion(100L);
 
     // A shared ADR-014 text belongs to a Träger, not to one agency, so it is guarded like the
-    // library itself.
+    // library itself: full agency admins only, plus the owning-tenant check.
+    verify(accessGuard).assertFullAgencyAdmin();
     verify(accessGuard).assertCallerTenantIs(3L);
+  }
+
+  @Test
+  void getVersion_Should_rejectARestrictedAdminReadingASharedVersion() {
+    var stored = version(LegalTextLevel.SHARED, 55L);
+    when(legalTextVersionRepository.findById(100L)).thenReturn(Optional.of(stored));
+    doThrow(new AgencyAccessDeniedException()).when(accessGuard).assertFullAgencyAdmin();
+
+    // A shared text spans agencies a restricted admin does not administer, so guessing a version id
+    // must not hand them tenant-wide wording and publisher identities.
+    assertThatExceptionOfType(AgencyAccessDeniedException.class)
+        .isThrownBy(() -> service.getVersion(100L));
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/service/legal/LegalTextVersionServiceTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/service/legal/LegalTextVersionServiceTest.java
@@ -117,6 +117,57 @@ class LegalTextVersionServiceTest {
   }
 
   @Test
+  void supersedeCurrent_Should_closeTheOpenVersion_withoutInsertingADraftOne() {
+    var previous = openVersion("withdrawn");
+    when(legalTextVersionRepository.findByOwnerLevelAndOwnerIdAndKindAndSupersededAtIsNull(
+            LegalTextLevel.AGENCY, 7L, LegalTextKind.DPP))
+        .thenReturn(List.of(previous));
+
+    assertThat(service.supersedeCurrent(LegalTextLevel.AGENCY, 7L, LegalTextKind.DPP)).isTrue();
+
+    // Unpublishing is not a new version, but leaving the old one open would have the history claim
+    // a withdrawn policy is still in force.
+    assertThat(previous.getSupersededAt()).isNotNull();
+    verify(legalTextVersionRepository).saveAll(anyList());
+    verify(legalTextVersionRepository, never()).save(any());
+  }
+
+  @Test
+  void supersedeCurrent_Should_beANoOp_When_nothingIsInForce() {
+    when(legalTextVersionRepository.findByOwnerLevelAndOwnerIdAndKindAndSupersededAtIsNull(
+            LegalTextLevel.AGENCY, 7L, LegalTextKind.DPP))
+        .thenReturn(List.of());
+
+    assertThat(service.supersedeCurrent(LegalTextLevel.AGENCY, 7L, LegalTextKind.DPP)).isFalse();
+    verify(legalTextVersionRepository, never()).saveAll(anyList());
+  }
+
+  @Test
+  void recordPublication_Should_recordANewVersion_When_onlyTheConsentWordingChanged() {
+    var previous = openVersion("same policy");
+    previous.setConsentText("{\"de\":\"alt {{legal_links}}\"}");
+    when(legalTextVersionRepository.findByOwnerLevelAndOwnerIdAndKindAndSupersededAtIsNull(
+            LegalTextLevel.AGENCY, 7L, LegalTextKind.DPP))
+        .thenReturn(List.of(previous));
+    when(legalTextVersionRepository.save(any(LegalTextVersion.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+
+    var result =
+        service.recordPublication(
+            LegalTextLevel.AGENCY,
+            7L,
+            LegalTextKind.DPP,
+            3L,
+            "same policy",
+            "{\"de\":\"neu {{legal_links}}\"}");
+
+    // ADR-021 decision 4: changing only the consent sentence is still a new version of the policy -
+    // that is what makes "which consent belonged to which policy" answerable by "the same version".
+    assertThat(result).isPresent();
+    assertThat(result.get().getConsentText()).contains("neu");
+  }
+
+  @Test
   void recordPublication_Should_recordAnUnknownPublisher_ratherThanGuessingOne() {
     noOpenVersion();
     when(authenticatedUser.getUserId()).thenReturn(null);

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/service/legal/LegalTextVersionServiceTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/service/legal/LegalTextVersionServiceTest.java
@@ -1,0 +1,133 @@
+package de.caritas.cob.agencyservice.api.admin.service.legal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import de.caritas.cob.agencyservice.api.repository.legaltext.LegalTextKind;
+import de.caritas.cob.agencyservice.api.repository.legaltext.LegalTextLevel;
+import de.caritas.cob.agencyservice.api.repository.legaltext.LegalTextVersion;
+import de.caritas.cob.agencyservice.api.repository.legaltext.LegalTextVersionRepository;
+import de.caritas.cob.agencyservice.api.util.AuthenticatedUser;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/** ADR-021 decision 3: what does and does not become a version. */
+@ExtendWith(MockitoExtension.class)
+class LegalTextVersionServiceTest {
+
+  @Mock private LegalTextVersionRepository legalTextVersionRepository;
+  @Mock private AuthenticatedUser authenticatedUser;
+
+  @InjectMocks private LegalTextVersionService service;
+
+  private void noOpenVersion() {
+    when(legalTextVersionRepository.findByOwnerLevelAndOwnerIdAndKindAndSupersededAtIsNull(
+            any(), any(), any()))
+        .thenReturn(List.of());
+  }
+
+  private LegalTextVersion openVersion(String content) {
+    return LegalTextVersion.builder()
+        .id(1L)
+        .ownerLevel(LegalTextLevel.AGENCY)
+        .ownerId(7L)
+        .kind(LegalTextKind.DPP)
+        .content(content)
+        .publishedAt(LocalDateTime.of(2026, 1, 1, 0, 0))
+        .build();
+  }
+
+  @Test
+  void recordPublication_Should_storeTheWording_withPublisherAndTimestamp() {
+    noOpenVersion();
+    when(authenticatedUser.getUserId()).thenReturn("admin-uuid");
+    when(legalTextVersionRepository.save(any(LegalTextVersion.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+
+    var result =
+        service.recordPublication(
+            LegalTextLevel.DEPARTMENT, 42L, LegalTextKind.DPP, 3L, "{\"de\":\"<p>x</p>\"}");
+
+    assertThat(result).isPresent();
+    var stored = result.get();
+    assertThat(stored.getOwnerLevel()).isEqualTo(LegalTextLevel.DEPARTMENT);
+    assertThat(stored.getOwnerId()).isEqualTo(42L);
+    assertThat(stored.getKind()).isEqualTo(LegalTextKind.DPP);
+    assertThat(stored.getTenantId()).isEqualTo(3L);
+    assertThat(stored.getContent()).isEqualTo("{\"de\":\"<p>x</p>\"}");
+    assertThat(stored.getPublishedBy()).isEqualTo("admin-uuid");
+    assertThat(stored.getPublishedAt()).isNotNull();
+    assertThat(stored.getSupersededAt()).isNull();
+  }
+
+  @Test
+  void recordPublication_Should_supersedeThePreviousCurrentVersion() {
+    var previous = openVersion("old");
+    when(legalTextVersionRepository.findByOwnerLevelAndOwnerIdAndKindAndSupersededAtIsNull(
+            LegalTextLevel.AGENCY, 7L, LegalTextKind.DPP))
+        .thenReturn(List.of(previous));
+    when(legalTextVersionRepository.save(any(LegalTextVersion.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+
+    service.recordPublication(LegalTextLevel.AGENCY, 7L, LegalTextKind.DPP, 3L, "new");
+
+    ArgumentCaptor<List<LegalTextVersion>> captor = ArgumentCaptor.captor();
+    verify(legalTextVersionRepository).saveAll(captor.capture());
+    assertThat(captor.getValue()).singleElement().extracting(LegalTextVersion::getSupersededAt)
+        .isNotNull();
+    // The old wording itself is untouched — an archive that rewrites history proves nothing.
+    assertThat(previous.getContent()).isEqualTo("old");
+  }
+
+  @Test
+  void recordPublication_Should_skip_When_theWordingIsUnchanged() {
+    when(legalTextVersionRepository.findByOwnerLevelAndOwnerIdAndKindAndSupersededAtIsNull(
+            LegalTextLevel.AGENCY, 7L, LegalTextKind.DPP))
+        .thenReturn(List.of(openVersion("same")));
+
+    var result = service.recordPublication(LegalTextLevel.AGENCY, 7L, LegalTextKind.DPP, 3L, "same");
+
+    // Load-bearing for the agency level, where every unrelated update resends the legal texts:
+    // without this, editing the opening hours would forge a new version of the privacy policy.
+    assertThat(result).isEmpty();
+    verify(legalTextVersionRepository, never()).save(any());
+    verify(legalTextVersionRepository, never()).saveAll(anyList());
+  }
+
+  @Test
+  void recordPublication_Should_skip_When_thereIsNoDocument() {
+    assertThat(service.recordPublication(LegalTextLevel.AGENCY, 7L, LegalTextKind.DPP, 3L, null))
+        .isEmpty();
+    assertThat(service.recordPublication(LegalTextLevel.AGENCY, 7L, LegalTextKind.DPP, 3L, "   "))
+        .isEmpty();
+    // The sanitizer serialises "no translations" to an empty JSON object, which is just as absent.
+    assertThat(service.recordPublication(LegalTextLevel.AGENCY, 7L, LegalTextKind.DPP, 3L, "{}"))
+        .isEmpty();
+
+    verify(legalTextVersionRepository, never()).save(any());
+  }
+
+  @Test
+  void recordPublication_Should_recordAnUnknownPublisher_ratherThanGuessingOne() {
+    noOpenVersion();
+    when(authenticatedUser.getUserId()).thenReturn(null);
+    when(legalTextVersionRepository.save(any(LegalTextVersion.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+
+    var result =
+        service.recordPublication(LegalTextLevel.AGENCY, 7L, LegalTextKind.IMPRINT, null, "x");
+
+    assertThat(result).isPresent();
+    assertThat(result.get().getPublishedBy()).isNull();
+  }
+}

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/service/legal/LegalTextVersionServiceTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/service/legal/LegalTextVersionServiceTest.java
@@ -55,8 +55,7 @@ class LegalTextVersionServiceTest {
         .thenAnswer(invocation -> invocation.getArgument(0));
 
     var result =
-        service.recordPublication(
-            LegalTextLevel.DEPARTMENT, 42L, LegalTextKind.DPP, 3L, "{\"de\":\"<p>x</p>\"}");
+        service.recordPublication(LegalTextLevel.DEPARTMENT, 42L, LegalTextKind.DPP, 3L, "{\"de\":\"<p>x</p>\"}", null);
 
     assertThat(result).isPresent();
     var stored = result.get();
@@ -79,7 +78,7 @@ class LegalTextVersionServiceTest {
     when(legalTextVersionRepository.save(any(LegalTextVersion.class)))
         .thenAnswer(invocation -> invocation.getArgument(0));
 
-    service.recordPublication(LegalTextLevel.AGENCY, 7L, LegalTextKind.DPP, 3L, "new");
+    service.recordPublication(LegalTextLevel.AGENCY, 7L, LegalTextKind.DPP, 3L, "new", null);
 
     ArgumentCaptor<List<LegalTextVersion>> captor = ArgumentCaptor.captor();
     verify(legalTextVersionRepository).saveAll(captor.capture());
@@ -95,7 +94,7 @@ class LegalTextVersionServiceTest {
             LegalTextLevel.AGENCY, 7L, LegalTextKind.DPP))
         .thenReturn(List.of(openVersion("same")));
 
-    var result = service.recordPublication(LegalTextLevel.AGENCY, 7L, LegalTextKind.DPP, 3L, "same");
+    var result = service.recordPublication(LegalTextLevel.AGENCY, 7L, LegalTextKind.DPP, 3L, "same", null);
 
     // Load-bearing for the agency level, where every unrelated update resends the legal texts:
     // without this, editing the opening hours would forge a new version of the privacy policy.
@@ -106,12 +105,12 @@ class LegalTextVersionServiceTest {
 
   @Test
   void recordPublication_Should_skip_When_thereIsNoDocument() {
-    assertThat(service.recordPublication(LegalTextLevel.AGENCY, 7L, LegalTextKind.DPP, 3L, null))
+    assertThat(service.recordPublication(LegalTextLevel.AGENCY, 7L, LegalTextKind.DPP, 3L, null, null))
         .isEmpty();
-    assertThat(service.recordPublication(LegalTextLevel.AGENCY, 7L, LegalTextKind.DPP, 3L, "   "))
+    assertThat(service.recordPublication(LegalTextLevel.AGENCY, 7L, LegalTextKind.DPP, 3L, "   ", null))
         .isEmpty();
     // The sanitizer serialises "no translations" to an empty JSON object, which is just as absent.
-    assertThat(service.recordPublication(LegalTextLevel.AGENCY, 7L, LegalTextKind.DPP, 3L, "{}"))
+    assertThat(service.recordPublication(LegalTextLevel.AGENCY, 7L, LegalTextKind.DPP, 3L, "{}", null))
         .isEmpty();
 
     verify(legalTextVersionRepository, never()).save(any());
@@ -125,7 +124,7 @@ class LegalTextVersionServiceTest {
         .thenAnswer(invocation -> invocation.getArgument(0));
 
     var result =
-        service.recordPublication(LegalTextLevel.AGENCY, 7L, LegalTextKind.IMPRINT, null, "x");
+        service.recordPublication(LegalTextLevel.AGENCY, 7L, LegalTextKind.IMPRINT, null, "x", null);
 
     assertThat(result).isPresent();
     assertThat(result.get().getPublishedBy()).isNull();

--- a/src/test/java/de/caritas/cob/agencyservice/api/controller/AgencyControllerTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/controller/AgencyControllerTest.java
@@ -34,6 +34,8 @@ import de.caritas.cob.agencyservice.api.model.FullAgencyResponseDTO;
 import de.caritas.cob.agencyservice.api.service.AgencyService;
 import de.caritas.cob.agencyservice.api.service.DepartmentLegalService;
 import de.caritas.cob.agencyservice.api.service.DepartmentLegalView;
+import de.caritas.cob.agencyservice.api.service.legal.LegalTextSourceLevel;
+import de.caritas.cob.agencyservice.api.service.legal.ResolvedLegalText;
 import de.caritas.cob.agencyservice.api.service.LogService;
 import de.caritas.cob.agencyservice.api.service.TopicEnrichmentService;
 import de.caritas.cob.agencyservice.config.security.AuthorisationService;
@@ -360,7 +362,17 @@ class AgencyControllerTest {
 
     when(departmentLegalService.getPublishedDepartmentLegal(7L, 42L))
         .thenReturn(
-            new DepartmentLegalView("{\"de\":\"<p>DSE</p>\"}", "{\"de\":\"<p>Impressum</p>\"}"));
+            new DepartmentLegalView(
+                new ResolvedLegalText(
+                    "{\"de\":\"<p>DSE</p>\"}",
+                    null,
+                    LegalTextSourceLevel.DEPARTMENT,
+                    100L),
+                new ResolvedLegalText(
+                    "{\"de\":\"<p>Impressum</p>\"}",
+                    null,
+                    LegalTextSourceLevel.AGENCY,
+                    null)));
 
     mvc.perform(get("/agencies/7/topics/42/legal").accept(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk())
@@ -375,7 +387,7 @@ class AgencyControllerTest {
     // the service resolves drafts/never-authored texts to null - the JSON must carry null, so a
     // draft can never leak through this public endpoint
     when(departmentLegalService.getPublishedDepartmentLegal(7L, 42L))
-        .thenReturn(new DepartmentLegalView(null, null));
+        .thenReturn(new DepartmentLegalView(ResolvedLegalText.none(), ResolvedLegalText.none()));
 
     mvc.perform(get("/agencies/7/topics/42/legal").accept(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk())

--- a/src/test/java/de/caritas/cob/agencyservice/api/repository/legaltext/LegalTextVersionRepositoryTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/repository/legaltext/LegalTextVersionRepositoryTest.java
@@ -1,0 +1,121 @@
+package de.caritas.cob.agencyservice.api.repository.legaltext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
+import org.springframework.boot.liquibase.autoconfigure.LiquibaseAutoConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+/**
+ * ADR-021 decision 3 persistence model: an append-only publication history addressed by a
+ * surrogate id, generic over kind and level.
+ */
+@TestPropertySource(properties = {"spring.profiles.active=testing"})
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.ANY)
+@ExtendWith(SpringExtension.class)
+@DataJpaTest(excludeAutoConfiguration = LiquibaseAutoConfiguration.class)
+class LegalTextVersionRepositoryTest {
+
+  @Autowired private LegalTextVersionRepository repository;
+
+  private LegalTextVersion persist(
+      LegalTextLevel level, Long ownerId, LegalTextKind kind, String content, LocalDateTime at) {
+    return repository.save(
+        LegalTextVersion.builder()
+            .tenantId(1L)
+            .kind(kind)
+            .ownerLevel(level)
+            .ownerId(ownerId)
+            .content(content)
+            .publishedAt(at)
+            .publishedBy("admin-uuid")
+            .build());
+  }
+
+  @Test
+  void save_Should_assignSurrogateId_soIdentityNeverDependsOnTheTimestamp() {
+    var sameSecond = LocalDateTime.of(2026, 8, 16, 12, 0, 0);
+
+    var first = persist(LegalTextLevel.DEPARTMENT, 5L, LegalTextKind.DPP, "v1", sameSecond);
+    var second = persist(LegalTextLevel.DEPARTMENT, 5L, LegalTextKind.DPP, "v2", sameSecond);
+
+    // The AVV defect in one line: two publications inside the same second are indistinguishable by
+    // timestamp on MariaDB DATETIME(0). They must still be two addressable versions.
+    assertThat(first.getId()).isNotNull().isNotEqualTo(second.getId());
+  }
+
+  @Test
+  void findHistory_Should_returnNewestFirst_andScopeToOwnerAndKind() {
+    persist(
+        LegalTextLevel.DEPARTMENT,
+        5L,
+        LegalTextKind.DPP,
+        "old",
+        LocalDateTime.of(2026, 1, 1, 0, 0));
+    persist(
+        LegalTextLevel.DEPARTMENT,
+        5L,
+        LegalTextKind.DPP,
+        "new",
+        LocalDateTime.of(2026, 6, 1, 0, 0));
+    persist(
+        LegalTextLevel.DEPARTMENT,
+        5L,
+        LegalTextKind.IMPRINT,
+        "imprint",
+        LocalDateTime.of(2026, 7, 1, 0, 0));
+    persist(
+        LegalTextLevel.AGENCY, 5L, LegalTextKind.DPP, "agency", LocalDateTime.of(2026, 7, 1, 0, 0));
+
+    var history =
+        repository.findByOwnerLevelAndOwnerIdAndKindOrderByPublishedAtDescIdDesc(
+            LegalTextLevel.DEPARTMENT, 5L, LegalTextKind.DPP);
+
+    // Same owner id on a different level is a different document — that is the whole point of
+    // naming the level (ADR-021 decision 1).
+    assertThat(history).extracting(LegalTextVersion::getContent).containsExactly("new", "old");
+  }
+
+  @Test
+  void findCurrent_Should_returnOnlyTheNotYetSupersededVersion() {
+    var superseded =
+        persist(
+            LegalTextLevel.AGENCY, 9L, LegalTextKind.DPP, "old", LocalDateTime.of(2026, 1, 1, 0, 0));
+    superseded.setSupersededAt(LocalDateTime.of(2026, 6, 1, 0, 0));
+    repository.save(superseded);
+    persist(
+        LegalTextLevel.AGENCY, 9L, LegalTextKind.DPP, "new", LocalDateTime.of(2026, 6, 1, 0, 0));
+
+    var current =
+        repository.findFirstByOwnerLevelAndOwnerIdAndKindAndSupersededAtIsNullOrderByIdDesc(
+            LegalTextLevel.AGENCY, 9L, LegalTextKind.DPP);
+
+    assertThat(current).isPresent();
+    assertThat(current.get().getContent()).isEqualTo("new");
+  }
+
+  @Test
+  void storedWording_Should_beReadableVerbatimAfterItWasSuperseded() {
+    var archived =
+        persist(
+            LegalTextLevel.DEPARTMENT,
+            3L,
+            LegalTextKind.DPP,
+            "{\"de\":\"<p>Fassung 2025</p>\"}",
+            LocalDateTime.of(2025, 5, 1, 0, 0));
+    archived.setSupersededAt(LocalDateTime.of(2026, 5, 1, 0, 0));
+    repository.save(archived);
+
+    // The epic's first acceptance criterion: a superseded version is still retrievable verbatim.
+    assertThat(repository.findById(archived.getId()))
+        .get()
+        .extracting(LegalTextVersion::getContent)
+        .isEqualTo("{\"de\":\"<p>Fassung 2025</p>\"}");
+  }
+}

--- a/src/test/java/de/caritas/cob/agencyservice/api/service/AgencyServiceMatrixCredentialsTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/service/AgencyServiceMatrixCredentialsTest.java
@@ -38,6 +38,7 @@ class AgencyServiceMatrixCredentialsTest {
   @Mock private ApplicationSettingsService applicationSettingsService;
   @Mock private AgencySettingsService agencySettingsService;
   @Mock private AgencyAdminControlsService agencyAdminControlsService;
+  @Mock private de.caritas.cob.agencyservice.api.service.legal.LegalTextInheritanceResolver legalTextInheritanceResolver;
 
   @org.mockito.Spy
   private final de.caritas.cob.agencyservice.api.converter.AgencyEffectivePermissionSettingsApplier

--- a/src/test/java/de/caritas/cob/agencyservice/api/service/AgencyServiceTenantAwareTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/service/AgencyServiceTenantAwareTest.java
@@ -1,5 +1,6 @@
 package de.caritas.cob.agencyservice.api.service;
 
+import de.caritas.cob.agencyservice.api.service.legal.LegalTextInheritanceResolver;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -36,6 +37,9 @@ public class AgencyServiceTenantAwareTest {
 
   @Mock
   ConsultingTypeManager consultingTypeManager;
+  @Mock
+  private LegalTextInheritanceResolver legalTextInheritanceResolver;
+
 
   @Mock
   DemographicsConverter demographicsConverter;

--- a/src/test/java/de/caritas/cob/agencyservice/api/service/AgencyServiceTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/service/AgencyServiceTest.java
@@ -1,5 +1,8 @@
 package de.caritas.cob.agencyservice.api.service;
 
+import de.caritas.cob.agencyservice.api.service.legal.ResolvedLegalText;
+import de.caritas.cob.agencyservice.api.service.legal.LegalTextSourceLevel;
+import de.caritas.cob.agencyservice.api.service.legal.LegalTextInheritanceResolver;
 import static de.caritas.cob.agencyservice.testHelper.TestConstants.AGENCY_ID;
 import static de.caritas.cob.agencyservice.testHelper.TestConstants.AGENCY_IDS_LIST;
 import static de.caritas.cob.agencyservice.testHelper.TestConstants.AGENCY_LIST;
@@ -79,6 +82,25 @@ import org.springframework.test.util.ReflectionTestUtils;
 @RunWith(MockitoJUnitRunner.class)
 public class AgencyServiceTest {
 
+  /**
+   * ADR-021 decision 9: AgencyService no longer decides what is in force — it asks the resolver.
+   * The default here is "nothing authored anywhere", so a test that cares about the legal flags has
+   * to say so explicitly instead of inheriting an accident of the fixture data.
+   */
+  @org.junit.Before
+  public void stubLegalResolutionAsEmpty() {
+    org.mockito.Mockito.lenient()
+        .when(legalTextInheritanceResolver.resolveDpp(org.mockito.ArgumentMatchers.any()))
+        .thenReturn(ResolvedLegalText.none());
+    org.mockito.Mockito.lenient()
+        .when(legalTextInheritanceResolver.resolveImprint(org.mockito.ArgumentMatchers.any()))
+        .thenReturn(ResolvedLegalText.none());
+  }
+
+  private static ResolvedLegalText resolved(LegalTextSourceLevel level) {
+    return new ResolvedLegalText("{\"de\":\"<p>x</p>\"}", null, level, null);
+  }
+
   private static final Integer AGE = null;
   private static final String GENDER = null;
 
@@ -92,6 +114,9 @@ public class AgencyServiceTest {
 
   @Mock
   TenantService tenantService;
+  @Mock
+  private LegalTextInheritanceResolver legalTextInheritanceResolver;
+
 
   @Mock
   DemographicsConverter demographicsConverter;
@@ -219,18 +244,16 @@ public class AgencyServiceTest {
   public void getListOfAgencies_Should_MapDepartmentsWithLegalPublicationFlags()
       throws MissingConsultingTypeException {
 
-    // one department with both legal texts published, one still fully in draft
     Agency agency = Agency.builder().id(100L).name("Zentrum").consultingTypeId(CONSULTING_TYPE_SUCHT)
         .build();
-    AgencyTopic publishedDepartment = AgencyTopic.builder().agency(agency).topicId(1L)
-        .contentDpp("{\"de\":\"<p>DSE</p>\"}").publicationStatus(PublicationStatus.PUBLISHED)
-        .contentImprint("{\"de\":\"<p>Impressum</p>\"}")
-        .publicationStatusImprint(PublicationStatus.PUBLISHED).build();
-    AgencyTopic draftDepartment = AgencyTopic.builder().agency(agency).topicId(2L)
-        .contentDpp("{\"de\":\"<p>Entwurf</p>\"}").publicationStatus(PublicationStatus.DRAFT)
-        .build();
-    ReflectionTestUtils.setField(agency, "agencyTopics",
-        List.of(publishedDepartment, draftDepartment));
+    AgencyTopic withLegal = AgencyTopic.builder().agency(agency).topicId(1L).build();
+    AgencyTopic withoutLegal = AgencyTopic.builder().agency(agency).topicId(2L).build();
+    ReflectionTestUtils.setField(agency, "agencyTopics", List.of(withLegal, withoutLegal));
+
+    when(legalTextInheritanceResolver.resolveDpp(withLegal))
+        .thenReturn(resolved(LegalTextSourceLevel.DEPARTMENT));
+    when(legalTextInheritanceResolver.resolveImprint(withLegal))
+        .thenReturn(resolved(LegalTextSourceLevel.DEPARTMENT));
 
     when(agencyRepository.searchWithoutTopic(VALID_POSTCODE, VALID_POSTCODE_LENGTH,
         CONSULTING_TYPE_SUCHT, AGE, GENDER, COUNSELLING_RELATION, TENANT_ID))
@@ -242,107 +265,30 @@ public class AgencyServiceTest {
         agencyService.getAgencies(Optional.of(VALID_POSTCODE), CONSULTING_TYPE_SUCHT,
             Optional.empty());
 
-    assertEquals(1, result.size());
-    var departments = result.get(0).getDepartments();
-    assertEquals(2, departments.size());
-    var byTopicId = departments.stream()
+    var byTopicId = result.get(0).getDepartments().stream()
         .collect(java.util.stream.Collectors.toMap(d -> d.getTopicId(), d -> d));
     assertTrue(byTopicId.get(1L).getHasPublishedDpp());
     assertTrue(byTopicId.get(1L).getHasPublishedImprint());
     assertEquals(Boolean.FALSE, byTopicId.get(2L).getHasPublishedDpp());
     assertEquals(Boolean.FALSE, byTopicId.get(2L).getHasPublishedImprint());
-    // the existing topicIds contract is untouched
-    assertEquals(List.of(1L, 2L), result.get(0).getTopicIds());
   }
 
   @Test
-  public void getListOfAgencies_Should_ResolveDepartmentDetails_FachbereichBeforeAgency()
+  public void getListOfAgencies_Should_ReportAnInheritedDppAsPublished()
       throws MissingConsultingTypeException {
 
-    // ORISO-Admin#197: a center may run several Fachbereiche at different floors/areas with
-    // different hours. Resolution chain: Fachbereich override ?? Beratungsstelle value.
-    Agency agency = Agency.builder().id(102L).name("Zentrum")
-        .consultingTypeId(CONSULTING_TYPE_SUCHT)
-        .openingHours("Mo-Fr 9-17 Uhr").floorBuilding("Haus B").build();
-    AgencyTopic overriding = AgencyTopic.builder().agency(agency).topicId(1L)
-        .openingHours("Di+Do 14-18 Uhr").phoneExtension("-23").floorLocation("3. OG").build();
-    AgencyTopic inheriting = AgencyTopic.builder().agency(agency).topicId(2L).build();
-    ReflectionTestUtils.setField(agency, "agencyTopics", List.of(overriding, inheriting));
-
-    when(agencyRepository.searchWithoutTopic(VALID_POSTCODE, VALID_POSTCODE_LENGTH,
-        CONSULTING_TYPE_SUCHT, AGE, GENDER, COUNSELLING_RELATION, TENANT_ID))
-        .thenReturn(List.of(agency));
-    when(consultingTypeManager.getConsultingTypeSettings(Mockito.anyInt()))
-        .thenReturn(CONSULTING_TYPE_SETTINGS_WITH_WHITESPOT_AGENCY);
-
-    var result = agencyService.getAgencies(Optional.of(VALID_POSTCODE),
-        CONSULTING_TYPE_SUCHT, Optional.empty());
-
-    assertEquals(1, result.size());
-    var byTopicId = result.get(0).getDepartments().stream()
-        .collect(java.util.stream.Collectors.toMap(d -> d.getTopicId(), d -> d));
-    // the overriding Fachbereich serves its own values
-    assertEquals("Di+Do 14-18 Uhr", byTopicId.get(1L).getOpeningHours());
-    assertEquals("-23", byTopicId.get(1L).getPhoneExtension());
-    assertEquals("3. OG", byTopicId.get(1L).getFloorLocation());
-    // the inheriting Fachbereich resolves to the Beratungsstelle values
-    assertEquals("Mo-Fr 9-17 Uhr", byTopicId.get(2L).getOpeningHours());
-    assertEquals(null, byTopicId.get(2L).getPhoneExtension());
-    assertEquals("Haus B", byTopicId.get(2L).getFloorLocation());
-  }
-
-  @Test
-  public void getListOfAgencies_Should_MapAddressPhoneAndOpeningHours()
-      throws MissingConsultingTypeException {
-
-    Agency agency = Agency.builder().id(101L).name("Zentrum")
-        .consultingTypeId(CONSULTING_TYPE_SUCHT)
-        .street("Musterstraße").houseNumber("12a")
-        .phone("+49301234567").openingHours("Mo-Fr 9-17 Uhr").build();
-    ReflectionTestUtils.setField(agency, "agencyTopics", List.of());
-
-    when(agencyRepository.searchWithoutTopic(VALID_POSTCODE, VALID_POSTCODE_LENGTH,
-        CONSULTING_TYPE_SUCHT, AGE, GENDER, COUNSELLING_RELATION, TENANT_ID))
-        .thenReturn(List.of(agency));
-    when(consultingTypeManager.getConsultingTypeSettings(Mockito.anyInt()))
-        .thenReturn(CONSULTING_TYPE_SETTINGS_WITH_WHITESPOT_AGENCY);
-
-    var result = agencyService.getAgencies(Optional.of(VALID_POSTCODE),
-        CONSULTING_TYPE_SUCHT, Optional.empty());
-
-    assertEquals(1, result.size());
-    assertEquals("Musterstraße", result.get(0).getStreet());
-    assertEquals("12a", result.get(0).getHouseNumber());
-    assertEquals("+49301234567", result.get(0).getPhone());
-    assertEquals("Mo-Fr 9-17 Uhr", result.get(0).getOpeningHours());
-  }
-
-  @Test
-  public void getListOfAgencies_Should_DeriveLegalPublicationFlagsFromReferencedLegalText_WhenDepartmentReferencesOne()
-      throws MissingConsultingTypeException {
-
-    // ADR-014 write-through only updates the referenced legal_text object; the inline columns are
-    // intentionally kept stale. The search flags must therefore resolve reference-first, exactly
-    // like DepartmentLegalService — otherwise a publish/draft-save would not show up here.
+    // The measured defect (CONTEXT-legal-documents, "known traps"): hasPublishedDpp was computed
+    // from the department level alone while DepartmentLegalService already fell back to the
+    // agency-wide text, so a department reported false while /legal returned content and the
+    // client hid a document that existed. Both now go through the same resolver.
     Agency agency = Agency.builder().id(100L).name("Zentrum").consultingTypeId(CONSULTING_TYPE_SUCHT)
+        .contentDpp("{\"de\":\"<p>agenturweite DSE</p>\"}")
         .build();
-    // referenced DPP is PUBLISHED while the stale inline copy says DRAFT → flag must be true
-    AgencyTopic publishedViaReference = AgencyTopic.builder().agency(agency).topicId(1L)
-        .contentDpp("{\"de\":\"<p>stale inline</p>\"}").publicationStatus(PublicationStatus.DRAFT)
-        .dpp(LegalText.builder().id(500L).kind(LegalTextKind.DPP).label("Geteilte DSE")
-            .content("{\"de\":\"<p>geteilt</p>\"}")
-            .publicationStatus(PublicationStatus.PUBLISHED).build())
-        .build();
-    // referenced imprint is DRAFT while the stale inline copy says PUBLISHED → flag must be false
-    AgencyTopic draftViaReference = AgencyTopic.builder().agency(agency).topicId(2L)
-        .contentImprint("{\"de\":\"<p>stale inline</p>\"}")
-        .publicationStatusImprint(PublicationStatus.PUBLISHED)
-        .imprint(LegalText.builder().id(501L).kind(LegalTextKind.IMPRINT)
-            .label("Geteiltes Impressum").content("{\"de\":\"<p>Entwurf</p>\"}")
-            .publicationStatus(PublicationStatus.DRAFT).build())
-        .build();
-    ReflectionTestUtils.setField(agency, "agencyTopics",
-        List.of(publishedViaReference, draftViaReference));
+    AgencyTopic departmentWithoutOwnText = AgencyTopic.builder().agency(agency).topicId(1L).build();
+    ReflectionTestUtils.setField(agency, "agencyTopics", List.of(departmentWithoutOwnText));
+
+    when(legalTextInheritanceResolver.resolveDpp(departmentWithoutOwnText))
+        .thenReturn(resolved(LegalTextSourceLevel.AGENCY));
 
     when(agencyRepository.searchWithoutTopic(VALID_POSTCODE, VALID_POSTCODE_LENGTH,
         CONSULTING_TYPE_SUCHT, AGE, GENDER, COUNSELLING_RELATION, TENANT_ID))
@@ -354,13 +300,7 @@ public class AgencyServiceTest {
         agencyService.getAgencies(Optional.of(VALID_POSTCODE), CONSULTING_TYPE_SUCHT,
             Optional.empty());
 
-    assertEquals(1, result.size());
-    var byTopicId = result.get(0).getDepartments().stream()
-        .collect(java.util.stream.Collectors.toMap(d -> d.getTopicId(), d -> d));
-    assertTrue(byTopicId.get(1L).getHasPublishedDpp());
-    assertEquals(Boolean.FALSE, byTopicId.get(1L).getHasPublishedImprint());
-    assertEquals(Boolean.FALSE, byTopicId.get(2L).getHasPublishedDpp());
-    assertEquals(Boolean.FALSE, byTopicId.get(2L).getHasPublishedImprint());
+    assertTrue(result.get(0).getDepartments().get(0).getHasPublishedDpp());
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/agencyservice/api/service/DepartmentLegalServiceTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/service/DepartmentLegalServiceTest.java
@@ -8,9 +8,9 @@ import de.caritas.cob.agencyservice.api.exception.httpresponses.NotFoundExceptio
 import de.caritas.cob.agencyservice.api.repository.agency.Agency;
 import de.caritas.cob.agencyservice.api.repository.agencytopic.AgencyTopic;
 import de.caritas.cob.agencyservice.api.repository.agencytopic.AgencyTopicRepository;
-import de.caritas.cob.agencyservice.api.repository.agencytopic.PublicationStatus;
-import de.caritas.cob.agencyservice.api.repository.legaltext.LegalText;
-import de.caritas.cob.agencyservice.api.repository.legaltext.LegalTextKind;
+import de.caritas.cob.agencyservice.api.service.legal.LegalTextInheritanceResolver;
+import de.caritas.cob.agencyservice.api.service.legal.LegalTextSourceLevel;
+import de.caritas.cob.agencyservice.api.service.legal.ResolvedLegalText;
 import java.time.LocalDateTime;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
@@ -20,30 +20,31 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 /**
- * The public (unauthenticated) read side of ADR-003: users may only ever see PUBLISHED department
- * legal texts. The central invariant tested here is that DRAFT or never-authored content is
- * returned as {@code null} - drafts must never leak to clients.
+ * The public read side after ADR-021 decision 9: this service no longer resolves anything itself,
+ * it looks the department up, refuses deleted agencies, and hands both kinds to the one resolver
+ * that walks the whole ladder. The resolution rules themselves are covered by {@link
+ * de.caritas.cob.agencyservice.api.service.legal.LegalTextInheritanceResolverTest}.
  */
 @ExtendWith(MockitoExtension.class)
 class DepartmentLegalServiceTest {
 
   @Mock private AgencyTopicRepository agencyTopicRepository;
+  @Mock private LegalTextInheritanceResolver legalTextInheritanceResolver;
 
   @InjectMocks private DepartmentLegalService service;
 
-  private AgencyTopic department(
-      String dppContent,
-      PublicationStatus dppStatus,
-      String imprintContent,
-      PublicationStatus imprintStatus) {
+  private AgencyTopic department(LocalDateTime agencyDeleteDate) {
     var department =
         AgencyTopic.builder()
+            .id(4711L)
             .topicId(42L)
-            .agency(Agency.builder().id(7L).name("Zentrum").consultingTypeId(1).build())
-            .contentDpp(dppContent)
-            .publicationStatus(dppStatus)
-            .contentImprint(imprintContent)
-            .publicationStatusImprint(imprintStatus)
+            .agency(
+                Agency.builder()
+                    .id(7L)
+                    .name("Zentrum")
+                    .consultingTypeId(1)
+                    .deleteDate(agencyDeleteDate)
+                    .build())
             .build();
     when(agencyTopicRepository.findByAgency_IdAndTopicId(7L, 42L))
         .thenReturn(Optional.of(department));
@@ -51,197 +52,43 @@ class DepartmentLegalServiceTest {
   }
 
   @Test
-  void getPublishedDepartmentLegal_Should_returnBothContents_When_bothPublished() {
-    department(
-        "{\"de\":\"<p>DSE</p>\"}",
-        PublicationStatus.PUBLISHED,
-        "{\"de\":\"<p>Impressum</p>\"}",
-        PublicationStatus.PUBLISHED);
+  void getPublishedDepartmentLegal_Should_returnBothResolvedTexts() {
+    var department = department(null);
+    when(legalTextInheritanceResolver.resolveDpp(department))
+        .thenReturn(
+            new ResolvedLegalText(
+                "{\"de\":\"<p>DSE</p>\"}",
+                "{\"de\":\"Ich habe die {{legal_links}} gelesen.\"}",
+                LegalTextSourceLevel.DEPARTMENT,
+                100L));
+    when(legalTextInheritanceResolver.resolveImprint(department))
+        .thenReturn(
+            new ResolvedLegalText(
+                "{\"de\":\"<p>Impressum</p>\"}", null, LegalTextSourceLevel.AGENCY, null));
 
     var view = service.getPublishedDepartmentLegal(7L, 42L);
 
-    assertThat(view.dppContent()).isEqualTo("{\"de\":\"<p>DSE</p>\"}");
-    assertThat(view.imprintContent()).isEqualTo("{\"de\":\"<p>Impressum</p>\"}");
+    assertThat(view.dpp().content()).contains("DSE");
+    assertThat(view.dpp().consentText()).contains("{{legal_links}}");
+    assertThat(view.dpp().sourceLevel()).isEqualTo(LegalTextSourceLevel.DEPARTMENT);
+    // The version id is what ORISO-UserService pins a recorded consent to (ADR-022 decision 2).
+    assertThat(view.dpp().versionId()).isEqualTo(100L);
+    // An inherited imprint is legitimately reachable and reported as coming from the agency level.
+    assertThat(view.imprint().sourceLevel()).isEqualTo(LegalTextSourceLevel.AGENCY);
   }
 
   @Test
-  void getPublishedDepartmentLegal_Should_neverLeakDraftContent() {
-    // both texts exist in the database but are still drafts - the public API must return null
-    department(
-        "{\"de\":\"<p>DSE Entwurf</p>\"}",
-        PublicationStatus.DRAFT,
-        "{\"de\":\"<p>Impressum Entwurf</p>\"}",
-        PublicationStatus.DRAFT);
+  void getPublishedDepartmentLegal_Should_returnNoContent_When_nothingIsAuthoredAnywhere() {
+    var department = department(null);
+    when(legalTextInheritanceResolver.resolveDpp(department)).thenReturn(ResolvedLegalText.none());
+    when(legalTextInheritanceResolver.resolveImprint(department))
+        .thenReturn(ResolvedLegalText.none());
 
     var view = service.getPublishedDepartmentLegal(7L, 42L);
 
     assertThat(view.dppContent()).isNull();
     assertThat(view.imprintContent()).isNull();
-  }
-
-  @Test
-  void getPublishedDepartmentLegal_Should_treatEachTextsLifecycleIndependently() {
-    // published DPP next to a draft imprint: only the published half is exposed
-    department(
-        "{\"de\":\"<p>DSE</p>\"}",
-        PublicationStatus.PUBLISHED,
-        "{\"de\":\"<p>Impressum Entwurf</p>\"}",
-        PublicationStatus.DRAFT);
-
-    var view = service.getPublishedDepartmentLegal(7L, 42L);
-
-    assertThat(view.dppContent()).isEqualTo("{\"de\":\"<p>DSE</p>\"}");
-    assertThat(view.imprintContent()).isNull();
-  }
-
-  @Test
-  void getPublishedDepartmentLegal_Should_returnNull_When_publishedButNeverAuthored() {
-    // PUBLISHED status without stored content must not turn into an empty-but-present document
-    department(null, PublicationStatus.PUBLISHED, "   ", PublicationStatus.PUBLISHED);
-
-    var view = service.getPublishedDepartmentLegal(7L, 42L);
-
-    assertThat(view.dppContent()).isNull();
-    assertThat(view.imprintContent()).isNull();
-  }
-
-  @Test
-  void getPublishedDepartmentLegal_Should_preferReferencedLegalText_OverInlineContent() {
-    // ADR-014: when the department references a shared legal-text object, that object is the
-    // truth — the leftover inline copy must be ignored entirely.
-    var department =
-        department(
-            "{\"de\":\"<p>alte Inline-DSE</p>\"}",
-            PublicationStatus.PUBLISHED,
-            null,
-            PublicationStatus.DRAFT);
-    department.setDpp(
-        LegalText.builder()
-            .id(100L)
-            .kind(LegalTextKind.DPP)
-            .label("Geteilte DSE")
-            .content("{\"de\":\"<p>geteilte DSE</p>\"}")
-            .publicationStatus(PublicationStatus.PUBLISHED)
-            .build());
-
-    var view = service.getPublishedDepartmentLegal(7L, 42L);
-
-    assertThat(view.dppContent()).isEqualTo("{\"de\":\"<p>geteilte DSE</p>\"}");
-  }
-
-  @Test
-  void getPublishedDepartmentLegal_Should_returnNull_When_referencedTextIsDraft() {
-    // a DRAFT shared object must not fall back to a published inline leftover — the reference,
-    // once set, fully replaces the inline column
-    var department =
-        department(
-            "{\"de\":\"<p>alte Inline-DSE</p>\"}",
-            PublicationStatus.PUBLISHED,
-            null,
-            PublicationStatus.DRAFT);
-    department.setDpp(
-        LegalText.builder()
-            .id(100L)
-            .kind(LegalTextKind.DPP)
-            .label("Entwurf")
-            .content("{\"de\":\"<p>Entwurf</p>\"}")
-            .publicationStatus(PublicationStatus.DRAFT)
-            .build());
-
-    var view = service.getPublishedDepartmentLegal(7L, 42L);
-
-    assertThat(view.dppContent()).isNull();
-  }
-
-  @Test
-  void getPublishedDepartmentLegal_Should_resolveImprintReferenceIndependently() {
-    var department =
-        department(null, PublicationStatus.DRAFT, null, PublicationStatus.DRAFT);
-    department.setImprint(
-        LegalText.builder()
-            .id(101L)
-            .kind(LegalTextKind.IMPRINT)
-            .label("Geteiltes Impressum")
-            .content("{\"de\":\"<p>Impressum</p>\"}")
-            .publicationStatus(PublicationStatus.PUBLISHED)
-            .build());
-
-    var view = service.getPublishedDepartmentLegal(7L, 42L);
-
-    assertThat(view.dppContent()).isNull();
-    assertThat(view.imprintContent()).isEqualTo("{\"de\":\"<p>Impressum</p>\"}");
-  }
-
-  @Test
-  void getPublishedDepartmentLegal_Should_fallBackToAgencyWideText_When_departmentHasNoneOfItsOwn() {
-    // ADR-014 chain tenant -> agency -> department: a Fachbereich that never authored anything
-    // shows what its Beratungsstelle publishes, not nothing.
-    var department = department(null, PublicationStatus.DRAFT, null, PublicationStatus.DRAFT);
-    department.getAgency().setContentDpp("{\"de\":\"<p>DSE der Stelle</p>\"}");
-    department.getAgency().setContentImprint("{\"de\":\"<p>Impressum der Stelle</p>\"}");
-
-    var view = service.getPublishedDepartmentLegal(7L, 42L);
-
-    assertThat(view.dppContent()).isEqualTo("{\"de\":\"<p>DSE der Stelle</p>\"}");
-    assertThat(view.imprintContent()).isEqualTo("{\"de\":\"<p>Impressum der Stelle</p>\"}");
-  }
-
-  @Test
-  void getPublishedDepartmentLegal_Should_preferOwnPublishedText_OverAgencyWideText() {
-    // Publishing is what leaves the inheritance for good.
-    var department =
-        department(
-            "{\"de\":\"<p>eigene DSE</p>\"}", PublicationStatus.PUBLISHED, null,
-            PublicationStatus.DRAFT);
-    department.getAgency().setContentDpp("{\"de\":\"<p>DSE der Stelle</p>\"}");
-
-    var view = service.getPublishedDepartmentLegal(7L, 42L);
-
-    assertThat(view.dppContent()).isEqualTo("{\"de\":\"<p>eigene DSE</p>\"}");
-  }
-
-  @Test
-  void getPublishedDepartmentLegal_Should_keepShowingAgencyWideText_While_ownTextIsStillDraft() {
-    // The draft copy is invisible to users until it is published — until then the inherited text
-    // stays in force. A draft must never blank out a legally required document.
-    var department =
-        department(
-            "{\"de\":\"<p>Entwurf</p>\"}", PublicationStatus.DRAFT, null, PublicationStatus.DRAFT);
-    department.getAgency().setContentDpp("{\"de\":\"<p>DSE der Stelle</p>\"}");
-
-    var view = service.getPublishedDepartmentLegal(7L, 42L);
-
-    assertThat(view.dppContent()).isEqualTo("{\"de\":\"<p>DSE der Stelle</p>\"}");
-  }
-
-  @Test
-  void getPublishedDepartmentLegal_Should_fallBackToAgencyWideText_When_referencedTextIsDraft() {
-    var department = department(null, PublicationStatus.DRAFT, null, PublicationStatus.DRAFT);
-    department.getAgency().setContentDpp("{\"de\":\"<p>DSE der Stelle</p>\"}");
-    department.setDpp(
-        LegalText.builder()
-            .id(100L)
-            .kind(LegalTextKind.DPP)
-            .label("Entwurf")
-            .content("{\"de\":\"<p>Entwurf</p>\"}")
-            .publicationStatus(PublicationStatus.DRAFT)
-            .build());
-
-    var view = service.getPublishedDepartmentLegal(7L, 42L);
-
-    assertThat(view.dppContent()).isEqualTo("{\"de\":\"<p>DSE der Stelle</p>\"}");
-  }
-
-  @Test
-  void getPublishedDepartmentLegal_Should_returnNull_When_neitherLevelHasText() {
-    // A blank agency column is an absent text, not an empty-but-present document.
-    var department = department(null, PublicationStatus.DRAFT, null, PublicationStatus.DRAFT);
-    department.getAgency().setContentDpp("   ");
-
-    var view = service.getPublishedDepartmentLegal(7L, 42L);
-
-    assertThat(view.dppContent()).isNull();
-    assertThat(view.imprintContent()).isNull();
+    assertThat(view.dpp().sourceLevel()).isEqualTo(LegalTextSourceLevel.NONE);
   }
 
   @Test
@@ -254,15 +101,22 @@ class DepartmentLegalServiceTest {
 
   @Test
   void getPublishedDepartmentLegal_Should_throwNotFound_When_agencyIsDeleted() {
-    var department =
-        department(
-            "{\"de\":\"<p>DSE</p>\"}",
-            PublicationStatus.PUBLISHED,
-            "{\"de\":\"<p>Impressum</p>\"}",
-            PublicationStatus.PUBLISHED);
-    department.getAgency().setDeleteDate(LocalDateTime.now());
+    department(LocalDateTime.of(2026, 1, 1, 0, 0));
 
+    // A deleted Beratungsstelle has no public surface at all, legal texts included.
     assertThatExceptionOfType(NotFoundException.class)
         .isThrownBy(() -> service.getPublishedDepartmentLegal(7L, 42L));
+  }
+
+  @Test
+  void hasResolvableDpp_Should_followTheSameChainAsTheEndpoint() {
+    var department = AgencyTopic.builder().id(4711L).topicId(42L).build();
+    when(legalTextInheritanceResolver.resolveDpp(department))
+        .thenReturn(
+            new ResolvedLegalText("{\"de\":\"x\"}", null, LegalTextSourceLevel.AGENCY, null));
+
+    // The measured defect: the flag used to look only at the department level while the endpoint
+    // already inherited, so a department reported false while /legal returned content.
+    assertThat(service.hasResolvableDpp(department)).isTrue();
   }
 }

--- a/src/test/java/de/caritas/cob/agencyservice/api/service/DepartmentLegalServiceTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/service/DepartmentLegalServiceTest.java
@@ -30,8 +30,19 @@ class DepartmentLegalServiceTest {
 
   @Mock private AgencyTopicRepository agencyTopicRepository;
   @Mock private LegalTextInheritanceResolver legalTextInheritanceResolver;
+  @Mock private de.caritas.cob.agencyservice.api.service.legal.PublicLegalTextRenderer publicLegalTextRenderer;
 
   @InjectMocks private DepartmentLegalService service;
+
+  @org.junit.jupiter.api.BeforeEach
+  void renderPassThrough() {
+    // Substitution is covered by PublicLegalTextRendererTest; here it must not hide the resolution.
+    org.mockito.Mockito.lenient()
+        .when(
+            publicLegalTextRenderer.render(
+                org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any()))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+  }
 
   private AgencyTopic department(LocalDateTime agencyDeleteDate) {
     var department =

--- a/src/test/java/de/caritas/cob/agencyservice/api/service/DepartmentLegalServiceTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/service/DepartmentLegalServiceTest.java
@@ -2,6 +2,9 @@ package de.caritas.cob.agencyservice.api.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import de.caritas.cob.agencyservice.api.exception.httpresponses.NotFoundException;
@@ -34,15 +37,32 @@ class DepartmentLegalServiceTest {
 
   @InjectMocks private DepartmentLegalService service;
 
+  /**
+   * The renderer is stubbed to MARK what passes through it, not to pass it through unchanged.
+   *
+   * <p>A transparent pass-through would make this test blind to the thing it exists to prove: drop
+   * the render call from the service and every assertion would still hold, so the substitution step
+   * could be deleted without a single test going red. The marker means every text this service
+   * returns must have been through the renderer.
+   */
   @org.junit.jupiter.api.BeforeEach
-  void renderPassThrough() {
-    // Substitution is covered by PublicLegalTextRendererTest; here it must not hide the resolution.
+  void markWhatPassesThroughTheRenderer() {
     org.mockito.Mockito.lenient()
         .when(
             publicLegalTextRenderer.render(
                 org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any()))
-        .thenAnswer(invocation -> invocation.getArgument(0));
+        .thenAnswer(
+            invocation -> {
+              ResolvedLegalText resolved = invocation.getArgument(0);
+              return new ResolvedLegalText(
+                  resolved.content() == null ? null : resolved.content() + RENDERED,
+                  resolved.consentText() == null ? null : resolved.consentText() + RENDERED,
+                  resolved.sourceLevel(),
+                  resolved.versionId());
+            });
   }
+
+  private static final String RENDERED = "|rendered";
 
   private AgencyTopic department(LocalDateTime agencyDeleteDate) {
     var department =
@@ -79,13 +99,15 @@ class DepartmentLegalServiceTest {
 
     var view = service.getPublishedDepartmentLegal(7L, 42L);
 
-    assertThat(view.dpp().content()).contains("DSE");
-    assertThat(view.dpp().consentText()).contains("{{legal_links}}");
+    // Every returned text must have gone through the substitution step.
+    assertThat(view.dpp().content()).contains("DSE").endsWith(RENDERED);
+    assertThat(view.dpp().consentText()).contains("{{legal_links}}").endsWith(RENDERED);
     assertThat(view.dpp().sourceLevel()).isEqualTo(LegalTextSourceLevel.DEPARTMENT);
     // The version id is what ORISO-UserService pins a recorded consent to (ADR-022 decision 2).
     assertThat(view.dpp().versionId()).isEqualTo(100L);
     // An inherited imprint is legitimately reachable and reported as coming from the agency level.
     assertThat(view.imprint().sourceLevel()).isEqualTo(LegalTextSourceLevel.AGENCY);
+    assertThat(view.imprint().content()).endsWith(RENDERED);
   }
 
   @Test
@@ -129,5 +151,7 @@ class DepartmentLegalServiceTest {
     // The measured defect: the flag used to look only at the department level while the endpoint
     // already inherited, so a department reported false while /legal returned content.
     assertThat(service.hasResolvableDpp(department)).isTrue();
+    // hasResolvableDpp asks the resolver directly - substitution is irrelevant to a yes/no flag.
+    verify(publicLegalTextRenderer, never()).render(any(), any());
   }
 }

--- a/src/test/java/de/caritas/cob/agencyservice/api/service/legal/LegalTextInheritanceResolverTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/service/legal/LegalTextInheritanceResolverTest.java
@@ -1,0 +1,282 @@
+package de.caritas.cob.agencyservice.api.service.legal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import de.caritas.cob.agencyservice.api.repository.agency.Agency;
+import de.caritas.cob.agencyservice.api.repository.agencytopic.AgencyTopic;
+import de.caritas.cob.agencyservice.api.repository.agencytopic.PublicationStatus;
+import de.caritas.cob.agencyservice.api.repository.legaltext.LegalText;
+import de.caritas.cob.agencyservice.api.repository.legaltext.LegalTextKind;
+import de.caritas.cob.agencyservice.api.repository.legaltext.LegalTextLevel;
+import de.caritas.cob.agencyservice.api.repository.legaltext.LegalTextVersion;
+import de.caritas.cob.agencyservice.api.repository.legaltext.LegalTextVersionRepository;
+import de.caritas.cob.agencyservice.api.service.ApplicationSettingsService;
+import de.caritas.cob.agencyservice.api.service.TenantService;
+import de.caritas.cob.agencyservice.applicationsettingsservice.generated.web.model.ApplicationSettingsDTO;
+import de.caritas.cob.agencyservice.applicationsettingsservice.generated.web.model.FeatureToggleDTO;
+import de.caritas.cob.agencyservice.tenantservice.generated.web.model.Content;
+import de.caritas.cob.agencyservice.tenantservice.generated.web.model.RestrictedTenantDTO;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * ADR-021 decision 9: the whole department → agency → Träger → platform-operator chain in one
+ * place. These tests walk each rung and, just as importantly, pin what makes a rung fall through.
+ */
+@ExtendWith(MockitoExtension.class)
+class LegalTextInheritanceResolverTest {
+
+  @Mock private LegalTextVersionRepository legalTextVersionRepository;
+  @Mock private TenantService tenantService;
+  @Mock private ApplicationSettingsService applicationSettingsService;
+
+  @InjectMocks private LegalTextInheritanceResolver resolver;
+
+  @BeforeEach
+  void setUp() {
+    lenient()
+        .when(
+            legalTextVersionRepository
+                .findFirstByOwnerLevelAndOwnerIdAndKindAndSupersededAtIsNullOrderByIdDesc(
+                    any(), any(), any()))
+        .thenReturn(Optional.empty());
+  }
+
+  private void singleDomainMultitenancy(boolean enabled) {
+    ReflectionTestUtils.setField(resolver, "multitenancyWithSingleDomain", enabled);
+  }
+
+  private void tenantMayOverridePlatformText(boolean allowed) {
+    when(applicationSettingsService.getApplicationSettings())
+        .thenReturn(
+            new ApplicationSettingsDTO()
+                .legalContentChangesBySingleTenantAdminsAllowed(
+                    new FeatureToggleDTO().value(allowed)));
+  }
+
+  private Agency agency(String dpp, String imprint, String consent) {
+    return Agency.builder()
+        .id(7L)
+        .name("Zentrum")
+        .consultingTypeId(1)
+        .tenantId(3L)
+        .contentDpp(dpp)
+        .contentImprint(imprint)
+        .consentText(consent)
+        .build();
+  }
+
+  private AgencyTopic department(Agency agency) {
+    return AgencyTopic.builder().id(4711L).topicId(42L).agency(agency).build();
+  }
+
+  private RestrictedTenantDTO tenantWith(String privacyHtml) {
+    return new RestrictedTenantDTO()
+        .id(3L)
+        .name("Träger")
+        .content(new Content().impressum("").privacyLanguages(Map.of("de", privacyHtml)));
+  }
+
+  // ---------------------------------------------------------------- level 4
+
+  @Test
+  void resolveDpp_Should_useTheDepartmentText_When_itIsPublished() {
+    var department = department(agency("{\"de\":\"agency\"}", null, null));
+    department.setContentDpp("{\"de\":\"department\"}");
+    department.setConsentText("{\"de\":\"Ich habe die {{legal_links}} gelesen.\"}");
+    department.setPublicationStatus(PublicationStatus.PUBLISHED);
+    when(legalTextVersionRepository
+            .findFirstByOwnerLevelAndOwnerIdAndKindAndSupersededAtIsNullOrderByIdDesc(
+                LegalTextLevel.DEPARTMENT, 4711L, LegalTextKind.DPP))
+        .thenReturn(Optional.of(LegalTextVersion.builder().id(100L).build()));
+
+    var resolved = resolver.resolveDpp(department);
+
+    assertThat(resolved.content()).contains("department");
+    assertThat(resolved.consentText()).contains("{{legal_links}}");
+    assertThat(resolved.sourceLevel()).isEqualTo(LegalTextSourceLevel.DEPARTMENT);
+    assertThat(resolved.versionId()).isEqualTo(100L);
+    // Rung 4 answered, so nothing above it is consulted at all.
+    verify(tenantService, never()).getRestrictedTenantDataByTenantId(any());
+  }
+
+  @Test
+  void resolveDpp_Should_fallThroughADraft_ratherThanBlankingOutTheDocument() {
+    var department = department(agency("{\"de\":\"agency\"}", null, null));
+    department.setContentDpp("{\"de\":\"still drafting\"}");
+    department.setPublicationStatus(PublicationStatus.DRAFT);
+
+    var resolved = resolver.resolveDpp(department);
+
+    // A Fachbereich mid-edit must not remove a legally required document from its help-seekers.
+    assertThat(resolved.content()).contains("agency").doesNotContain("still drafting");
+    assertThat(resolved.sourceLevel()).isEqualTo(LegalTextSourceLevel.AGENCY);
+  }
+
+  @Test
+  void resolveDpp_Should_preferAReferencedSharedObject_overTheInlineColumn() {
+    var department = department(agency("{\"de\":\"agency\"}", null, null));
+    department.setContentDpp("{\"de\":\"stale inline leftover\"}");
+    department.setPublicationStatus(PublicationStatus.PUBLISHED);
+    department.setDpp(
+        LegalText.builder()
+            .id(55L)
+            .kind(LegalTextKind.DPP)
+            .label("Standard-DSE")
+            .content("{\"de\":\"shared\"}")
+            .consentText("{\"de\":\"shared consent {{legal_links}}\"}")
+            .publicationStatus(PublicationStatus.PUBLISHED)
+            .build());
+    when(legalTextVersionRepository
+            .findFirstByOwnerLevelAndOwnerIdAndKindAndSupersededAtIsNullOrderByIdDesc(
+                LegalTextLevel.SHARED, 55L, LegalTextKind.DPP))
+        .thenReturn(Optional.of(LegalTextVersion.builder().id(200L).build()));
+
+    var resolved = resolver.resolveDpp(department);
+
+    // ADR-014: once assigned, the shared object fully replaces the inline column - which is what
+    // makes the 0026 backfill leftovers harmless.
+    assertThat(resolved.content()).contains("shared");
+    assertThat(resolved.consentText()).contains("shared consent");
+    assertThat(resolved.versionId()).isEqualTo(200L);
+  }
+
+  @Test
+  void resolveDpp_Should_fallThrough_When_theReferencedSharedObjectIsStillADraft() {
+    var department = department(agency("{\"de\":\"agency\"}", null, null));
+    department.setDpp(
+        LegalText.builder()
+            .id(55L)
+            .kind(LegalTextKind.DPP)
+            .label("Entwurf")
+            .content("{\"de\":\"shared draft\"}")
+            .publicationStatus(PublicationStatus.DRAFT)
+            .build());
+
+    assertThat(resolver.resolveDpp(department).sourceLevel())
+        .isEqualTo(LegalTextSourceLevel.AGENCY);
+  }
+
+  // ---------------------------------------------------------------- level 3
+
+  @Test
+  void resolveDpp_Should_useTheAgencyText_WithoutAnyPublicationStatus() {
+    var agency = agency("{\"de\":\"agency\"}", null, "{\"de\":\"agency consent {{legal_links}}\"}");
+    when(legalTextVersionRepository
+            .findFirstByOwnerLevelAndOwnerIdAndKindAndSupersededAtIsNullOrderByIdDesc(
+                LegalTextLevel.AGENCY, 7L, LegalTextKind.DPP))
+        .thenReturn(Optional.of(LegalTextVersion.builder().id(300L).build()));
+
+    var resolved = resolver.resolveDpp(department(agency));
+
+    // "What is stored, applies" - there is no draft state on this level to fall through.
+    assertThat(resolved.sourceLevel()).isEqualTo(LegalTextSourceLevel.AGENCY);
+    assertThat(resolved.consentText()).contains("agency consent");
+    assertThat(resolved.versionId()).isEqualTo(300L);
+  }
+
+  // ---------------------------------------------------------------- levels 2 and 1
+
+  @Test
+  void resolveDpp_Should_useTheTraegerText_When_aTraegerMayReplaceThePlatformText() {
+    singleDomainMultitenancy(true);
+    tenantMayOverridePlatformText(true);
+    when(tenantService.getRestrictedTenantDataByTenantId(3L))
+        .thenReturn(tenantWith("<p>Träger-DSE</p>"));
+
+    var resolved = resolver.resolveDpp(department(agency(null, null, null)));
+
+    assertThat(resolved.sourceLevel()).isEqualTo(LegalTextSourceLevel.TENANT);
+    assertThat(resolved.content()).contains("Träger-DSE");
+    // Träger and platform histories live in ORISO-TenantService, not here.
+    assertThat(resolved.versionId()).isNull();
+  }
+
+  @Test
+  void resolveDpp_Should_useThePlatformText_When_aTraegerMayNotReplaceIt() {
+    singleDomainMultitenancy(true);
+    tenantMayOverridePlatformText(false);
+    when(tenantService.getMainTenant()).thenReturn(tenantWith("<p>Plattform-DSE</p>"));
+
+    var resolved = resolver.resolveDpp(department(agency(null, null, null)));
+
+    // The toggle decides level 1 vs level 2; when it is off the Träger's own text is not consulted.
+    assertThat(resolved.sourceLevel()).isEqualTo(LegalTextSourceLevel.PLATFORM);
+    assertThat(resolved.content()).contains("Plattform-DSE");
+    verify(tenantService, never()).getRestrictedTenantDataByTenantId(any());
+  }
+
+  @Test
+  void resolveDpp_Should_returnTheTenantTextAsALanguageMap_EvenWhenOnlyTheFlatFieldIsSet() {
+    singleDomainMultitenancy(false);
+    when(tenantService.getRestrictedTenantDataByTenantId(3L))
+        .thenReturn(
+            new RestrictedTenantDTO()
+                .id(3L)
+                .name("Träger")
+                .content(new Content().impressum("").privacy("<p>nur Deutsch</p>")));
+
+    var resolved = resolver.resolveDpp(department(agency(null, null, null)));
+
+    // Every level below stores a language->HTML map; handing callers two shapes depending on which
+    // rung answered would push the multilingual pick back onto the client.
+    assertThat(resolved.content()).startsWith("{").contains("nur Deutsch");
+    assertThat(resolved.sourceLevel()).isEqualTo(LegalTextSourceLevel.TENANT);
+  }
+
+  @Test
+  void resolveDpp_Should_degradeToAGap_When_tenantServiceIsUnreachable() {
+    singleDomainMultitenancy(false);
+    when(tenantService.getRestrictedTenantDataByTenantId(3L))
+        .thenThrow(new IllegalStateException("tenant service down"));
+
+    var resolved = resolver.resolveDpp(department(agency(null, null, null)));
+
+    // A neighbouring service being down must not turn a help-seeker's request for a privacy policy
+    // into a 500 - the caller sees a gap it can react to.
+    assertThat(resolved.sourceLevel()).isEqualTo(LegalTextSourceLevel.NONE);
+    assertThat(resolved.isPresent()).isFalse();
+  }
+
+  @Test
+  void resolveDpp_Should_returnNone_When_nothingIsAuthoredAnywhere() {
+    singleDomainMultitenancy(false);
+    when(tenantService.getRestrictedTenantDataByTenantId(3L))
+        .thenReturn(new RestrictedTenantDTO().id(3L).name("Träger"));
+
+    assertThat(resolver.resolveDpp(department(agency(null, null, null))))
+        .isEqualTo(ResolvedLegalText.none());
+  }
+
+  // ---------------------------------------------------------------- imprint
+
+  @Test
+  void resolveImprint_Should_neverCarryAConsentSentence() {
+    var agency = agency(null, "{\"de\":\"Impressum\"}", "{\"de\":\"consent {{legal_links}}\"}");
+
+    var resolved = resolver.resolveImprint(department(agency));
+
+    // ADR-021 decision 7: the imprint is an information duty, never a consent gate. Carrying the
+    // policy's sentence here would invite a second, meaningless tick.
+    assertThat(resolved.content()).contains("Impressum");
+    assertThat(resolved.consentText()).isNull();
+  }
+
+  @Test
+  void resolve_Should_returnNone_When_thereIsNoDepartment() {
+    assertThat(resolver.resolveDpp(null)).isEqualTo(ResolvedLegalText.none());
+    assertThat(resolver.resolveImprint(null)).isEqualTo(ResolvedLegalText.none());
+  }
+}

--- a/src/test/java/de/caritas/cob/agencyservice/api/service/legal/PublicLegalTextRendererTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/service/legal/PublicLegalTextRendererTest.java
@@ -105,6 +105,83 @@ class PublicLegalTextRendererTest {
   }
 
   @Test
+  void render_Should_escapeMarkupInSubstitutedNames() {
+    when(topicService.getAllTopics())
+        .thenReturn(List.of(new TopicDTO().id(42L).name("Sucht<script>alert(1)</script>")));
+    var department = department();
+    department.setAgency(
+        Agency.builder()
+            .id(7L)
+            .name("<img src=x onerror=alert(1)>")
+            .consultingTypeId(1)
+            .build());
+
+    var rendered = renderer(true).render(resolved(), department);
+
+    // Substitution happens AFTER LegalContentSanitizer, so an unescaped name would land in HTML
+    // that the frontend renders with dangerouslySetInnerHTML - stored XSS reaching every
+    // help-seeker of that Beratungsstelle.
+    assertThat(rendered.content()).doesNotContain("<img").doesNotContain("<script>");
+    assertThat(rendered.content()).contains("&lt;img").contains("&lt;script&gt;");
+  }
+
+  @Test
+  void render_Should_produceValidJson_When_aNameContainsQuotes() throws Exception {
+    var department = department();
+    department.setAgency(
+        Agency.builder().id(7L).name("Caritas \"Mitte\"").consultingTypeId(1).build());
+
+    var rendered = renderer(false).render(resolved(), department);
+
+    // Substituting into the serialized JSON would break out of the string and hand every client an
+    // unparseable legal document. Round-tripping proves it stayed a map.
+    var parsed =
+        new com.fasterxml.jackson.databind.ObjectMapper()
+            .readValue(
+                rendered.content(),
+                new com.fasterxml.jackson.core.type.TypeReference<
+                    java.util.LinkedHashMap<String, String>>() {});
+    assertThat(parsed).containsKey("de");
+    assertThat(parsed.get("de")).contains("Caritas &quot;Mitte&quot;");
+  }
+
+  @Test
+  void render_Should_leaveTranslationMetadataUntouched() throws Exception {
+    var mapper = new com.fasterxml.jackson.databind.ObjectMapper();
+    var metaValue = "{\"mt\":true,\"src\":\"de\"}";
+    var stored =
+        mapper.writeValueAsString(
+            java.util.Map.of("de", "<p>{{Beratungsstelle}}</p>", "de__meta", metaValue));
+
+    var rendered =
+        renderer(false)
+            .render(
+                new ResolvedLegalText(stored, null, LegalTextSourceLevel.DEPARTMENT, 1L),
+                department());
+
+    var parsed =
+        mapper.readValue(
+            rendered.content(),
+            new com.fasterxml.jackson.core.type.TypeReference<
+                java.util.LinkedHashMap<String, String>>() {});
+    // __meta carries JSON, not prose; it must survive byte-identically.
+    assertThat(parsed.get("de__meta")).isEqualTo(metaValue);
+    assertThat(parsed.get("de")).contains("Caritas Freiburg");
+  }
+
+  @Test
+  void render_Should_serveUnsubstituted_When_theStoredContentIsNotAMap() {
+    var broken =
+        new ResolvedLegalText("not json at all", null, LegalTextSourceLevel.DEPARTMENT, 1L);
+
+    var rendered = renderer(false).render(broken, department());
+
+    // An already-damaged legal document must not additionally be handed over half-rewritten, and
+    // this is a public read path that must not fail.
+    assertThat(rendered.content()).isEqualTo("not json at all");
+  }
+
+  @Test
   void render_Should_passThrough_When_thereIsNoDepartment() {
     var resolved = resolved();
 

--- a/src/test/java/de/caritas/cob/agencyservice/api/service/legal/PublicLegalTextRendererTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/service/legal/PublicLegalTextRendererTest.java
@@ -1,0 +1,114 @@
+package de.caritas.cob.agencyservice.api.service.legal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import de.caritas.cob.agencyservice.api.repository.agency.Agency;
+import de.caritas.cob.agencyservice.api.repository.agencytopic.AgencyTopic;
+import de.caritas.cob.agencyservice.topicservice.generated.web.model.TopicDTO;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * ADR-021 decision 5: the server substitutes what it owns and stops there. This closes the gap
+ * CONTEXT-legal-documents records against the public {@code /legal} path, which returned raw,
+ * unrendered text so a placeholder could reach a help-seeker verbatim.
+ */
+@ExtendWith(MockitoExtension.class)
+class PublicLegalTextRendererTest {
+
+  @Mock private de.caritas.cob.agencyservice.api.service.TopicService topicService;
+
+  private PublicLegalTextRenderer renderer(boolean withTopicService) {
+    var instance = new PublicLegalTextRenderer();
+    if (withTopicService) {
+      ReflectionTestUtils.setField(instance, "topicService", topicService);
+    }
+    return instance;
+  }
+
+  private AgencyTopic department() {
+    return AgencyTopic.builder()
+        .id(4711L)
+        .topicId(42L)
+        .agency(Agency.builder().id(7L).name("Caritas Freiburg").consultingTypeId(1).build())
+        .build();
+  }
+
+  private ResolvedLegalText resolved() {
+    return new ResolvedLegalText(
+        "{\"de\":\"<p>DSE der {{Beratungsstelle}}, Fachbereich {{Thema}}.</p>\"}",
+        "{\"de\":\"Ich habe die {{legal_links}} der {{Beratungsstelle}} zum Thema {{Thema}}"
+            + " gelesen.\"}",
+        LegalTextSourceLevel.DEPARTMENT,
+        100L);
+  }
+
+  @Test
+  void render_Should_substituteTheServerOwnedTokens_andLeaveLegalLinksForTheClient() {
+    when(topicService.getAllTopics())
+        .thenReturn(List.of(new TopicDTO().id(42L).name("Suchtberatung")));
+
+    var rendered = renderer(true).render(resolved(), department());
+
+    assertThat(rendered.content()).contains("Caritas Freiburg").contains("Suchtberatung");
+    assertThat(rendered.content()).doesNotContain("{{Beratungsstelle}}").doesNotContain("{{Thema}}");
+    assertThat(rendered.consentText()).contains("Caritas Freiburg").contains("Suchtberatung");
+    // The link targets live in the frontend deployment configuration; the backend does not know
+    // them, so its token survives on purpose.
+    assertThat(rendered.consentText()).contains("{{legal_links}}");
+  }
+
+  @Test
+  void render_Should_keepTheLevelAndVersionId() {
+    when(topicService.getAllTopics()).thenReturn(List.of());
+
+    var rendered = renderer(true).render(resolved(), department());
+
+    // Substitution must not lose the two facts a consumer needs: which level governs, and which
+    // version the wording is (ORISO-UserService session.consented_legal_version_id).
+    assertThat(rendered.sourceLevel()).isEqualTo(LegalTextSourceLevel.DEPARTMENT);
+    assertThat(rendered.versionId()).isEqualTo(100L);
+  }
+
+  @Test
+  void render_Should_leaveTheTopicToken_When_theTopicNameCannotBeResolved() {
+    when(topicService.getAllTopics()).thenThrow(new IllegalStateException("no bearer token"));
+
+    var rendered = renderer(true).render(resolved(), department());
+
+    // The Fachbereich name lives in ORISO-TopicService behind the caller's bearer token, which the
+    // public endpoint does not have. Leaving the token lets the client — which knows the topic it
+    // navigated to — finish the job. Substituting an empty string would silently corrupt a legal
+    // sentence into "zum Thema  gelesen".
+    assertThat(rendered.content()).contains("Caritas Freiburg").contains("{{Thema}}");
+  }
+
+  @Test
+  void render_Should_workWithoutTheOptionalTopicService() {
+    var rendered = renderer(false).render(resolved(), department());
+
+    // The topics feature is toggleable; the public legal path must not depend on it.
+    assertThat(rendered.content()).contains("Caritas Freiburg").contains("{{Thema}}");
+  }
+
+  @Test
+  void render_Should_tolerateNothingToSubstitute() {
+    var rendered = renderer(false).render(ResolvedLegalText.none(), department());
+
+    assertThat(rendered.content()).isNull();
+    assertThat(rendered.sourceLevel()).isEqualTo(LegalTextSourceLevel.NONE);
+  }
+
+  @Test
+  void render_Should_passThrough_When_thereIsNoDepartment() {
+    var resolved = resolved();
+
+    assertThat(renderer(false).render(resolved, null)).isSameAs(resolved);
+    assertThat(renderer(false).render(null, department())).isNull();
+  }
+}

--- a/src/test/resources/database/AgencyDatabase.sql
+++ b/src/test/resources/database/AgencyDatabase.sql
@@ -1,5 +1,6 @@
 DROP TABLE IF EXISTS AGENCY_POSTCODE_RANGE;
 DROP TABLE IF EXISTS AGENCY_TOPIC;
+DROP TABLE IF EXISTS LEGAL_TEXT_VERSION;
 DROP TABLE IF EXISTS LEGAL_TEXT;
 DROP TABLE IF EXISTS AGENCY;
 DROP TABLE IF EXISTS AGENCY_ADMIN_CONTROL;
@@ -7,6 +8,7 @@ DROP TABLE IF EXISTS DIOCESE;
 
 DROP SEQUENCE IF EXISTS SEQUENCE_AGENCY_POSTCODE_RANGE;
 DROP SEQUENCE IF EXISTS SEQUENCE_AGENCY_TOPIC;
+DROP SEQUENCE IF EXISTS SEQUENCE_LEGAL_TEXT_VERSION;
 DROP SEQUENCE IF EXISTS SEQUENCE_LEGAL_TEXT;
 DROP SEQUENCE IF EXISTS SEQUENCE_AGENCY;
 DROP SEQUENCE IF EXISTS SEQUENCE_AGENCY_ADMIN_CONTROL;
@@ -50,6 +52,8 @@ create table AGENCY
     SETTINGS longtext null default null,
     CONTENT_DPP longtext null default null,
     CONTENT_IMPRINT longtext null default null,
+    -- ADR-021 decision 4 (changeset 0032): the consent sentence is a field of the DPP.
+    CONSENT_TEXT longtext null default null,
     primary key (ID)
 );
 CREATE SEQUENCE SEQUENCE_AGENCY
@@ -81,12 +85,33 @@ create table LEGAL_TEXT
     KIND               varchar(20) not null,
     LABEL              varchar(255) not null,
     CONTENT            longtext    null,
+    CONSENT_TEXT       longtext    null,
     PUBLICATION_STATUS varchar(20) not null default 'DRAFT',
     CREATE_DATE        timestamp,
     UPDATE_DATE        timestamp,
     primary key (ID)
 );
 CREATE SEQUENCE SEQUENCE_LEGAL_TEXT
+    START WITH 100000
+    INCREMENT BY 1;
+
+-- ADR-021 decision 3 (Liquibase changeset 0031_legal_text_version): the immutable publication
+-- history, generic over kind and level. Identity is the surrogate ID, never PUBLISHED_AT.
+create table LEGAL_TEXT_VERSION
+(
+    ID            bigint      not null,
+    TENANT_ID     bigint      null,
+    KIND          varchar(20) not null,
+    OWNER_LEVEL   varchar(20) not null,
+    OWNER_ID      bigint      not null,
+    CONTENT       longtext    null,
+    CONSENT_TEXT  longtext    null,
+    PUBLISHED_AT  timestamp   not null,
+    PUBLISHED_BY  varchar(255) null,
+    SUPERSEDED_AT timestamp   null,
+    primary key (ID)
+);
+CREATE SEQUENCE SEQUENCE_LEGAL_TEXT_VERSION
     START WITH 100000
     INCREMENT BY 1;
 
@@ -106,6 +131,7 @@ create table AGENCY_TOPIC
     OPENING_HOURS   varchar(1000) null,
     PHONE_EXTENSION varchar(50)   null,
     FLOOR_LOCATION  varchar(100)  null,
+    CONSENT_TEXT    longtext      null,
     primary key (ID),
     foreign key (AGENCY_ID) references AGENCY (ID),
     foreign key (DPP_ID) references LEGAL_TEXT (ID),


### PR DESCRIPTION
**Affected repos:** `ORISO-AgencyService` (this PR) · `ORISO-Admin` · `ORISO-Frontend` · `ORISO-UserService` (consumers, separate PRs)

Implements the AgencyService half of the `ADR-021` foundation: epic #250, sub-issues #251, #252, #253, #254. Also closes the publisher/date gap in #212 and the agency-level gap in #222.

## Why

`ADR-021` establishes four legal-text levels (platform operator → Träger → Beratungsstelle → Fachbereich), a generic version history, and the consent sentence as a field of the data protection policy. None of it existed:

- Publishing a policy or imprint **overwrote the previous wording without trace**, so no Träger could prove which policy was in force on a given date. Only the AVV had a history.
- The consent sentence a help-seeker ticks was **static frontend i18n** assembled from three fragments; no Träger could change it.
- Inheritance was **asymmetric**: department → agency resolved server-side, → Träger resolved twice on clients (Admin `mergeTranslatedContent`, Frontend `pickConsentPrivacyContent`).
- The public `/legal` endpoint returned **raw, unrendered text**, so a placeholder could reach a help-seeker verbatim.

## What

Four commits, one per slice.

### 1. Generic legal-text version history (#251, `ADR-021` decision 3)

Changeset **0031** adds `legal_text_version`, an append-only snapshot table generic over `(kind, owner_level, owner_id)` — covering the department level (`agency_topic`), the agency level (`agency`) and the ADR-014 shared objects (`legal_text`). Blueprint is ORISO-TenantService `tenant_dpa_version` (changeset 0018); this is copying, not inventing.

**Identity is a surrogate id, never the publication timestamp.** Keying versions by their timestamp is what forced the AVV work to truncate to seconds against MariaDB `DATETIME(0)` and made equality matches fail silently. Nothing here depends on timestamp equality.

`published_by` / `published_at` / `superseded_at` answer #212: who published, when, and until when it applied. A draft-save records nothing — that is the distinction `update_date` could never make. Pre-existing rows get **no backfilled history**, because a date guessed from `update_date` may well be a draft timestamp and is worse than an honest gap.

**The agency level deliberately has no publication status** ("what is stored, applies"), so it has no publish button to hang a snapshot on. Decision taken and documented in code: **a save is a publish at that level** — `AgencyAdminService.updateAgency` records after saving. That makes deduplication load-bearing rather than cosmetic: an update about opening hours resends the untouched legal texts, and without skipping an unchanged wording every such edit would forge a version of a document nobody touched.

### 2. Consent text as a field of the DPP + mandatory-token validator (#252, decisions 2/4/6)

Changeset **0032** adds `consent_text` to `agency_topic`, `agency`, `legal_text` and `legal_text_version`. Not a `legal_text` kind of its own: it shares the policy's publication status and version history, so "which consent belonged to which policy" is answered by "the same version" instead of by correlating timestamps.

Publishing a consent text without `{{legal_links}}` is **rejected with a 400** naming the language and the token — not a 500. Every authored translation is checked; a draft-save is not; authoring no sentence at all stays allowed (the platform default then applies). Validation runs before anything is written, so a rejected publish leaves the stored document untouched rather than half-updated.

The **cookie/authentication notice is not stored** — it is a fixed addendum the client renders, so no Träger can edit away the platform's own disclosure.

### 3. Server-side inheritance end to end (#253, decision 9)

`LegalTextInheritanceResolver` walks the whole chain in one place. Which of the two upper rungs answers is the existing `legalContentChangesBySingleTenantAdminsAllowed` decision — deliberately the same rule `CentralDataProtectionTemplateService` already applies, because two different answers to "whose text governs" is the bug class this ADR closes. No new cross-service client: the existing `TenantService` client is reused.

Every resolution reports the level it came from. If TenantService is unreachable the resolution degrades to what AgencyService knows locally and logs it — a help-seeker's request for a privacy policy must not become a 500 because a neighbouring service is down.

**Fixes the measured defect:** `AgencyService.hasPublishedDpp` computed the flag from the department level alone while `DepartmentLegalService` already fell back to the agency-wide text, so a department could report `hasPublishedDpp: false` while `/legal` returned content and the client hid a document that existed. Flag and endpoint now go through the same resolver and cannot disagree.

### 4. Public delivery with server-side substitution (#254, decision 5)

The **existing endpoint is extended, not replaced**. The additions are all new optional fields, so no client breaks, and the old raw-text behaviour was a defect rather than a contract worth preserving. A parallel endpoint would have left the broken one live and reintroduced the "which one do I call" ambiguity this ADR exists to remove.

`{{Beratungsstelle}}` and `{{Thema}}` are substituted server-side; `{{legal_links}}` is left standing for the client, which owns the link targets. Substitution is a literal `String.replace`, never Freemarker.

**`versionId` on the public response unblocks ORISO-UserService #1033.** That PR records `session.consented_legal_version_id` (`ADR-022` decision 2) but had nothing to point at: the public legal response carried no version identifier, so "is this room cleared for the version currently in force" was unanswerable. It is the surrogate `legal_text_version.id`, never a timestamp; null for the Träger and platform levels, whose history lives in ORISO-TenantService.

## FINDING: `{{...}}` does not survive the OWASP sanitiser

Asserted, then fixed. `org.owasp.html` rewrites `{{` to `{<!-- -->{` in text nodes — a deliberate defence against sanitised HTML being re-read as a mustache template by a client-side engine. So a consent sentence typed **correctly** by an admin came back broken: it would have failed the publication validator on valid input and rendered as visible braces to the help-seeker.

`LegalTextTokens.restoreKnownTokens` repairs this **for the three product tokens only** (`legal_links`, `Beratungsstelle`, `Thema`) and only in their exact form. A blanket undo would hand every Träger the ability to smuggle an arbitrary mustache expression downstream — precisely what the sanitiser's comment injection exists to stop. `LegalTextTokensTest` pins the sanitiser's current behaviour, so the day the library changes it the test says so instead of the repair quietly becoming dead code.

## Endpoints

| Method | Path | Purpose |
|---|---|---|
| GET | `/agencyadmin/agencies/{agencyId}/topics/{topicId}/legal-versions?kind=` | department publication history, newest first |
| GET | `/agencyadmin/agencies/{agencyId}/legal-versions?kind=` | agency-wide publication history |
| GET | `/agencyadmin/legal-versions/{versionId}` | one archived version, verbatim |
| GET | `/agencies/{agencyId}/topics/{topicId}/legal` | **extended**: `consentText`, `sourceLevel`, `versionId`, substituted content |

A version id is not a capability: the single-version endpoint re-derives the owner from the stored row and applies the same IDOR and cross-tenant guards as the publish endpoints (extracted into `LegalAdminAccessGuard` so the two cannot drift apart).

## Known gaps against the ADR as written

Stated rather than deviated from silently:

1. **`{{Thema}}` is not always substituted server-side.** The Fachbereich name lives in ORISO-TopicService, whose client sends the caller's bearer token — which the public, unauthenticated legal endpoint does not have. When the name cannot be resolved the token is left intact for the client (which knows the topic it navigated to) rather than replaced with an empty string, which would silently corrupt a legal sentence into "zum Thema  gelesen". Substituting it unconditionally would need the topic name reachable without a caller token.
2. **The Träger/platform level has no version id.** `ADR-021` decision 3 asks for a history "on all levels"; levels 1–2 are stored in ORISO-TenantService and their history has to be built there. `sourceLevel` tells a consumer when that is the case.
3. **`legal_text.kind` still has no CHECK constraint** (noted in the ADR's measured state). Out of scope here; the enum guards the write path.

## How to test

Base `pre-dev`. JDK 21. `./mvnw verify` — 649 unit tests + 227 integration tests green, checkstyle clean (`google_checks_light.xml`, warnings fail the build). New test files: `LegalTextVersionRepositoryTest`, `LegalTextVersionServiceTest`, `LegalTextVersionAdminServiceTest`, `AgencyAdminControllerLegalVersionsTest`, `LegalTextTokensTest`, `ConsentTextServiceTest`, `LegalTextInheritanceResolverTest`, `PublicLegalTextRendererTest`.

### Reviewer test plan

- [ ] `./mvnw verify` is green; checkstyle reports 0 violations
- [ ] Publish a Fachbereich DPP twice with different wording → `GET .../legal-versions?kind=DPP` lists two entries, newest first, the older one carrying `supersededAt`
- [ ] Fetch the superseded version by id → the **original wording comes back verbatim**
- [ ] Draft-save a Fachbereich DPP → **no** new version appears
- [ ] Save an agency with unchanged legal texts (e.g. change only the opening hours) → **no** new agency-level version appears
- [ ] Save an agency with changed `content.privacy` → exactly one new agency-level version appears
- [ ] Publish a DPP with `consentText` `{"de": "Ich stimme zu."}` → **400**, message names `de` and `{{legal_links}}`; the previously stored policy is unchanged
- [ ] Publish the same with `{"de": "Ich habe die {{legal_links}} gelesen."}` → stored, and reading it back shows `{{legal_links}}` intact (no `<!-- -->` inside the braces)
- [ ] Publish a consent text in two languages where only one carries the token → **400** naming the other language
- [ ] `GET /agencies/{id}/topics/{tid}/legal` for a department with **no** own DPP but an agency-wide one → content returned, `sourceLevel: AGENCY`
- [ ] Same department in the agency search → `hasPublishedDpp: true` (previously `false` while `/legal` returned content)
- [ ] `GET .../legal` for a department whose consent text contains all three tokens → `{{Beratungsstelle}}` replaced by the agency name, `{{legal_links}}` still present
- [ ] `GET .../legal` returns a non-null `versionId` for a department-level or agency-level text, and `null` for `sourceLevel: TENANT` / `PLATFORM`
- [ ] Try to read another Träger's version by id → rejected, not returned
- [ ] Liquibase 0031 + 0032 apply and roll back cleanly against MariaDB

## References

`ADR-021` · `ADR-022` · `CONTEXT-legal-documents.md` · epic #250 · #251 #252 #253 #254 · #212 · #222 · ORISO-UserService #1033

🤖 Generated with [Claude Code](https://claude.com/claude-code)
