### PR TITLE
test: lock downstream 403 propagation

### DIFF
--- a/src/test/java/de/caritas/cob/agencyservice/api/ResponseEntityExceptionHandlerIT.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/ResponseEntityExceptionHandlerIT.java
@@ -6,6 +6,7 @@ import static de.caritas.cob.agencyservice.testHelper.TestConstants.AGENCY_ID;
 import static org.apache.commons.lang3.exception.ExceptionUtils.getStackTrace;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -24,9 +25,12 @@ import de.caritas.cob.agencyservice.api.service.AgencyService;
 import de.caritas.cob.agencyservice.api.service.DepartmentLegalService;
 import de.caritas.cob.agencyservice.api.service.LogService;
 import de.caritas.cob.agencyservice.api.service.TopicEnrichmentService;
+import de.caritas.cob.agencyservice.config.resttemplate.CustomResponseErrorHandler;
 import de.caritas.cob.agencyservice.config.security.AuthorisationService;
 import de.caritas.cob.agencyservice.config.security.JwtAuthConverter;
 import de.caritas.cob.agencyservice.config.security.JwtAuthConverterProperties;
+import java.io.ByteArrayInputStream;
+import java.net.URI;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -39,7 +43,9 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.dao.InvalidDataAccessApiUsageException;
 import org.springframework.hateoas.client.LinkDiscoverers;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
+import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.web.client.HttpClientErrorException;
@@ -183,6 +189,24 @@ public class ResponseEntityExceptionHandlerIT {
     mvc.perform(get(PATH_GET_AGENCIES_WITH_IDS + AGENCY_ID)
         .accept(MediaType.APPLICATION_JSON))
         .andExpect(status().isEarlyHints());
+  }
+
+  @Test
+  public void handleException_Should_PreserveForbidden_When_ResponseStatusExceptionIsThrown()
+      throws Exception {
+
+    ClientHttpResponse downstreamResponse = mock(ClientHttpResponse.class);
+    when(downstreamResponse.getStatusCode()).thenReturn(HttpStatus.FORBIDDEN);
+    when(downstreamResponse.getBody()).thenReturn(new ByteArrayInputStream(new byte[0]));
+    when(agencyService.getAgencies(any())).thenAnswer(invocation -> {
+      new CustomResponseErrorHandler().handleError(
+          URI.create("https://downstream.example/agencies"), HttpMethod.GET, downstreamResponse);
+      return null;
+    });
+
+    mvc.perform(get(PATH_GET_AGENCIES_WITH_IDS + AGENCY_ID)
+        .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isForbidden());
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/agencyservice/config/resttemplate/RestTemplateConfigIT.java
+++ b/src/test/java/de/caritas/cob/agencyservice/config/resttemplate/RestTemplateConfigIT.java
@@ -14,8 +14,10 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.restclient.autoconfigure.RestTemplateAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.client.RestTemplate;
+import org.springframework.web.server.ResponseStatusException;
 
 @SpringBootTest(
     classes = {RestTemplateConfig.class, RestTemplateAutoConfiguration.class},
@@ -53,5 +55,19 @@ class RestTemplateConfigIT {
 
     long elapsed = System.currentTimeMillis() - start;
     assertThat(elapsed).isLessThan(MAX_ELAPSED_MS);
+  }
+
+  @Test
+  void restTemplate_shouldPreserveForbiddenStatusFromDownstream() {
+    wireMockServer.stubFor(
+        get(urlEqualTo("/forbidden"))
+            .willReturn(aResponse().withStatus(HttpStatus.FORBIDDEN.value()).withBody("denied")));
+    String url = "http://localhost:" + wireMockServer.port() + "/forbidden";
+
+    ResponseStatusException exception =
+        assertThrows(
+            ResponseStatusException.class, () -> restTemplate.getForObject(url, String.class));
+
+    assertThat(exception.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
   }
 }


### PR DESCRIPTION
## Summary

- lock the downstream `CustomResponseErrorHandler` → Spring MVC exception-advice boundary to HTTP 403
- prove the production `RestTemplate` bean actually registers that handler by exercising a real WireMock 403
- keep the existing generic `RuntimeException` → HTTP 500 regression in the same composed MVC suite
- record that the original static 403→500 hypothesis is not reproducible on current Spring Boot 4 / Spring Framework 7, so no production mapping change is needed

## Diagnosis and TDD evidence

The requested regression was written first against current `pre-dev`. It was already green: Spring Framework 7 handles `ResponseStatusException` as an `ErrorResponseException` in the inherited `ResponseEntityExceptionHandler` before the generic runtime advice. The test was then strengthened to invoke the production `CustomResponseErrorHandler` during the MockMvc request, reproducing the downstream-style exception path.

There is intentionally no manufactured RED and no redundant production handler. This PR locks the currently correct behavior against future framework, bean-registration, or advice-order changes.

## Verification

Local only, Java 21.0.11; no deployment or shared environment change.

- `./mvnw -B -Dtest=ResponseEntityExceptionHandlerIT test` — 10 tests passed, 0 failed, 0 skipped
- `./mvnw -B -Dtest=RestTemplateConfigIT clean test` — 2 tests passed, 0 failed, 0 skipped; real WireMock 403 preserved
- `./mvnw -B test` — 612 tests passed, 0 failed, 0 skipped before the review-only test addition
- `./mvnw -B package -DskipTests` — build succeeded before the review-only test addition
- Checkstyle — 0 violations

### Reviewer test plan

- [ ] Run `./mvnw -B -Dtest=RestTemplateConfigIT test` on Java 21 → the configured production bean converts a real downstream 403 into `ResponseStatusException(FORBIDDEN)`.
- [ ] Run `./mvnw -B -Dtest=ResponseEntityExceptionHandlerIT test` → the downstream-style 403 returns 403 and unrelated runtime failure returns 500.
- [ ] Run `./mvnw -B test` → all repository tests pass with no skipped tests.
- [ ] Review the diff → only regression coverage changes; production exception handling is untouched.

Closes OpenResilienceInitiative/ORISO-AgencyService#266

🤖 Generated with [Claude Code](https://claude.com/claude-code)
