### PR TITLE
ci: show test coverage % in the run summary

### DIFF
--- a/.github/actions/maven-build/action.yml
+++ b/.github/actions/maven-build/action.yml
@@ -54,6 +54,50 @@ runs:
           sys.exit(1)
       PY
 
+  # jacoco:report is bound to the `test` phase behind surefire, so a green suite has
+  # already written the report and this step has nothing to do. Only a red suite halts
+  # the build before the goal, and only then is it invoked directly against the
+  # execution data the prepare-agent JVM left behind.
+  #
+  # That direct invocation is best-effort: run from the command line the goal resolves
+  # the plugin's reporting dependencies, which the lifecycle-bound execution never needs
+  # and which do not reliably resolve from a restored runner cache. Coverage is a
+  # diagnostic, so failing to produce it must never fail the build.
+  - name: Generate coverage report
+    if: ${{ always() }}
+    shell: bash
+    run: |
+      if [ -f target/site/jacoco/jacoco.csv ]; then
+        echo "Coverage report already written during the test phase."
+      elif [ -f target/jacoco.exec ]; then
+        ./mvnw -B jacoco:report \
+          || echo "Standalone jacoco:report failed; coverage is unavailable for this run."
+      else
+        echo "No target/jacoco.exec: the run did not reach the test phase."
+      fi
+
+  - name: Report coverage
+    if: ${{ always() }}
+    shell: bash
+    run: |
+      set -o pipefail
+      {
+        echo "### Coverage"
+        echo
+        python3 scripts/ci/coverage-summary.py
+      } | tee -a "$GITHUB_STEP_SUMMARY"
+
+  # The summary carries totals and a per-package breakdown. Per-class and per-line
+  # detail lives in the HTML report, which is too large to inline.
+  - name: Upload coverage report
+    if: ${{ always() }}
+    uses: actions/upload-artifact@v4
+    with:
+      name: jacoco-coverage-report
+      path: target/site/jacoco
+      if-no-files-found: ignore
+      retention-days: 14
+
   - name: Package Java application
     shell: bash
     run: ./mvnw -B package -DskipTests

--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,11 @@
     <springfox-swagger-ui.version>2.10.0</springfox-swagger-ui.version>
     <spring-security-oauth2-test-webmvc-addons.version>3.0.1</spring-security-oauth2-test-webmvc-addons.version>
     <mockito.version>5.20.0</mockito.version>
+    <!-- Filled in by jacoco:prepare-agent and consumed by surefire's argLine below.
+         Declared empty here so a run that never reaches prepare-agent (`-DskipTests`,
+         or an invocation of surefire on its own) still resolves the placeholder
+         instead of handing the JVM a literal `@{jacocoArgLine}`. -->
+    <jacocoArgLine></jacocoArgLine>
     <maven.compiler.source>21</maven.compiler.source>
     <maven.compiler.target>21</maven.compiler.target>
     <hibernate.search.version>6.1.1.Final</hibernate.search.version>
@@ -710,7 +715,12 @@
         </artifactId> <!-- surefire plugin version managed by Spring Boot -->
         <configuration>
           <skipTests>true</skipTests>
-          <argLine>-javaagent:${settings.localRepository}/org/mockito/mockito-core/${mockito.version}/mockito-core-${mockito.version}.jar</argLine>
+          <!-- @{jacocoArgLine} is late-replaced by surefire with the value
+               jacoco:prepare-agent set. It has to be spliced in here rather than left to
+               JaCoCo's default: JaCoCo writes the `argLine` PROPERTY, but this explicit
+               <argLine> configuration overrides that property outright, so without this the
+               coverage agent would be dropped silently and every report would read 0%. -->
+          <argLine>@{jacocoArgLine} -javaagent:${settings.localRepository}/org/mockito/mockito-core/${mockito.version}/mockito-core-${mockito.version}.jar</argLine>
         </configuration>
         <executions>
           <execution>
@@ -742,6 +752,45 @@
                 <include>**/*IT.*</include>
               </includes>
             </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <!-- Coverage for the CI run summary. `report` is bound to the `test` phase so it runs
+           behind the surefire `unit-tests` execution; the integration-test execution appends
+           to the same exec file afterwards, so the reported figure is the unit-suite floor
+           rather than the whole picture. `prepare-agent` publishes its JVM flags as
+           `jacocoArgLine` instead of the default `argLine`, because surefire here sets an
+           explicit <argLine> for the Mockito agent that would otherwise override it — see
+           the property and the surefire configuration above. Generated and inner classes are
+           excluded: they inflate the denominator without being anything a test could
+           meaningfully reach. -->
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <version>0.8.10</version>
+        <configuration>
+          <excludes>
+            <exclude>**/*generated*/**</exclude>
+            <exclude>**/org/openapitools/**</exclude>
+            <exclude>**/*$*</exclude>
+          </excludes>
+        </configuration>
+        <executions>
+          <execution>
+            <id>prepare-agent</id>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+            <configuration>
+              <propertyName>jacocoArgLine</propertyName>
+            </configuration>
+          </execution>
+          <execution>
+            <id>report</id>
+            <phase>test</phase>
+            <goals>
+              <goal>report</goal>
+            </goals>
           </execution>
         </executions>
       </plugin>

--- a/scripts/ci/coverage-summary.py
+++ b/scripts/ci/coverage-summary.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+
+"""Renders JaCoCo line and branch coverage as a step-summary section.
+
+The run summary already reports how many tests executed. It does not say how
+much of the service those tests actually reach, so a shrinking covered share
+stayed invisible between merges. JaCoCo already runs in the build; this turns
+its CSV into the same table the summary shows for the suite inventory.
+
+Coverage is measured over the unit suite only. The integration suite runs in a
+separate job with its own execution data, so the figure here is a floor rather
+than the whole picture.
+"""
+
+import argparse
+import csv
+from pathlib import Path
+import sys
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_REPORT = REPOSITORY_ROOT / "target" / "site" / "jacoco" / "jacoco.csv"
+
+# JaCoCo emits one row per class. Rendering them all buries the totals, so the
+# breakdown aggregates to packages and the per-class detail stays in the HTML
+# report published alongside the run.
+COUNTERS = ("LINE", "BRANCH")
+
+
+class Coverage:
+    def __init__(self) -> None:
+        self.covered = {counter: 0 for counter in COUNTERS}
+        self.missed = {counter: 0 for counter in COUNTERS}
+
+    def add(self, row: dict) -> None:
+        for counter in COUNTERS:
+            self.covered[counter] += int(row[f"{counter}_COVERED"])
+            self.missed[counter] += int(row[f"{counter}_MISSED"])
+
+    def total(self, counter: str) -> int:
+        return self.covered[counter] + self.missed[counter]
+
+    def percentage(self, counter: str) -> float:
+        total = self.total(counter)
+        # A class with no branches at all is not 0% covered, it is not
+        # applicable. Reporting 100 keeps such packages from dragging the
+        # ordering below genuinely uncovered ones.
+        return self.covered[counter] / total * 100.0 if total else 100.0
+
+
+def collect(report: Path) -> tuple[Coverage, dict[str, Coverage]]:
+    overall = Coverage()
+    packages: dict[str, Coverage] = {}
+
+    with report.open(newline="") as handle:
+        for row in csv.DictReader(handle):
+            overall.add(row)
+            packages.setdefault(row["PACKAGE"], Coverage()).add(row)
+
+    return overall, packages
+
+
+def render_markdown(overall: Coverage, packages: dict[str, Coverage]) -> str:
+    lines = [
+        "| Metric | Covered | Total | Coverage |",
+        "| --- | ---: | ---: | ---: |",
+    ]
+    for counter, label in (("LINE", "Lines"), ("BRANCH", "Branches")):
+        lines.append(
+            f"| {label} | {overall.covered[counter]:,} | {overall.total(counter):,} | "
+            f"**{overall.percentage(counter):.2f}%** |"
+        )
+
+    lines.extend(
+        [
+            "",
+            f"Measured over the unit suite across {len(packages):,} packages. "
+            "The integration suite runs in its own job and is not included.",
+            "",
+            "<details>",
+            "<summary>Per-package breakdown (least covered first)</summary>",
+            "",
+            "| Package | Lines | Line % | Branch % |",
+            "| --- | ---: | ---: | ---: |",
+        ]
+    )
+
+    ordered = sorted(
+        packages.items(),
+        key=lambda item: (item[1].percentage("LINE"), -item[1].total("LINE")),
+    )
+    for name, coverage in ordered:
+        lines.append(
+            f"| `{name}` | {coverage.total('LINE'):,} | "
+            f"{coverage.percentage('LINE'):.1f}% | "
+            f"{coverage.percentage('BRANCH'):.1f}% |"
+        )
+
+    lines.extend(["", "</details>"])
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--report",
+        type=Path,
+        default=DEFAULT_REPORT,
+        help="JaCoCo CSV report (default: target/site/jacoco/jacoco.csv)",
+    )
+    arguments = parser.parse_args()
+
+    # A build that fails before the report goal leaves no CSV. Say so plainly
+    # rather than failing the step: the suite inventory already decides whether
+    # the run passes, and a missing report is a symptom of that, not a cause.
+    if not arguments.report.is_file():
+        print(f"No JaCoCo report at {arguments.report}.")
+        print()
+        print("Coverage is produced by the `report` goal during the `test` phase.")
+        return 0
+
+    overall, packages = collect(arguments.report)
+    if not packages:
+        print(f"JaCoCo report at {arguments.report} contains no classes.")
+        return 0
+
+    # Trailing blank line: the next summary section's heading would otherwise sit
+    # directly under this section's closing </details> and stop rendering. It is
+    # printed here rather than by the workflow step, because an `echo` after the
+    # script inside the step's `{ ... } | tee` group would replace the script's
+    # exit status with the echo's and mask a failing step.
+    print(render_markdown(overall, packages))
+    print()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/ci/test_coverage_summary.py
+++ b/tests/ci/test_coverage_summary.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+COVERAGE_SUMMARY = ROOT / "scripts/ci/coverage-summary.py"
+MAVEN_BUILD_ACTION = ROOT / ".github/actions/maven-build/action.yml"
+
+HEADER = (
+    "GROUP,PACKAGE,CLASS,INSTRUCTION_MISSED,INSTRUCTION_COVERED,BRANCH_MISSED,"
+    "BRANCH_COVERED,LINE_MISSED,LINE_COVERED,COMPLEXITY_MISSED,COMPLEXITY_COVERED,"
+    "METHOD_MISSED,METHOD_COVERED"
+)
+
+
+def row(
+    package: str,
+    class_name: str,
+    line_covered: int,
+    line_missed: int,
+    branch_covered: int = 0,
+    branch_missed: int = 0,
+) -> str:
+    return (
+        f"userservice,{package},{class_name},0,0,{branch_missed},{branch_covered},"
+        f"{line_missed},{line_covered},0,0,0,0"
+    )
+
+
+class CoverageSummaryTest(unittest.TestCase):
+    def run_summary(self, rows: list[str] | None):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            report = Path(temp_dir) / "jacoco.csv"
+            if rows is not None:
+                report.write_text("\n".join([HEADER, *rows]) + "\n")
+
+            return subprocess.run(
+                [sys.executable, COVERAGE_SUMMARY, "--report", report],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+
+    def test_reports_line_and_branch_percentages(self):
+        result = self.run_summary(
+            [
+                row("de.example.one", "Foo", line_covered=75, line_missed=25),
+                row(
+                    "de.example.two",
+                    "Bar",
+                    line_covered=25,
+                    line_missed=75,
+                    branch_covered=1,
+                    branch_missed=3,
+                ),
+            ]
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("| Lines | 100 | 200 | **50.00%** |", result.stdout)
+        self.assertIn("| Branches | 1 | 4 | **25.00%** |", result.stdout)
+
+    def test_orders_the_breakdown_least_covered_first(self):
+        result = self.run_summary(
+            [
+                row("de.example.covered", "Foo", line_covered=90, line_missed=10),
+                row("de.example.bare", "Bar", line_covered=1, line_missed=99),
+            ]
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        bare = result.stdout.index("de.example.bare")
+        covered = result.stdout.index("de.example.covered")
+        self.assertLess(bare, covered, "least covered package must come first")
+
+    def test_aggregates_classes_of_one_package_into_a_single_row(self):
+        """A per-class table would bury the totals; the HTML report carries that detail."""
+        result = self.run_summary(
+            [
+                row("de.example", "Foo", line_covered=50, line_missed=0),
+                row("de.example", "Bar", line_covered=0, line_missed=50),
+            ]
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.count("| `de.example` |"), 1)
+        self.assertIn("| `de.example` | 100 | 50.0% |", result.stdout)
+        self.assertIn("across 1 packages", result.stdout)
+
+    def test_counts_a_class_without_branches_as_fully_covered(self):
+        """Zero of zero branches is not applicable, not uncovered."""
+        result = self.run_summary([row("de.example", "Foo", line_covered=10, line_missed=0)])
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("| Branches | 0 | 0 | **100.00%** |", result.stdout)
+
+    def test_explains_a_missing_report_without_failing_the_step(self):
+        """A build that fails before the report goal leaves no CSV behind."""
+        result = self.run_summary(None)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("No JaCoCo report at", result.stdout)
+
+    def test_tolerates_a_report_that_contains_no_classes(self):
+        result = self.run_summary([])
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("contains no classes", result.stdout)
+
+    def test_coverage_report_is_generated_outside_the_test_phase(self):
+        """jacoco:report sits behind surefire in the `test` phase.
+
+        A red suite halts the build before it, so the goal is invoked directly
+        against the execution data the agent already wrote.
+        """
+        action = MAVEN_BUILD_ACTION.read_text()
+
+        self.assertIn("./mvnw -B jacoco:report", action)
+        self.assertIn("target/jacoco.exec", action)
+
+    def test_standalone_report_generation_cannot_fail_the_build(self):
+        """Coverage is a diagnostic; being unable to produce it is not a build failure.
+
+        Run from the command line the goal resolves the plugin's reporting
+        dependencies, which the lifecycle-bound execution never needs and which do
+        not reliably resolve from a restored runner cache. A green suite skips the
+        invocation entirely, because the test phase has already written the report.
+        """
+        action = MAVEN_BUILD_ACTION.read_text()
+
+        invocation = action.index("./mvnw -B jacoco:report")
+        following = action[invocation : invocation + 200]
+        self.assertIn("||", following, "the standalone goal must tolerate its own failure")
+
+        guard = action.index("target/site/jacoco/jacoco.csv")
+        self.assertLess(guard, invocation, "an existing report must short-circuit the invocation")
+
+    def test_does_not_suppress_test_failures_in_maven(self):
+        """testFailureIgnore would hide a red suite from every consumer of the build."""
+        action = MAVEN_BUILD_ACTION.read_text()
+
+        self.assertNotIn("maven.test.failure.ignore", action)
+        self.assertNotIn("testFailureIgnore", action)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

The run summary reports how many tests executed, not how much of the service they reach, so a shrinking covered share stayed invisible between merges. This repo had no JaCoCo configured at all, so there was no coverage data to report.

## Changes

- `pom.xml`: adds the JaCoCo plugin. `report` is bound to the `test` phase behind the surefire `unit-tests` execution; generated and inner classes excluded.
- `scripts/ci/coverage-summary.py`: renders the JaCoCo CSV as a summary table plus a collapsed per-package breakdown, least covered first.
- `maven-build` action: three `always()`-guarded steps — regenerate the report if a red suite halted before the goal, render the summary, upload the HTML report as an artifact. Coverage is reported for failing runs too, without touching the existing test gate.
- Ports UserService's script test, trimmed to the coverage scope.

**Repo-specific, and why this is not a copy-paste:** surefire here sets an explicit `<argLine>` for the Mockito javaagent, which overrides the `argLine` property JaCoCo normally publishes — the coverage agent would have been dropped silently and every report would have read 0%. `prepare-agent` therefore publishes to `jacocoArgLine`, spliced in via `@{jacocoArgLine}`.

Not ported: UserService's failed-test-name step and held-back Maven status — both hang off its `suite-inventory.py` gate, which this repo does not have.

## Verification

`./mvnw -B test` → 612 tests, logs `jacocoArgLine set to ...` alongside the Mockito agent.
`scripts/ci/coverage-summary.py` → **62.82% line / 43.60% branch** across 39 packages — non-zero, which is the proof the agent attached.
`tests/ci/test_coverage_summary.py` → 9 tests, OK.

Same change in ORISO-TenantService and ORISO-ConsultingTypeService.