### PR TITLE
Report each department's own-legal-text state on the admin agency read (ORISO-Admin#583)

### DIFF
--- a/api/agencyadminservice.yaml
+++ b/api/agencyadminservice.yaml
@@ -1190,6 +1190,15 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/TopicDTO'
+        departments:
+          type: array
+          description: >
+            The agency's departments (one per assigned topic) with the publication state of
+            their own legal texts. Lets the admin UI mark, in the Fachbereich switcher, which
+            departments have left the inherited text and will therefore not receive a change
+            to the agency-wide one (ORISO-Admin#583). Optional - older clients ignore it.
+          items:
+            $ref: '#/components/schemas/AgencyAdminDepartmentDTO'
         demographics:
           $ref: '#/components/schemas/DemographicsDTO'
         createDate:
@@ -1221,6 +1230,27 @@ components:
         settings:
           $ref: '#/components/schemas/Settings'
           description: Agency settings including platform-level agencyAdminControls
+
+    AgencyAdminDepartmentDTO:
+      type: object
+      description: >
+        One department (Fachbereich = agency x topic) and whether it carries published legal
+        texts of its own. Deliberately smaller than the public AgencyDepartmentDTO: the admin
+        read answers "who has left the inherited text", not the contact-detail overrides the
+        registration search needs.
+      properties:
+        topicId:
+          type: integer
+          format: int64
+          example: 7
+        hasPublishedDpp:
+          type: boolean
+          description: true if the department has a published data privacy policy of its own
+          example: true
+        hasPublishedImprint:
+          type: boolean
+          description: true if the department has a published imprint of its own
+          example: false
 
     AgencyLegalContentDTO:
       type: object

--- a/src/main/java/de/caritas/cob/agencyservice/api/admin/service/agency/AgencyAdminFullResponseDTOBuilder.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/admin/service/agency/AgencyAdminFullResponseDTOBuilder.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.ObjectReader;
 import com.google.common.base.Splitter;
 import com.google.common.collect.Lists;
 import de.caritas.cob.agencyservice.api.admin.hallink.AgencyLinksBuilder;
+import de.caritas.cob.agencyservice.api.model.AgencyAdminDepartmentDTO;
 import de.caritas.cob.agencyservice.api.model.AgencyAdminFullResponseDTO;
 import de.caritas.cob.agencyservice.api.model.AgencyAdminResponseDTO;
 import de.caritas.cob.agencyservice.api.model.AgencyLegalContentDTO;
@@ -15,6 +16,7 @@ import de.caritas.cob.agencyservice.api.model.DemographicsDTO;
 import de.caritas.cob.agencyservice.api.model.TopicDTO;
 import de.caritas.cob.agencyservice.api.repository.agency.Agency;
 import de.caritas.cob.agencyservice.api.repository.agencytopic.AgencyTopic;
+import de.caritas.cob.agencyservice.api.service.legal.DepartmentLegalPublicationState;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -70,6 +72,7 @@ public class AgencyAdminFullResponseDTOBuilder {
         .external((this.agency.isExternal()))
         .offline(this.agency.isOffline())
         .topics(getTopics())
+        .departments(getDepartments())
         .counsellingRelations(splitToList(agency.getCounsellingRelations()))
         .createDate(String.valueOf(this.agency.getCreateDate()))
         .updateDate(String.valueOf(this.agency.getUpdateDate()))
@@ -121,6 +124,30 @@ public class AgencyAdminFullResponseDTOBuilder {
   private DemographicsDTO getDemographics(Agency agency) {
     return agency.hasAnyDemographicsAttributes() ? new DemographicsConverter().convertToDTO(agency)
         : null;
+  }
+
+  /**
+   * The departments with the publication state of their own legal texts (ORISO-Admin#583).
+   *
+   * <p>An admin editing the agency-wide text needs to see who will <em>not</em> receive the
+   * change — a Fachbereich that has published its own text no longer inherits. The resolution
+   * is shared with the public agency read via {@link DepartmentLegalPublicationState}, so the
+   * switcher can never claim something different from what help-seekers are shown.
+   *
+   * <p>Built from the already-loaded {@code agencyTopics} association ({@code topics} above uses
+   * the same one), so this adds no query per agency or topic.
+   */
+  private List<AgencyAdminDepartmentDTO> getDepartments() {
+    var agencyTopics = agency.getAgencyTopics();
+    if (agencyTopics == null) {
+      return Lists.newArrayList();
+    }
+    return agencyTopics.stream()
+        .map(agencyTopic -> new AgencyAdminDepartmentDTO()
+            .topicId(agencyTopic.getTopicId())
+            .hasPublishedDpp(DepartmentLegalPublicationState.hasPublishedDpp(agencyTopic))
+            .hasPublishedImprint(DepartmentLegalPublicationState.hasPublishedImprint(agencyTopic)))
+        .toList();
   }
 
   private List<TopicDTO> getTopics() {

--- a/src/main/java/de/caritas/cob/agencyservice/api/service/AgencyService.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/service/AgencyService.java
@@ -27,6 +27,7 @@ import de.caritas.cob.agencyservice.api.repository.legaltext.LegalText;
 import de.caritas.cob.agencyservice.api.tenant.TenantContext;
 import de.caritas.cob.agencyservice.consultingtypeservice.generated.web.model.ExtendedConsultingTypeResponseDTO;
 import de.caritas.cob.agencyservice.tenantservice.generated.web.model.RestrictedTenantDTO;
+import de.caritas.cob.agencyservice.api.service.legal.DepartmentLegalPublicationState;
 import de.caritas.cob.agencyservice.api.service.matrix.MatrixProvisioningService;
 import de.caritas.cob.agencyservice.api.service.matrix.AgencyMatrixPasswordCipher;
 import java.time.LocalDateTime;
@@ -530,13 +531,15 @@ public class AgencyService {
    * <p>ADR-014: like {@link DepartmentLegalService}, a referenced shared legal-text object fully
    * replaces the inline column — the flags must follow the same resolution order, otherwise the
    * registration search would report stale inline state after a write-through publish/draft-save.
+   * That order lives in {@link DepartmentLegalPublicationState}, shared with the admin read so the
+   * Fachbereich switcher (ORISO-Admin#583) can never disagree with what help-seekers are shown.
    */
   private AgencyDepartmentDTO convertToAgencyDepartmentDTO(AgencyTopic agencyTopic,
       Agency agency) {
     return new AgencyDepartmentDTO()
         .topicId(agencyTopic.getTopicId())
-        .hasPublishedDpp(hasPublishedDpp(agencyTopic))
-        .hasPublishedImprint(hasPublishedImprint(agencyTopic))
+        .hasPublishedDpp(DepartmentLegalPublicationState.hasPublishedDpp(agencyTopic))
+        .hasPublishedImprint(DepartmentLegalPublicationState.hasPublishedImprint(agencyTopic))
         .openingHours(resolve(agencyTopic.getOpeningHours(), agency.getOpeningHours()))
         .phoneExtension(agencyTopic.getPhoneExtension())
         .floorLocation(resolve(agencyTopic.getFloorLocation(), agency.getFloorBuilding()));
@@ -549,28 +552,6 @@ public class AgencyService {
    */
   private String resolve(String departmentValue, String agencyValue) {
     return departmentValue != null ? departmentValue : agencyValue;
-  }
-
-  private boolean hasPublishedDpp(AgencyTopic agencyTopic) {
-    LegalText referenced = agencyTopic.getDpp();
-    if (referenced != null) {
-      return hasPublishedContent(referenced.getContent(), referenced.getPublicationStatus());
-    }
-    return hasPublishedContent(agencyTopic.getContentDpp(), agencyTopic.getPublicationStatus());
-  }
-
-  private boolean hasPublishedImprint(AgencyTopic agencyTopic) {
-    LegalText referenced = agencyTopic.getImprint();
-    if (referenced != null) {
-      return hasPublishedContent(referenced.getContent(), referenced.getPublicationStatus());
-    }
-    return hasPublishedContent(
-        agencyTopic.getContentImprint(), agencyTopic.getPublicationStatusImprint());
-  }
-
-  private boolean hasPublishedContent(String content, PublicationStatus status) {
-    var hasContent = content != null && !content.isBlank();
-    return PublicationStatus.PUBLISHED == status && hasContent;
   }
 
   private DemographicsDTO getDemographics(Agency agency) {

--- a/src/main/java/de/caritas/cob/agencyservice/api/service/legal/DepartmentLegalPublicationState.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/service/legal/DepartmentLegalPublicationState.java
@@ -1,0 +1,54 @@
+package de.caritas.cob.agencyservice.api.service.legal;
+
+import de.caritas.cob.agencyservice.api.repository.agencytopic.AgencyTopic;
+import de.caritas.cob.agencyservice.api.repository.agencytopic.PublicationStatus;
+import de.caritas.cob.agencyservice.api.repository.legaltext.LegalText;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+/**
+ * Whether a department (Fachbereich = agency × topic) has left the inherited legal text, i.e.
+ * carries a published one of its own.
+ *
+ * <p>Two reads answer this question: the public agency read (registration search) and the admin
+ * read (the Fachbereich switcher in the legal editors, ORISO-Admin#583). They must agree — an
+ * admin publishing a correction to the agency-wide text needs to know who will <em>not</em>
+ * receive it, and a switcher that disagrees with what help-seekers actually see is worse than no
+ * marker at all. The resolution therefore lives here once instead of in each caller.
+ *
+ * <p>ADR-014 resolution order: a referenced shared {@link LegalText} fully replaces the inline
+ * column. Reading the inline column first would report stale state after a write-through
+ * publish or draft-save.
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class DepartmentLegalPublicationState {
+
+  /** True when the department has a published data-protection policy of its own. */
+  public static boolean hasPublishedDpp(AgencyTopic agencyTopic) {
+    LegalText referenced = agencyTopic.getDpp();
+    if (referenced != null) {
+      return hasPublishedContent(referenced.getContent(), referenced.getPublicationStatus());
+    }
+    return hasPublishedContent(agencyTopic.getContentDpp(), agencyTopic.getPublicationStatus());
+  }
+
+  /** True when the department has a published imprint of its own. */
+  public static boolean hasPublishedImprint(AgencyTopic agencyTopic) {
+    LegalText referenced = agencyTopic.getImprint();
+    if (referenced != null) {
+      return hasPublishedContent(referenced.getContent(), referenced.getPublicationStatus());
+    }
+    return hasPublishedContent(
+        agencyTopic.getContentImprint(), agencyTopic.getPublicationStatusImprint());
+  }
+
+  /**
+   * A document counts as published only when it is both marked PUBLISHED and actually has
+   * content: a PUBLISHED row with an empty body would mark a department as having left the
+   * inherited text while showing help-seekers nothing.
+   */
+  private static boolean hasPublishedContent(String content, PublicationStatus status) {
+    var hasContent = content != null && !content.isBlank();
+    return PublicationStatus.PUBLISHED == status && hasContent;
+  }
+}

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/service/agency/AgencyAdminFullResponseDTOBuilderTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/service/agency/AgencyAdminFullResponseDTOBuilderTest.java
@@ -1,10 +1,12 @@
 package de.caritas.cob.agencyservice.api.admin.service.agency;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import de.caritas.cob.agencyservice.api.model.AgencyAdminDepartmentDTO;
 import de.caritas.cob.agencyservice.api.model.AgencyAdminFullResponseDTO;
 import de.caritas.cob.agencyservice.api.model.AgencyAdminResponseDTO;
 import de.caritas.cob.agencyservice.api.model.AgencyDTO;
@@ -14,7 +16,10 @@ import de.caritas.cob.agencyservice.api.model.HalLink.MethodEnum;
 import de.caritas.cob.agencyservice.api.repository.agency.Agency;
 import de.caritas.cob.agencyservice.api.repository.agency.DataProtectionResponsibleEntity;
 import de.caritas.cob.agencyservice.api.repository.agency.Gender;
+import de.caritas.cob.agencyservice.api.repository.agencytopic.AgencyTopic;
+import de.caritas.cob.agencyservice.api.repository.agencytopic.PublicationStatus;
 import de.caritas.cob.agencyservice.api.util.JsonConverter;
+import java.util.List;
 import org.jeasy.random.EasyRandom;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -44,6 +49,52 @@ class AgencyAdminFullResponseDTOBuilderTest {
     var result = agencyAdminFullResponseDTOBuilder.fromAgency();
 
     assertBaseDTOAttributesAreMapped(result);
+  }
+
+  /**
+   * ORISO-Admin#583: the Fachbereich switcher marks who has left the inherited text. The admin
+   * read is the one the admin page uses, so the flags have to be on THIS response — reaching
+   * across to the public agency read just to render a marker is the wrong shape.
+   */
+  @Test
+  void fromAgency_Should_Report_WhichDepartmentsCarryTheirOwnPublishedTexts() {
+    var withOwnDpp = AgencyTopic.builder()
+        .topicId(7L)
+        .contentDpp("<p>eigene Richtlinie</p>")
+        .publicationStatus(PublicationStatus.PUBLISHED)
+        .build();
+    var stillInheriting = AgencyTopic.builder()
+        .topicId(8L)
+        .contentDpp("<p>noch Entwurf</p>")
+        .publicationStatus(PublicationStatus.DRAFT)
+        .build();
+    var withOwnImprint = AgencyTopic.builder()
+        .topicId(9L)
+        .contentImprint("<p>eigenes Impressum</p>")
+        .publicationStatusImprint(PublicationStatus.PUBLISHED)
+        .build();
+    agency.setAgencyTopics(List.of(withOwnDpp, stillInheriting, withOwnImprint));
+
+    var departments = new AgencyAdminFullResponseDTOBuilder(agency).fromAgency()
+        .getEmbedded().getDepartments();
+
+    assertThat(departments).hasSize(3);
+    assertThat(departments).extracting(
+            AgencyAdminDepartmentDTO::getTopicId,
+            AgencyAdminDepartmentDTO::getHasPublishedDpp,
+            AgencyAdminDepartmentDTO::getHasPublishedImprint)
+        .containsExactly(
+            tuple(7L, true, false),
+            tuple(8L, false, false),
+            tuple(9L, false, true));
+  }
+
+  @Test
+  void fromAgency_Should_Return_EmptyDepartments_When_TheAgencyHasNoTopics() {
+    agency.setAgencyTopics(null);
+
+    assertThat(new AgencyAdminFullResponseDTOBuilder(agency).fromAgency()
+        .getEmbedded().getDepartments()).isEmpty();
   }
 
   private void assertBaseDTOAttributesAreMapped(AgencyAdminFullResponseDTO result) {

--- a/src/test/java/de/caritas/cob/agencyservice/api/service/legal/DepartmentLegalPublicationStateTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/service/legal/DepartmentLegalPublicationStateTest.java
@@ -1,0 +1,93 @@
+package de.caritas.cob.agencyservice.api.service.legal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import de.caritas.cob.agencyservice.api.repository.agencytopic.AgencyTopic;
+import de.caritas.cob.agencyservice.api.repository.agencytopic.PublicationStatus;
+import de.caritas.cob.agencyservice.api.repository.legaltext.LegalText;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The single answer to "has this Fachbereich left the inherited text?", used by both the public
+ * agency read and the admin read (ORISO-Admin#583). The two must never disagree.
+ */
+class DepartmentLegalPublicationStateTest {
+
+  private AgencyTopic inline(String dpp, PublicationStatus dppStatus) {
+    var topic = new AgencyTopic();
+    topic.setContentDpp(dpp);
+    topic.setPublicationStatus(dppStatus);
+    return topic;
+  }
+
+  @Test
+  void hasPublishedDpp_isTrue_forPublishedInlineContent() {
+    assertThat(DepartmentLegalPublicationState.hasPublishedDpp(
+        inline("<p>eigene Richtlinie</p>", PublicationStatus.PUBLISHED))).isTrue();
+  }
+
+  @Test
+  void hasPublishedDpp_isFalse_whileTheOwnTextIsStillADraft() {
+    assertThat(DepartmentLegalPublicationState.hasPublishedDpp(
+        inline("<p>eigene Richtlinie</p>", PublicationStatus.DRAFT))).isFalse();
+  }
+
+  @Test
+  void hasPublishedDpp_isFalse_forAPublishedButEmptyDocument() {
+    // Marking a department as "has its own text" while help-seekers are shown nothing
+    // would send an admin looking for a document that does not exist.
+    assertThat(DepartmentLegalPublicationState.hasPublishedDpp(
+        inline("   ", PublicationStatus.PUBLISHED))).isFalse();
+  }
+
+  @Test
+  void hasPublishedDpp_isFalse_whenNothingIsStoredAtAll() {
+    assertThat(DepartmentLegalPublicationState.hasPublishedDpp(inline(null, null))).isFalse();
+  }
+
+  /**
+   * ADR-014: a referenced shared legal text fully REPLACES the inline column. Reading the inline
+   * column first would report stale state after a write-through publish or draft-save.
+   */
+  @Test
+  void hasPublishedDpp_prefersTheReferencedTextOverAStaleInlineColumn() {
+    var topic = inline("<p>alt, noch als veröffentlicht markiert</p>", PublicationStatus.PUBLISHED);
+    var referenced = new LegalText();
+    referenced.setContent("<p>neu</p>");
+    referenced.setPublicationStatus(PublicationStatus.DRAFT);
+    topic.setDpp(referenced);
+
+    assertThat(DepartmentLegalPublicationState.hasPublishedDpp(topic)).isFalse();
+  }
+
+  @Test
+  void hasPublishedDpp_followsAPublishedReferencedTextEvenWithAnEmptyInlineColumn() {
+    var topic = inline(null, null);
+    var referenced = new LegalText();
+    referenced.setContent("<p>geteilte Richtlinie</p>");
+    referenced.setPublicationStatus(PublicationStatus.PUBLISHED);
+    topic.setDpp(referenced);
+
+    assertThat(DepartmentLegalPublicationState.hasPublishedDpp(topic)).isTrue();
+  }
+
+  @Test
+  void hasPublishedImprint_readsTheImprintColumns_notTheDppOnes() {
+    var topic = new AgencyTopic();
+    topic.setContentDpp("<p>Richtlinie</p>");
+    topic.setPublicationStatus(PublicationStatus.PUBLISHED);
+    topic.setContentImprint(null);
+    topic.setPublicationStatusImprint(null);
+
+    assertThat(DepartmentLegalPublicationState.hasPublishedImprint(topic)).isFalse();
+  }
+
+  @Test
+  void hasPublishedImprint_isTrue_forItsOwnPublishedContent() {
+    var topic = new AgencyTopic();
+    topic.setContentImprint("<p>eigenes Impressum</p>");
+    topic.setPublicationStatusImprint(PublicationStatus.PUBLISHED);
+
+    assertThat(DepartmentLegalPublicationState.hasPublishedImprint(topic)).isTrue();
+  }
+}


### PR DESCRIPTION
## Problem

The Fachbereich switcher in the admin legal editors cannot mark which departments have already left the inherited text — the one thing that matters when a Beratungsstelle publishes a correction to the agency-wide text. The signal exists (`departments[].hasPublishedDpp` / `hasPublishedImprint`), but only on the **public** agency read. The admin page uses `GET /agencyadmin/agencies/{id}`, whose `AgencyAdminResponseDTO` has no department list, and reaching across to the public endpoint just to render a marker is the wrong shape.

## What changed

- New `AgencyAdminDepartmentDTO` (`topicId`, `hasPublishedDpp`, `hasPublishedImprint`) on `AgencyAdminResponseDTO`, populated in `AgencyAdminFullResponseDTOBuilder` from the already-loaded `agencyTopics` association — no extra query per agency or topic. Optional field; older clients ignore it.
- The ADR-014 resolution order (a referenced shared `LegalText` fully replaces the inline column) moves out of `AgencyService`'s private helpers into `DepartmentLegalPublicationState`, now shared by both reads. Two copies would drift, and a switcher that disagrees with what help-seekers actually see is worse than no marker at all.
- Deliberately a **smaller** DTO than the public `AgencyDepartmentDTO`, which has grown contact-detail overrides (openingHours, phoneExtension, floorLocation). The admin read answers "who has left the inherited text"; it has no business carrying the registration search's payload.

## Verification

- `mvn test` — 612 tests, green
- New `DepartmentLegalPublicationStateTest` (8 cases) pins the resolution order, including the two traps: a PUBLISHED-but-empty document is not published, and a referenced draft overrides a stale inline PUBLISHED column
- The department mapping was mutation-checked: removing `.departments(getDepartments())` fails the builder test

## Note on conflicts

`feat/legal-text-versioning-250` (#256) also touches `AgencyAdminFullResponseDTOBuilder`, `AgencyService` and `agencyadminservice.yaml`. This change is small and additive; whichever lands second takes the rebase.

Refs OpenResilienceInitiative/ORISO-Admin#583