### PR TITLE
Scan the image before publishing it, not after

### DIFF
--- a/.github/actions/docker-build-push/action.yml
+++ b/.github/actions/docker-build-push/action.yml
@@ -14,6 +14,14 @@ inputs:
     description: Comma-separated OCI target platforms
     required: false
     default: linux/amd64,linux/arm64
+  scan_before_push:
+    description: >-
+      Scan the image with Trivy before anything is published and fail on
+      fixable HIGH/CRITICAL findings. Must be enabled wherever this action
+      publishes: a scan that runs after the push cannot keep a vulnerable
+      image out of the registry (OpenResilienceInitiative/ORISO-Docs#88).
+    required: false
+    default: 'false'
 
 outputs:
   digest:
@@ -47,6 +55,47 @@ runs:
         type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
         type=raw,value=dev,enable=${{ github.ref == 'refs/heads/dev' }}
         type=raw,value=pre-dev,enable=${{ github.ref == 'refs/heads/pre-dev' }}
+
+  # The vulnerability gate only works ahead of the push. Scanning the image
+  # after `push: true` turns the run red but leaves the vulnerable image in
+  # GHCR under its branch tag and its sha tag, where the deploy scripts
+  # resolve it to a digest and roll it out without ever consulting the
+  # workflow result (OpenResilienceInitiative/ORISO-Docs#88).
+  #
+  # `load: true` hands the result to the runner's Docker daemon and only
+  # supports one platform, so the scanned image is amd64. That matches what
+  # was effectively scanned before: given a multi-platform index, Trivy picks
+  # the host platform anyway. The publish build below still produces the full
+  # multi-platform manifest and reuses this build's amd64 layers straight
+  # from the buildx builder's own cache, so only the arm64 half is new work.
+  # No `cache-to` here on purpose: the publish build stays the single
+  # exporter for the GHA cache scope.
+  - name: Build amd64 image locally for scanning
+    if: ${{ inputs.scan_before_push == 'true' }}
+    uses: docker/build-push-action@v7
+    with:
+      context: .
+      platforms: linux/amd64
+      push: false
+      load: true
+      # The docker exporter cannot carry attestations, and an image that is
+      # thrown away after the scan has no use for them either.
+      provenance: false
+      sbom: false
+      tags: ${{ inputs.image_name }}:ci-scan
+      labels: ${{ steps.meta.outputs.labels }}
+      cache-from: type=gha,scope=${{ inputs.image_name }}
+
+  - name: Reject fixable high or critical image vulnerabilities
+    if: ${{ inputs.scan_before_push == 'true' }}
+    uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+    with:
+      image-ref: ${{ inputs.image_name }}:ci-scan
+      format: table
+      exit-code: '1'
+      ignore-unfixed: true
+      vuln-type: os,library
+      severity: CRITICAL,HIGH
 
   - name: Build Docker image and publish when enabled
     id: build

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -52,16 +52,12 @@ jobs:
         push_to_ghcr: true
         image_name: oriso-agencyservice
         github_token: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: Reject fixable high or critical image vulnerabilities
-      uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
-      with:
-        image-ref: ${{ env.REGISTRY }}/${{ env.ORG }}/oriso-agencyservice@${{ steps.image.outputs.digest }}
-        format: table
-        exit-code: '1'
-        ignore-unfixed: true
-        vuln-type: os,library
-        severity: CRITICAL,HIGH
+        # Trivy runs inside the action, against a locally built image, and
+        # before anything reaches GHCR. It used to run as a separate step
+        # after this one, which could only redden the run — the vulnerable
+        # image was already published and deployable by then
+        # (OpenResilienceInitiative/ORISO-Docs#88).
+        scan_before_push: true
 
     - name: Sign and publish the image provenance attestation
       uses: actions/attest@f7c74d28b9d84cb8768d0b8ca14a4bac6ef463e6 # v4.1.0

--- a/src/test/java/de/caritas/cob/agencyservice/config/LegacyChatConfigurationTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/config/LegacyChatConfigurationTest.java
@@ -30,14 +30,21 @@ class LegacyChatConfigurationTest {
     assertTrue(mainWorkflow.contains("id-token: write"));
     assertTrue(mainWorkflow.contains("attestations: write"));
     assertTrue(
-        mainWorkflow.contains(
-            "aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25"));
+        buildAction.contains("aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25"));
     assertTrue(
         mainWorkflow.contains("actions/attest@f7c74d28b9d84cb8768d0b8ca14a4bac6ef463e6"));
-    assertTrue(
-        mainWorkflow.contains(
-            "image-ref: ${{ env.REGISTRY }}/${{ env.ORG }}/oriso-agencyservice@${{ steps.image.outputs.digest }}"));
     assertTrue(mainWorkflow.contains("subject-digest: ${{ steps.image.outputs.digest }}"));
+
+    // The vulnerability scan has to sit ahead of the publish. Scanning after
+    // `push: true` can only redden the run; the image is already in GHCR and the
+    // deploy scripts resolve a tag to a digest without reading workflow results
+    // (OpenResilienceInitiative/ORISO-Docs#88).
+    var scanIndex = buildAction.indexOf("aquasecurity/trivy-action@");
+    var publishIndex = buildAction.indexOf("push: ${{ inputs.push_to_ghcr }}");
+    assertTrue(scanIndex > -1, "the build action must run Trivy");
+    assertTrue(publishIndex > -1, "the build action must publish the image");
+    assertTrue(
+        scanIndex < publishIndex, "Trivy must run before the image is pushed to the registry");
   }
 
   @Test


### PR DESCRIPTION
Closes OpenResilienceInitiative/ORISO-Docs#88

## Problem

The image vulnerability gate could not keep a vulnerable image out of the
registry, because it ran **after** the image was pushed.

The publish job called `docker-build-push` with `push_to_ghcr: true` — image
built and pushed — and only then ran `aquasecurity/trivy-action` with
`exit-code: '1'`. By that point the image was in GHCR under its branch tag and
its `sha-*` tag, and the deploy scripts resolve a tag to a digest without ever
consulting the workflow result. The gate could turn a run red; it could not
prevent a deploy.

Observed on 2026-08-16: ORISO-AgencyService run 31974523926 and
ORISO-UserService run 31974525851 both concluded `failure` with the scan as the
only failing step, all functional jobs green — and both images were pulled and
deployed to Pre-Dev without difficulty.

## What changed

The scan moves inside `.github/actions/docker-build-push`, behind a new
`scan_before_push` input, and runs ahead of the publish:

1. build an **amd64** image with `push: false, load: true` and hand it to the
   runner's Docker daemon;
2. run Trivy against that local image, failing on fixable HIGH/CRITICAL;
3. build and push the full `linux/amd64,linux/arm64` image only if the scan
   passed.

Notes on the details:

- `load: true` supports a single platform only, so the scanned image is amd64.
  That is what was effectively scanned before as well — given a multi-platform
  index, Trivy picks the host platform.
- The publish build reuses the scan build's amd64 layers from the buildx
  builder's cache, so only the arm64 half is additional work.
- `provenance`/`sbom` are off for the scan image: the docker exporter cannot
  carry attestations, and a throwaway image has no use for them. The
  attestation step stays after the push, where the registry digest exists.
- Action versions are unchanged and still pinned.

## Verification

- Every touched workflow and action file parses: `python3 -c "import yaml; yaml.safe_load(open(F))"`.
- GitHub Actions cannot be executed locally, so the behavioural proof is the
  first run on this branch: the publish step must appear **after** the scan in
  the step list, and a scan failure must leave GHCR without a new tag.

## Reviewer test plan

- [ ] Open the first `Build and Publish` run on this branch and confirm the step order is build-for-scan → Trivy → build-and-push.
- [ ] Confirm the published image still carries both `linux/amd64` and `linux/arm64` (`docker buildx imagetools inspect <image>:<tag>`).
- [ ] Confirm the provenance attestation is still attached after the push.
- [ ] Optional: temporarily lower `severity` to force a finding and confirm no new tag reaches GHCR.

## Not in scope

Three open PRs would add the old, ineffective ordering to further repositories:
ORISO-Admin#705, ORISO-ConsultingTypeService#123, ORISO-TenantService#177.
They should adopt this shape or be closed rather than merged as they stand.
