### PR TITLE
Reject skipped tests in AgencyService CI reports

### DIFF
--- a/.github/actions/maven-build/action.yml
+++ b/.github/actions/maven-build/action.yml
@@ -15,44 +15,14 @@ runs:
       cache: maven
 
   # Blocking unit-test gate (Test Quality Audit 2026-07-04, item 3).
-  # Runs the surefire `unit-tests` execution (test phase, **/*Test) and fails the
-  # build if any report shows failures/errors — or if NO reports were produced at
-  # all (a green build with zero reports means tests were silently skipped).
+  # Runs the surefire `unit-tests` execution (test phase, **/*Test). The shared
+  # report guard fails on failures, errors, skips, zero reports, or zero executed
+  # tests, so a green Maven exit cannot hide an incomplete suite.
   - name: Run Maven tests
     shell: bash
     run: |
       ./mvnw -B test
-      python3 - <<'PY'
-      from pathlib import Path
-      import sys
-      import xml.etree.ElementTree as ET
-
-      reports = sorted(Path("target/surefire-reports").glob("TEST-*.xml"))
-      if not reports:
-          print("::error::Zero surefire reports found — tests were silently skipped or never ran.")
-          sys.exit(1)
-
-      total_tests = 0
-      failing_reports = []
-      for report in reports:
-          root = ET.parse(report).getroot()
-          total_tests += int(root.attrib.get("tests", 0))
-          failures = int(root.attrib.get("failures", 0))
-          errors = int(root.attrib.get("errors", 0))
-          if failures or errors:
-              failing_reports.append((report, failures, errors))
-
-      print(f"Parsed {len(reports)} surefire report(s), {total_tests} tests.")
-      if total_tests == 0:
-          print("::error::Surefire reports contain zero executed tests.")
-          sys.exit(1)
-
-      if failing_reports:
-          print("Maven reported test failures/errors:")
-          for report, failures, errors in failing_reports:
-              print(f"- {report}: failures={failures}, errors={errors}")
-          sys.exit(1)
-      PY
+      python3 scripts/ci/verify-test-reports.py
 
   # jacoco:report is bound to the `test` phase behind surefire, so a green suite has
   # already written the report and this step has nothing to do. Only a red suite halts

--- a/.github/actions/maven-verify-burnin/action.yml
+++ b/.github/actions/maven-verify-burnin/action.yml
@@ -44,22 +44,16 @@ runs:
         echo "::warning::Legacy integration failures are quarantined by #185 until 2026-09-30."
       fi
 
-  - name: Assert test reports were produced (zero-report guard)
+  - name: Reject incomplete legacy test reports
     if: ${{ always() }}
     shell: bash
-    # Guards against a future silent-skip: a green build that produced ZERO test
-    # reports must be treated as a failure, not a pass. Surefire writes both the
-    # unit (**/*Test) and integration (**/*IT) executions into surefire-reports;
-    # failsafe-reports is globbed too in case a module adopts failsafe later.
+    # The shared guard treats zero reports, zero executed tests, failures, errors,
+    # and skips as red. The calling workflow still owns the explicit, time-bounded
+    # continue-on-error quarantine; strict report truth does not make this suite blocking.
     run: |
       shopt -s nullglob globstar
       reports=( **/target/surefire-reports/TEST-*.xml **/target/failsafe-reports/TEST-*.xml )
-      count=${#reports[@]}
-      echo "Found ${count} test report file(s)."
-      if [ "${count}" -eq 0 ]; then
-        echo "::error::Zero test reports were produced — tests were silently skipped or never ran."
-        exit 1
-      fi
+      python3 scripts/ci/verify-test-reports.py "${reports[@]}"
 
   - name: Summarise legacy integration-test results
     if: ${{ always() }}

--- a/pom.xml
+++ b/pom.xml
@@ -403,6 +403,16 @@
       <version>3.3.1</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>testcontainers-junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>testcontainers-mariadb</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/scripts/ci/run-required-integration-tests.sh
+++ b/scripts/ci/run-required-integration-tests.sh
@@ -9,19 +9,22 @@ required_tests=(
   AgencyControllerIT
   AgencyControllerAuthorizationIT
   TracingConfigVerificationIT
+  LiquibaseChangelogDriftIT
+  DemoBaselineChangesetIT
 )
 test_selector="$(IFS=,; echo "${required_tests[*]}")"
 
 "${maven_wrapper}" -B -Dtest="${test_selector}" test
 
-report_count=0
+required_reports=()
 for test_name in "${required_tests[@]}"; do
   matches=(target/surefire-reports/TEST-*."${test_name}".xml)
   if [[ ! -e "${matches[0]}" ]]; then
     echo "Required integration test produced no report: ${test_name}" >&2
     exit 1
   fi
-  report_count=$((report_count + ${#matches[@]}))
+  required_reports+=("${matches[@]}")
 done
 
-echo "Required integration contract produced ${report_count} report(s)."
+python3 scripts/ci/verify-test-reports.py "${required_reports[@]}"
+echo "Required integration contract produced ${#required_reports[@]} complete report(s)."

--- a/scripts/ci/verify-test-reports.py
+++ b/scripts/ci/verify-test-reports.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import sys
+import xml.etree.ElementTree as ET
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Verify Surefire/Failsafe XML reports")
+    parser.add_argument("reports", nargs="*", type=Path)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    reports = args.reports or sorted(Path("target/surefire-reports").glob("TEST-*.xml"))
+    reports = [report for report in reports if report.is_file()]
+
+    if not reports:
+        print("::error::Zero test reports found — tests were silently skipped or never ran.")
+        return 1
+
+    total_tests = total_skipped = 0
+    failing_reports: list[tuple[Path, int, int]] = []
+    skipped_reports: list[tuple[Path, int]] = []
+    for report in reports:
+        root = ET.parse(report).getroot()
+        total_tests += int(root.attrib.get("tests", 0))
+        failures = int(root.attrib.get("failures", 0))
+        errors = int(root.attrib.get("errors", 0))
+        skipped = int(root.attrib.get("skipped", 0))
+        total_skipped += skipped
+        if failures or errors:
+            failing_reports.append((report, failures, errors))
+        if skipped:
+            skipped_reports.append((report, skipped))
+
+    executed_tests = total_tests - total_skipped
+    print(
+        f"Parsed {len(reports)} test report(s): "
+        f"tests={total_tests} executed={executed_tests} skipped={total_skipped}."
+    )
+    failed = False
+    if executed_tests <= 0:
+        print("::error::Test reports contain zero executed tests.")
+        failed = True
+
+    if skipped_reports:
+        print("::error::Skipped tests are not allowed in a blocking test gate:")
+        for report, skipped in skipped_reports:
+            print(f"- {report}: skipped={skipped}")
+        failed = True
+
+    if failing_reports:
+        print("Test reports contain failures/errors:")
+        for report, failures, errors in failing_reports:
+            print(f"- {report}: failures={failures}, errors={errors}")
+        failed = True
+
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/test/java/de/caritas/cob/agencyservice/api/repository/DemoBaselineChangesetIT.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/repository/DemoBaselineChangesetIT.java
@@ -9,11 +9,15 @@ import java.sql.ResultSet;
 import java.sql.Statement;
 import javax.sql.DataSource;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.context.TestPropertySource;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.mariadb.MariaDBContainer;
 
 /**
  * Regression guard for the opt-in demo baseline changeset
@@ -39,27 +43,14 @@ import org.springframework.test.context.TestPropertySource;
  * {@code seed,demo-baseline} contexts (so the base schema and the demo baseline are both built by
  * Liquibase), then asserts the baseline landed and that a sequence-driven insert does not collide.
  *
- * <p>Like {@link LiquibaseChangelogDriftIT} the test is gated on {@code LIQUIBASE_IT_DB_URL} and is
- * skipped on the normal H2-based {@code testing} build. Provide a fresh MariaDB, e.g.:
- *
- * <pre>
- *   docker run -d --name demo-baseline-mariadb -p 3313:3306 \
- *     -e MARIADB_ROOT_PASSWORD=root -e MARIADB_DATABASE=agencyservice mariadb:10.11
- *
- *   LIQUIBASE_IT_DB_URL="jdbc:mariadb://127.0.0.1:3313/agencyservice" \
- *   LIQUIBASE_IT_DB_USERNAME=root \
- *   LIQUIBASE_IT_DB_PASSWORD=root \
- *   ./mvnw -Dtest=DemoBaselineChangesetIT -DfailIfNoTests=false test
- * </pre>
+ * <p>The required CI contract owns this test and starts an isolated MariaDB 10.11 container. It
+ * therefore cannot report green by skipping when a manually supplied database URL is absent.
  */
 @SpringBootTest(classes = AgencyServiceApplication.class)
 @ActiveProfiles("dev")
-@EnabledIfEnvironmentVariable(named = "LIQUIBASE_IT_DB_URL", matches = ".+")
+@Testcontainers
 @TestPropertySource(
     properties = {
-      "spring.datasource.url=${LIQUIBASE_IT_DB_URL}",
-      "spring.datasource.username=${LIQUIBASE_IT_DB_USERNAME:root}",
-      "spring.datasource.password=${LIQUIBASE_IT_DB_PASSWORD:root}",
       "spring.datasource.driver-class-name=org.mariadb.jdbc.Driver",
       "spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MariaDBDialect",
       // Liquibase owns the schema; build the base schema (seed) AND the opt-in demo baseline.
@@ -84,6 +75,17 @@ import org.springframework.test.context.TestPropertySource;
       "user.admin.service.api.url=http://localhost:8082"
     })
 class DemoBaselineChangesetIT {
+
+  @Container
+  static final MariaDBContainer mariaDb =
+      new MariaDBContainer("mariadb:10.11").withDatabaseName("agencyservice");
+
+  @DynamicPropertySource
+  static void mariaDbProperties(DynamicPropertyRegistry registry) {
+    registry.add("spring.datasource.url", mariaDb::getJdbcUrl);
+    registry.add("spring.datasource.username", mariaDb::getUsername);
+    registry.add("spring.datasource.password", mariaDb::getPassword);
+  }
 
   /** The demo agency id reserved by the baseline changeset (0025). */
   private static final long DEMO_AGENCY_ID = 246L;

--- a/src/test/java/de/caritas/cob/agencyservice/api/repository/LiquibaseChangelogDriftIT.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/repository/LiquibaseChangelogDriftIT.java
@@ -5,11 +5,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 import de.caritas.cob.agencyservice.AgencyServiceApplication;
 import javax.sql.DataSource;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.context.TestPropertySource;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.mariadb.MariaDBContainer;
 
 /**
  * Permanent drift guard for the consolidated Liquibase changelog (Liquibase Re-Enablement
@@ -26,31 +30,14 @@ import org.springframework.test.context.TestPropertySource;
  * on dev by silently mutating the schema. With ddl-auto set to {@code validate}, that class of gap
  * is now caught here.
  *
- * <p>The project does not (yet) depend on Testcontainers, so the test is gated on the
- * {@code LIQUIBASE_IT_DB_URL} environment variable. Provide a fresh MariaDB and run it, e.g.:
- *
- * <pre>
- *   docker run -d --name l1-agency-mariadb -p 3313:3306 \
- *     -e MARIADB_ROOT_PASSWORD=root -e MARIADB_DATABASE=agencyservice mariadb:10.11
- *
- *   LIQUIBASE_IT_DB_URL="jdbc:mariadb://127.0.0.1:3313/agencyservice" \
- *   LIQUIBASE_IT_DB_USERNAME=root \
- *   LIQUIBASE_IT_DB_PASSWORD=root \
- *   ./mvnw -Dtest=LiquibaseChangelogDriftIT -DfailIfNoTests=false test
- * </pre>
- *
- * <p>When the variable is absent (normal CI/local unit runs) the test is skipped, so it never
- * breaks the H2-based {@code testing} profile build.
+ * <p>The required CI contract owns this test and starts an isolated MariaDB 10.11 container. It
+ * therefore cannot report green by skipping when a manually supplied database URL is absent.
  */
 @SpringBootTest(classes = AgencyServiceApplication.class)
 @ActiveProfiles("dev")
-@EnabledIfEnvironmentVariable(named = "LIQUIBASE_IT_DB_URL", matches = ".+")
+@Testcontainers
 @TestPropertySource(
     properties = {
-      // Real MariaDB instead of any embedded replacement.
-      "spring.datasource.url=${LIQUIBASE_IT_DB_URL}",
-      "spring.datasource.username=${LIQUIBASE_IT_DB_USERNAME:root}",
-      "spring.datasource.password=${LIQUIBASE_IT_DB_PASSWORD:root}",
       "spring.datasource.driver-class-name=org.mariadb.jdbc.Driver",
       "spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MariaDBDialect",
       // Liquibase owns the schema; run the consolidated master with the fresh-DB seed context.
@@ -79,6 +66,17 @@ import org.springframework.test.context.TestPropertySource;
       "user.admin.service.api.url=http://localhost:8082"
     })
 class LiquibaseChangelogDriftIT {
+
+  @Container
+  static final MariaDBContainer mariaDb =
+      new MariaDBContainer("mariadb:10.11").withDatabaseName("agencyservice");
+
+  @DynamicPropertySource
+  static void mariaDbProperties(DynamicPropertyRegistry registry) {
+    registry.add("spring.datasource.url", mariaDb::getJdbcUrl);
+    registry.add("spring.datasource.username", mariaDb::getUsername);
+    registry.add("spring.datasource.password", mariaDb::getPassword);
+  }
 
   @Autowired private DataSource dataSource;
 

--- a/tests/ci/test_required_ci_contract.py
+++ b/tests/ci/test_required_ci_contract.py
@@ -106,6 +106,33 @@ class RequiredCiContractTest(unittest.TestCase):
         self.assertNotIn("continue-on-error:", action)
         self.assertNotIn("if ! ./mvnw", action)
 
+    def test_blocking_suites_use_the_shared_zero_skip_guard(self):
+        guard = "scripts/ci/verify-test-reports.py"
+        unit_action = (ROOT / ".github/actions/maven-build/action.yml").read_text()
+        required_runner = (ROOT / "scripts/ci/run-required-integration-tests.sh").read_text()
+
+        self.assertIn(guard, unit_action)
+        self.assertIn(guard, required_runner)
+
+    def test_required_runner_owns_the_real_mariadb_contracts(self):
+        required_runner = (ROOT / "scripts/ci/run-required-integration-tests.sh").read_text()
+
+        self.assertIn("LiquibaseChangelogDriftIT", required_runner)
+        self.assertIn("DemoBaselineChangesetIT", required_runner)
+
+    def test_legacy_quarantine_uses_the_guard_but_stays_non_blocking(self):
+        action = (ROOT / ".github/actions/maven-verify-burnin/action.yml").read_text()
+        self.assertIn("scripts/ci/verify-test-reports.py", action)
+
+        for relative_path in (
+            ".github/workflows/ci-pull-request.yml",
+            ".github/workflows/ci-feature-branch.yml",
+            ".github/workflows/ci-main.yml",
+        ):
+            workflow = (ROOT / relative_path).read_text()
+            quarantine = job_block(workflow, "legacy-integration-quarantine")
+            self.assertIn("continue-on-error: true", quarantine)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/ci/test_test_report_guard.py
+++ b/tests/ci/test_test_report_guard.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+GUARD = ROOT / "scripts/ci/verify-test-reports.py"
+
+
+class TestReportGuardTest(unittest.TestCase):
+    def run_guard(self, reports: list[dict[str, int]]) -> subprocess.CompletedProcess[str]:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            paths = []
+            for index, attributes in enumerate(reports):
+                path = Path(temp_dir) / f"TEST-Suite{index}.xml"
+                rendered = " ".join(f'{name}="{value}"' for name, value in attributes.items())
+                path.write_text(f"<testsuite name=\"Suite{index}\" {rendered}></testsuite>\n")
+                paths.append(path)
+
+            return subprocess.run(
+                [sys.executable, GUARD, *paths],
+                cwd=temp_dir,
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+
+    def test_rejects_zero_reports(self):
+        result = self.run_guard([])
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("Zero test reports", result.stdout)
+
+    def test_rejects_zero_declared_tests(self):
+        result = self.run_guard(
+            [{"tests": 0, "failures": 0, "errors": 0, "skipped": 0}]
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("zero executed tests", result.stdout)
+
+    def test_rejects_an_all_skipped_report_and_counts_zero_executed(self):
+        result = self.run_guard(
+            [{"tests": 4, "failures": 0, "errors": 0, "skipped": 4}]
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("executed=0", result.stdout)
+        self.assertIn("skipped=4", result.stdout)
+
+    def test_rejects_one_skip_beside_executed_tests_and_names_the_report(self):
+        result = self.run_guard(
+            [
+                {"tests": 3, "failures": 0, "errors": 0, "skipped": 0},
+                {"tests": 2, "failures": 0, "errors": 0, "skipped": 1},
+            ]
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("TEST-Suite1.xml", result.stdout)
+        self.assertIn("skipped=1", result.stdout)
+        self.assertIn("executed=4", result.stdout)
+
+    def test_rejects_failures_and_errors(self):
+        result = self.run_guard(
+            [
+                {"tests": 2, "failures": 1, "errors": 0, "skipped": 0},
+                {"tests": 1, "failures": 0, "errors": 1, "skipped": 0},
+            ]
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("failures=1", result.stdout)
+        self.assertIn("errors=1", result.stdout)
+
+    def test_accepts_only_executed_passing_tests(self):
+        result = self.run_guard(
+            [{"tests": 3, "failures": 0, "errors": 0, "skipped": 0}]
+        )
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("tests=3 executed=3 skipped=0", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- replace the inline report counter with a behavior-tested shared Surefire/Failsafe XML guard
- count executed tests as `tests - skipped` and reject failures, errors, any skips, zero reports, and zero executed tests
- make both MariaDB Liquibase contracts mandatory in the required integration runner using isolated Testcontainers MariaDB 10.11 instances
- apply the same truthful report guard to the explicitly non-blocking legacy quarantine without changing its quarantine semantics

## TDD evidence

RED before implementation:
- `python3 -m pytest -q tests/ci/test_test_report_guard.py` — 3 failed, 3 passed; all-skipped and mixed-skipped reports were incorrectly accepted
- `python3 -m pytest -q tests/ci/test_required_ci_contract.py` — 3 failed, 6 passed; blocking suites did not share the guard and the MariaDB contracts were not required-owned

GREEN after implementation:
- `python3 -m pytest -q tests/ci` — 25 passed
- `scripts/ci/run-required-integration-tests.sh` on JDK 21 with Docker 29.7.2 — 20 tests, 0 failures, 0 errors, 0 skipped; 7 required reports
- `./mvnw -B test` on JDK 21 — 612 tests, 0 failures, 0 errors, 0 skipped
- `./mvnw -B package -DskipTests` on JDK 21 — BUILD SUCCESS, Checkstyle 0; the repository unit-test execution still ran all 612 tests
- `git diff --check` — clean

## Reviewer test plan

- [ ] Confirm an XML report with `tests=4 skipped=4` fails and reports `executed=0`
- [ ] Confirm a mixed executed/skipped report also fails
- [ ] Confirm passing reports with no skips remain green
- [ ] Confirm the required integration job runs both MariaDB changelog contracts through Testcontainers and produces zero skipped tests
- [ ] Confirm the legacy integration job remains explicitly `continue-on-error: true` and is not part of `required-ci`

## Scope and caveats

- No deployment or shared environment was changed.
- The full legacy integration suite remains quarantined under #185 and is not claimed green by this PR. Its reports are now evaluated truthfully inside that non-blocking job.
- Existing Maven model and OpenAPI generation warnings are unchanged.

Closes OpenResilienceInitiative/ORISO-AgencyService#268

🤖 Generated with [Claude Code](https://claude.com/claude-code)