### PR TITLE
fix(legal-versions): address the three review findings from #256

### DIFF
--- a/api/agencyadminservice.yaml
+++ b/api/agencyadminservice.yaml
@@ -1892,7 +1892,14 @@ components:
             that is the point: one version pointer covers both.
         publishedAt:
           type: string
-          description: When this wording came into force
+          description: >
+            When this wording came into force, as local date-time without offset, always in the
+            fixed 19-character form `yyyy-MM-ddTHH:mm:ss` — the seconds are never omitted, so a
+            strict parser and a plain string comparison both hold.
+
+            Intentionally a plain string and not `format: date-time`: the value has no offset, and
+            declaring an offset-less local date-time as date-time is what broke ORISO-UserService
+            #872/#874 under the Jackson 3 tightening.
           example: "2026-08-16T13:12:08"
         publishedBy:
           type: string
@@ -1903,7 +1910,9 @@ components:
         supersededAt:
           type: string
           nullable: true
-          description: When a newer version replaced this one; null = still in force
+          description: >
+            When a newer version replaced this one; null = still in force. Same fixed
+            19-character `yyyy-MM-ddTHH:mm:ss` form as `publishedAt`.
           example: "2026-09-01T09:00:00"
 
     CreateLegalTextDTO:

--- a/src/main/java/de/caritas/cob/agencyservice/api/admin/controller/AgencyAdminController.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/admin/controller/AgencyAdminController.java
@@ -44,6 +44,8 @@ import de.caritas.cob.agencyservice.api.model.Sort;
 import de.caritas.cob.agencyservice.api.model.UpdateAgencyDTO;
 import de.caritas.cob.agencyservice.generated.api.admin.controller.AgencyadminApi;
 import io.swagger.annotations.Api;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
@@ -62,6 +64,10 @@ import org.springframework.web.bind.annotation.RestController;
 @Api(tags = "admin-agency-controller")
 @RequiredArgsConstructor
 public class AgencyAdminController implements AgencyadminApi {
+
+  /** Fixed wire shape for the ADR-021 version timestamps; see {@code formatVersionTimestamp}. */
+  private static final DateTimeFormatter LEGAL_TEXT_VERSION_TIMESTAMP =
+      DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
 
   private final @NonNull AgencyAdminSearchService agencyAdminSearchService;
   private final @NonNull AgencyPostcodeRangeAdminService agencyPostcodeRangeAdminService;
@@ -563,9 +569,27 @@ public class AgencyAdminController implements AgencyadminApi {
         .ownerId(view.ownerId())
         .content(view.content())
         .consentText(view.consentText())
-        .publishedAt(view.publishedAt() == null ? null : view.publishedAt().toString())
+        .publishedAt(formatVersionTimestamp(view.publishedAt()))
         .publishedBy(view.publishedBy())
-        .supersededAt(view.supersededAt() == null ? null : view.supersededAt().toString());
+        .supersededAt(formatVersionTimestamp(view.supersededAt()));
+  }
+
+  /**
+   * The version timestamps go on the wire in one fixed shape, always 19 characters.
+   *
+   * <p>{@code LocalDateTime.toString()} drops the seconds when they are zero and appends fractional
+   * seconds when they are not, so the same field arrived as {@code 2026-05-01T09:00} or
+   * {@code 2026-08-16T13:12:08} depending on the value — enough to break a strict parser or any
+   * consumer comparing the strings. {@code published_at}/{@code superseded_at} are MariaDB
+   * {@code datetime} columns with no sub-second precision, so pinning the pattern to whole seconds
+   * discards nothing that survives a round-trip.
+   *
+   * <p>Deliberately a formatted {@code String} and not an OpenAPI {@code format: date-time} field:
+   * these are offset-less {@link LocalDateTime}s, and declaring them as date-time is what broke
+   * ORISO-UserService #872/#874 under the Jackson 3 tightening.
+   */
+  private String formatVersionTimestamp(LocalDateTime timestamp) {
+    return timestamp == null ? null : LEGAL_TEXT_VERSION_TIMESTAMP.format(timestamp);
   }
 
   private LegalTextAdminDTO toLegalTextAdminDto(

--- a/src/main/java/de/caritas/cob/agencyservice/api/admin/controller/AgencyAdminController.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/admin/controller/AgencyAdminController.java
@@ -538,7 +538,7 @@ public class AgencyAdminController implements AgencyadminApi {
       Long agencyId, Long topicId, String kind) {
     var views =
         legalTextVersionAdminService.listDepartmentVersions(
-            agencyId, topicId, LegalTextKind.valueOf(kind));
+            agencyId, topicId, parseLegalTextKind(kind));
     return ResponseEntity.ok(views.stream().map(this::toLegalTextVersionDto).toList());
   }
 
@@ -549,8 +549,25 @@ public class AgencyAdminController implements AgencyadminApi {
   @Override
   public ResponseEntity<List<LegalTextVersionDTO>> getAgencyLegalTextVersions(
       Long agencyId, String kind) {
-    var views = legalTextVersionAdminService.listAgencyVersions(agencyId, LegalTextKind.valueOf(kind));
+    var views =
+        legalTextVersionAdminService.listAgencyVersions(agencyId, parseLegalTextKind(kind));
     return ResponseEntity.ok(views.stream().map(this::toLegalTextVersionDto).toList());
+  }
+
+  /**
+   * The OpenAPI document constrains {@code kind} to an enum, but the generator emits it as a plain
+   * {@code String}, so nothing rejects a bad value before it reaches us. Left to
+   * {@code LegalTextKind.valueOf}, a typo raises {@link IllegalArgumentException}, which
+   * {@code ApiResponseEntityExceptionHandler} maps to 500 — blaming the server for the caller's
+   * mistake and burying it in the error budget. It is a 400, and the message names what is
+   * accepted so the caller can fix it without reading the spec.
+   */
+  private LegalTextKind parseLegalTextKind(String kind) {
+    try {
+      return LegalTextKind.valueOf(kind);
+    } catch (IllegalArgumentException e) {
+      throw new BadRequestException("kind must be one of DPP, IMPRINT");
+    }
   }
 
   /** One archived version, verbatim; authorised against the version's stored owner. */

--- a/src/main/java/de/caritas/cob/agencyservice/api/admin/service/AgencyAdminService.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/admin/service/AgencyAdminService.java
@@ -50,6 +50,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionOperations;
 
 /**
@@ -265,10 +266,20 @@ public class AgencyAdminService {
   /**
    * Updates an agency in the database.
    *
+   * <p>Transactional because the agency row and its ADR-021 publication history have to move
+   * together. Without a transaction spanning both, {@link LegalTextVersionService#recordPublication}
+   * opens its own after the agency save has already committed, so a failure writing the snapshot
+   * rolls back only the snapshot: the caller sees a 500 for an update that actually succeeded, and
+   * the agency is left carrying new legal wording with no history row to say when it came into
+   * force — the one thing this history exists to answer. Every sibling publish path
+   * ({@code DepartmentImprintService}, {@code DepartmentDataProtectionService},
+   * {@code LegalTextAdminService}) is transactional for the same reason.
+   *
    * @param agencyId        the id of the agency to update
    * @param updateAgencyDTO {@link UpdateAgencyDTO}
    * @return an {@link AgencyAdminFullResponseDTO} instance
    */
+  @Transactional
   public AgencyAdminFullResponseDTO updateAgency(Long agencyId, UpdateAgencyDTO updateAgencyDTO) {
     var agency = agencyRepository.findById(agencyId).orElseThrow(NotFoundException::new);
     applySettingsUpdate(updateAgencyDTO);

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/controller/AgencyAdminControllerLegalVersionsTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/controller/AgencyAdminControllerLegalVersionsTest.java
@@ -1,6 +1,8 @@
 package de.caritas.cob.agencyservice.api.admin.controller;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import de.caritas.cob.agencyservice.api.admin.service.AgencyAdminService;
@@ -15,6 +17,7 @@ import de.caritas.cob.agencyservice.api.admin.service.legal.LegalTextAdminServic
 import de.caritas.cob.agencyservice.api.admin.service.legal.LegalTextVersionAdminService;
 import de.caritas.cob.agencyservice.api.admin.service.legal.LegalTextVersionView;
 import de.caritas.cob.agencyservice.api.admin.validation.AgencyValidator;
+import de.caritas.cob.agencyservice.api.exception.httpresponses.BadRequestException;
 import de.caritas.cob.agencyservice.api.model.LegalTextVersionDTO;
 import de.caritas.cob.agencyservice.api.repository.legaltext.LegalTextKind;
 import de.caritas.cob.agencyservice.api.repository.legaltext.LegalTextLevel;
@@ -129,6 +132,31 @@ class AgencyAdminControllerLegalVersionsTest {
         // store it, so emitting it would advertise a precision the store does not have
         Arguments.of(
             LocalDateTime.of(2026, 8, 16, 13, 12, 8, 123_000_000), "2026-08-16T13:12:08"));
+  }
+
+  /**
+   * The OpenAPI declares {@code kind} as an enum but the generator emits a plain String, so an
+   * unparseable value used to reach {@code LegalTextKind.valueOf} and surface as a 500. A caller
+   * typo is a 400, and the message names the accepted values.
+   */
+  @Test
+  void getDepartmentLegalTextVersions_Should_rejectUnknownKind_withBadRequest() {
+    assertThatThrownBy(() -> controller.getDepartmentLegalTextVersions(7L, 42L, "DDP"))
+        .isInstanceOf(BadRequestException.class)
+        .hasMessageContaining("DPP")
+        .hasMessageContaining("IMPRINT");
+
+    verifyNoInteractions(legalTextVersionAdminService);
+  }
+
+  @Test
+  void getAgencyLegalTextVersions_Should_rejectUnknownKind_withBadRequest() {
+    assertThatThrownBy(() -> controller.getAgencyLegalTextVersions(7L, ""))
+        .isInstanceOf(BadRequestException.class)
+        .hasMessageContaining("DPP")
+        .hasMessageContaining("IMPRINT");
+
+    verifyNoInteractions(legalTextVersionAdminService);
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/controller/AgencyAdminControllerLegalVersionsTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/controller/AgencyAdminControllerLegalVersionsTest.java
@@ -20,8 +20,12 @@ import de.caritas.cob.agencyservice.api.repository.legaltext.LegalTextKind;
 import de.caritas.cob.agencyservice.api.repository.legaltext.LegalTextLevel;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -46,6 +50,11 @@ class AgencyAdminControllerLegalVersionsTest {
   @InjectMocks private AgencyAdminController controller;
 
   private LegalTextVersionView view(LegalTextLevel level, LocalDateTime supersededAt) {
+    return view(level, LocalDateTime.of(2026, 5, 1, 9, 0), supersededAt);
+  }
+
+  private LegalTextVersionView view(
+      LegalTextLevel level, LocalDateTime publishedAt, LocalDateTime supersededAt) {
     return new LegalTextVersionView(
         100L,
         LegalTextKind.DPP,
@@ -53,7 +62,7 @@ class AgencyAdminControllerLegalVersionsTest {
         4711L,
         "{\"de\":\"<p>Fassung</p>\"}",
         "{\"de\":\"Ich habe die {{legal_links}} gelesen.\"}",
-        LocalDateTime.of(2026, 5, 1, 9, 0),
+        publishedAt,
         "admin-uuid",
         supersededAt);
   }
@@ -72,9 +81,9 @@ class AgencyAdminControllerLegalVersionsTest {
       assertThat(dto.getOwnerLevel()).isEqualTo(LegalTextVersionDTO.OwnerLevelEnum.DEPARTMENT);
       assertThat(dto.getOwnerId()).isEqualTo(4711L);
       assertThat(dto.getContent()).contains("Fassung");
-      assertThat(dto.getPublishedAt()).isEqualTo("2026-05-01T09:00");
+      assertThat(dto.getPublishedAt()).isEqualTo("2026-05-01T09:00:00");
       assertThat(dto.getPublishedBy()).isEqualTo("admin-uuid");
-      assertThat(dto.getSupersededAt()).isEqualTo("2026-09-01T00:00");
+      assertThat(dto.getSupersededAt()).isEqualTo("2026-09-01T00:00:00");
     });
   }
 
@@ -87,6 +96,39 @@ class AgencyAdminControllerLegalVersionsTest {
 
     assertThat(response.getBody()).singleElement().satisfies(dto ->
         assertThat(dto.getSupersededAt()).isNull());
+  }
+
+  /**
+   * The wire shape is fixed at 19 characters whatever the seconds happen to be.
+   * {@code LocalDateTime.toString()} used to drop a zero seconds component and append fractional
+   * seconds when present, so the same field changed shape with its value and broke strict parsers
+   * and string comparisons.
+   */
+  @ParameterizedTest(name = "{0} is serialised as {1}")
+  @MethodSource("timestampsAndTheirWireForm")
+  void getDepartmentLegalTextVersions_Should_serialiseTimestampsInOneFixedShape(
+      LocalDateTime publishedAt, String expectedWireForm) {
+    when(legalTextVersionAdminService.listDepartmentVersions(7L, 42L, LegalTextKind.DPP))
+        .thenReturn(List.of(view(LegalTextLevel.DEPARTMENT, publishedAt, publishedAt)));
+
+    var response = controller.getDepartmentLegalTextVersions(7L, 42L, "DPP");
+
+    assertThat(response.getBody()).singleElement().satisfies(dto -> {
+      assertThat(dto.getPublishedAt()).isEqualTo(expectedWireForm);
+      assertThat(dto.getSupersededAt()).isEqualTo(expectedWireForm);
+    });
+  }
+
+  private static Stream<Arguments> timestampsAndTheirWireForm() {
+    return Stream.of(
+        // zero seconds - the case LocalDateTime.toString() shortened to "2026-05-01T09:00"
+        Arguments.of(LocalDateTime.of(2026, 5, 1, 9, 0), "2026-05-01T09:00:00"),
+        // the OpenAPI example, already 19 characters
+        Arguments.of(LocalDateTime.of(2026, 8, 16, 13, 12, 8), "2026-08-16T13:12:08"),
+        // sub-second precision is truncated: published_at is a MariaDB datetime, which cannot
+        // store it, so emitting it would advertise a precision the store does not have
+        Arguments.of(
+            LocalDateTime.of(2026, 8, 16, 13, 12, 8, 123_000_000), "2026-08-16T13:12:08"));
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/service/AgencyAdminServiceLegalVersionTransactionIT.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/service/AgencyAdminServiceLegalVersionTransactionIT.java
@@ -1,0 +1,76 @@
+package de.caritas.cob.agencyservice.api.admin.service;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import de.caritas.cob.agencyservice.AgencyServiceApplication;
+import de.caritas.cob.agencyservice.api.admin.service.legal.LegalTextVersionService;
+import de.caritas.cob.agencyservice.api.model.AgencyLegalContentDTO;
+import de.caritas.cob.agencyservice.api.service.TopicService;
+import java.util.Map;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase.Replace;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.junit4.SpringRunner;
+
+/**
+ * The agency row and its ADR-021 publication history commit together or not at all.
+ *
+ * <p>Deliberately <b>not</b> {@code @Transactional} at class level, unlike the sibling
+ * {@code AgencyAdminServiceIT}: a test-managed transaction would wrap the service call and roll
+ * everything back at the end regardless, so the assertion would hold whether or not
+ * {@code updateAgency} declares a transaction of its own — it would pass against the very bug it
+ * is meant to pin. Letting {@code updateAgency} own the outermost transaction is the whole point.
+ * The fixture script recreates its tables, so leaving no test-managed rollback is safe here.
+ */
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = AgencyServiceApplication.class)
+@TestPropertySource(properties = "spring.profiles.active=testing")
+@AutoConfigureTestDatabase(replace = Replace.ANY)
+@DirtiesContext(classMode = ClassMode.BEFORE_CLASS)
+@TestPropertySource(properties = "multitenancy.enabled=false")
+@Sql(scripts = "/database/AgencyDatabase.sql")
+public class AgencyAdminServiceLegalVersionTransactionIT extends AgencyAdminServiceITBase {
+
+  /** Keeps createAgency/updateAgency off the real ConsultingTypeService on localhost:8083 (#204). */
+  @MockitoBean private TopicService topicService;
+
+  @MockitoBean private LegalTextVersionService legalTextVersionService;
+
+  /**
+   * Before the fix, the agency save committed in its own transaction and
+   * {@code recordPublication} opened a second one afterwards. A failure writing the snapshot then
+   * rolled back the snapshot alone: the caller got a 500 for an update that had actually landed,
+   * and the agency was left carrying new legal wording that no history row accounted for.
+   */
+  @Test
+  public void updateAgency_Should_RollBackTheAgencyChange_WhenTheHistoryWriteFails() {
+    var storedAgency = agencyRepository.findById(0L).orElseThrow();
+    final var originalName = storedAgency.getName();
+    final var originalDpp = storedAgency.getContentDpp();
+
+    var updateAgencyDTO = createUpdateAgencyDtoFromExistingAgency();
+    updateAgencyDTO.setContent(
+        new AgencyLegalContentDTO().privacy(Map.of("de", "<p>Neue Fassung</p>")));
+    when(legalTextVersionService.recordPublication(any(), any(), any(), any(), any(), any()))
+        .thenThrow(new DataIntegrityViolationException("history write failed"));
+
+    assertThrows(
+        DataIntegrityViolationException.class,
+        () -> agencyAdminService.updateAgency(0L, updateAgencyDTO));
+
+    var afterFailedUpdate = agencyRepository.findById(0L).orElseThrow();
+    assertEquals(originalName, afterFailedUpdate.getName());
+    assertEquals(originalDpp, afterFailedUpdate.getContentDpp());
+  }
+}


### PR DESCRIPTION
Fixes the three non-blocking issues recorded in the review of #256 (ADR-021
legal-text version history), which was merged as acc2c9c without them being
addressed. Original review comment:
https://github.com/OpenResilienceInitiative/ORISO-AgencyService/pull/256#issuecomment-5322611788

One commit per finding.

## 1. `publishedAt` / `supersededAt` had a variable wire shape

`toLegalTextVersionDto` serialised both with `LocalDateTime::toString`, which
omits the seconds component when it is zero and appends fractional seconds when
it is not. The same field therefore went out as `2026-05-01T09:00` or
`2026-08-16T13:12:08` depending on its value — the controller test pinned the
short form while the OpenAPI example showed the long one. A consumer with a
strict parser, or one comparing the strings, breaks on whichever form it did
not expect.

Both fields are now formatted with an explicit `yyyy-MM-dd'T'HH:mm:ss` pattern,
so the value is always 19 characters. `published_at` and `superseded_at` are
MariaDB `datetime` columns with no sub-second precision, so truncating to whole
seconds discards nothing that survives a round-trip.

The fields stay plain strings — **no `format: date-time`**, as requested. They
are offset-less `LocalDateTime`s, and declaring such a value as date-time is
what broke ORISO-UserService #872/#874 under the Jackson 3 tightening. The
guaranteed shape is documented on both fields in `api/agencyadminservice.yaml`
instead, so the contract still tells consumers what to expect.

A parameterised controller test pins all three cases: zero seconds, the
seconds-bearing OpenAPI example, and sub-second input.

## 2. The agency update and its history row now commit together

`AgencyAdminService#updateAgency` was not `@Transactional`, so
`recordAgencyLegalTextVersions` ran inside
`LegalTextVersionService#recordPublication`'s own transaction — after the agency
save had already committed and flushed. A failure writing the snapshot rolled
back only the snapshot: the caller saw a 500 for an update that had actually
succeeded, and the agency was left carrying new legal wording with no history
row to say when it came into force. That is precisely the question this history
exists to answer.

`updateAgency` is now `@Transactional`, which also brings the agency level in
line with every sibling publish path — `DepartmentImprintService`,
`DepartmentDataProtectionService` and `LegalTextAdminService` are all
transactional around the same call.

`AgencyAdminServiceLegalVersionTransactionIT` covers it, and is deliberately
**not** `@Transactional` at class level unlike the sibling
`AgencyAdminServiceIT`: a test-managed transaction would wrap the service call
and roll everything back at the end regardless, so the assertion would hold
whether or not `updateAgency` declares a transaction of its own — it would pass
against the very bug it is meant to pin. I verified the test fails against the
previous code (the renamed agency committed as `…Bonn x` despite the exception)
and passes with the fix.

## 3. An unknown `?kind=` is a 400, not a 500

`getDepartmentLegalTextVersions` and `getAgencyLegalTextVersions` passed the raw
query string to `LegalTextKind.valueOf`. The OpenAPI document constrains `kind`
to an enum, but the generated parameter is a plain `String`, so nothing rejected
a bad value earlier: `?kind=DDP` raised `IllegalArgumentException`, which
`ApiResponseEntityExceptionHandler#handleInternal` maps to
`INTERNAL_SERVER_ERROR` — the server taking the blame for a caller mistake, and
the noise landing in the error budget.

Both endpoints now parse through a guard that raises `BadRequestException`
naming the accepted values, mirroring the existing `parseDirection` helper in
the same controller. Both already document 400 in the contract. Covered by two
controller tests, which also assert the service is never reached.

## Verification

`./mvnw verify` on JDK 21: **BUILD SUCCESS**, 892 tests across 131 report files,
0 failures, 0 errors, no checkstyle violations.

## Out of scope — one note for a follow-up

`AgencyAdminController#getLegalTexts` (line 477) has the same raw
`LegalTextKind.valueOf(kind)` on a plain-String query parameter, so it returns
500 for an unknown kind too. It comes from #250 rather than #256, so I left it
alone rather than widening this PR — happy to fold it in here or open a separate
issue, whichever you prefer. The two body-DTO call sites (`createLegalText`,
`assignDepartmentLegalText`) are already safe: the generated DTO enum validates
before they run.
