### PR TITLE
fix(sanitizer): keep anchor id and data-anchor-removed on headings

### DIFF
--- a/src/main/java/de/caritas/cob/agencyservice/api/validation/InputSanitizer.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/validation/InputSanitizer.java
@@ -1,5 +1,6 @@
 package de.caritas.cob.agencyservice.api.validation;
 
+import java.util.regex.Pattern;
 import org.owasp.html.HtmlPolicyBuilder;
 import org.springframework.stereotype.Component;
 
@@ -10,6 +11,19 @@ import org.springframework.stereotype.Component;
  */
 @Component
 public class InputSanitizer {
+
+  private static final String[] HEADING_ELEMENTS = {"h1", "h2", "h3", "h4", "h5", "h6"};
+
+  /**
+   * Anchor ids on headings power the legal-content anchor navigation (chapter chips in the Admin
+   * editor and reader). Restricted to a slug charset (no colons, quotes, spaces, ...) so the
+   * attribute cannot be abused as an XSS or DOM-clobbering vector. Same rule as
+   * ORISO-TenantService's InputSanitizer (its commit 7f37f30).
+   */
+  private static final Pattern SAFE_ANCHOR_ID = Pattern.compile("[a-zA-Z0-9\\-_]+");
+
+  /** Marker the admin editor sets on headings whose anchor was explicitly removed. */
+  private static final Pattern ANCHOR_REMOVED_TRUE = Pattern.compile("true");
 
   public String sanitize(String input) {
     var sanitizer = new HtmlPolicyBuilder().toFactory();
@@ -39,6 +53,12 @@ public class InputSanitizer {
             .allowElements("img")
             .allowAttributes("src", "width", "height")
             .onElements("img")
+            .allowAttributes("id")
+            .matching(SAFE_ANCHOR_ID)
+            .onElements(HEADING_ELEMENTS)
+            .allowAttributes("data-anchor-removed")
+            .matching(ANCHOR_REMOVED_TRUE)
+            .onElements(HEADING_ELEMENTS)
             .toFactory();
     return sanitizer.sanitize(input);
   }

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/service/legal/LegalContentSanitizerTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/service/legal/LegalContentSanitizerTest.java
@@ -41,6 +41,22 @@ class LegalContentSanitizerTest {
   }
 
   @Test
+  void sanitizeToJson_Should_keepHeadingAnchors_ThroughTheLegalWritePath() {
+    // The Admin editor persists chapter anchors as heading ids; the "x" removal persists as
+    // data-anchor-removed="true". Both must survive the save, or the read mode loses its
+    // chapter navigation and removed anchors resurrect on reload (TenantService 7f37f30).
+    var json =
+        sanitizer.sanitizeToJson(
+            Map.of(
+                "de",
+                "<h2 id=\"1-gegenstand\">§ 1 Gegenstand</h2>"
+                    + "<h2 data-anchor-removed=\"true\">Altkapitel</h2><p>Text</p>"));
+
+    assertThat(json).contains("id=\\\"1-gegenstand\\\"");
+    assertThat(json).contains("data-anchor-removed=\\\"true\\\"");
+  }
+
+  @Test
   void sanitizeToJson_Should_passThroughValidStrictMeta_Unsanitised() {
     var metaJson = "{\"mt\":true,\"src\":\"de\",\"at\":\"2026-07-16T10:00:00Z\"}";
 

--- a/src/test/java/de/caritas/cob/agencyservice/api/validation/InputSanitizerTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/validation/InputSanitizerTest.java
@@ -1,0 +1,80 @@
+package de.caritas.cob.agencyservice.api.validation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Anchor-navigation support on the legal-content write path: the OWASP policy must keep {@code id}
+ * (slug charset only) and {@code data-anchor-removed="true"} on headings, exactly like
+ * ORISO-TenantService's {@code InputSanitizer} does since its commit {@code 7f37f30}. Without this
+ * rule every agency/department legal text loses its chapter anchors on save, and anchors the author
+ * explicitly removed resurrect after a reload.
+ */
+class InputSanitizerTest {
+
+  private final InputSanitizer inputSanitizer = new InputSanitizer();
+
+  // --- Anchor navigation support (Admin anchor feature): id + data-anchor-removed on headings ---
+
+  @Test
+  void sanitizeAllowingFormattingAndLinks_should_keepIdOnHeadings() {
+    var input = "<h2 id=\"intro\">Intro</h2><h3 id=\"data-usage_2\">Data usage</h3>";
+
+    var result = inputSanitizer.sanitizeAllowingFormattingAndLinks(input);
+
+    assertThat(result).contains("<h2 id=\"intro\">");
+    assertThat(result).contains("<h3 id=\"data-usage_2\">");
+  }
+
+  @Test
+  void sanitizeAllowingFormattingAndLinks_should_keepDataAnchorRemovedTrueOnHeadings() {
+    var input = "<h2 data-anchor-removed=\"true\">Old chapter</h2>";
+
+    var result = inputSanitizer.sanitizeAllowingFormattingAndLinks(input);
+
+    assertThat(result).contains("data-anchor-removed=\"true\"");
+  }
+
+  @Test
+  void sanitizeAllowingFormattingAndLinks_should_dropIdWithUnsafeCharacters() {
+    var javascriptLike = "<h2 id=\"javascript:alert(1)\">x</h2>";
+    var withQuotes = "<h2 id=\"intro&quot;onmouseover=alert(1)\">x</h2>";
+    var withSpaces = "<h2 id=\"intro chapter\">x</h2>";
+
+    assertThat(inputSanitizer.sanitizeAllowingFormattingAndLinks(javascriptLike))
+        .doesNotContain("id=");
+    assertThat(inputSanitizer.sanitizeAllowingFormattingAndLinks(withQuotes)).doesNotContain("id=");
+    assertThat(inputSanitizer.sanitizeAllowingFormattingAndLinks(withSpaces)).doesNotContain("id=");
+  }
+
+  @Test
+  void sanitizeAllowingFormattingAndLinks_should_dropDataAnchorRemovedWithOtherValues() {
+    var input = "<h2 data-anchor-removed=\"false\">x</h2>";
+
+    var result = inputSanitizer.sanitizeAllowingFormattingAndLinks(input);
+
+    assertThat(result).doesNotContain("data-anchor-removed");
+  }
+
+  @Test
+  void sanitizeAllowingFormattingAndLinks_should_keepIdDisallowedOnNonHeadingElements() {
+    var input = "<p id=\"not-a-heading\">text</p><a id=\"link\" href=\"https://example.org\">a</a>";
+
+    var result = inputSanitizer.sanitizeAllowingFormattingAndLinks(input);
+
+    assertThat(result).doesNotContain("id=");
+    assertThat(result).contains("href=\"https://example.org\"");
+  }
+
+  @Test
+  void sanitizeAllowingFormattingAndLinks_should_stillStripScriptAndEventHandlers() {
+    var input = "<h2 id=\"intro\" onclick=\"alert(1)\">Intro</h2><script>alert(1)</script>";
+
+    var result = inputSanitizer.sanitizeAllowingFormattingAndLinks(input);
+
+    assertThat(result).contains("<h2 id=\"intro\">Intro</h2>");
+    assertThat(result).doesNotContain("onclick");
+    assertThat(result).doesNotContain("<script>");
+  }
+}


### PR DESCRIPTION
## Why

Chapter chips in the Admin legal-document reader stopped navigating: they work while authoring, but published agency/department legal texts render without usable chapter targets. Root cause attribution:

- **This service strips the anchors on save.** `InputSanitizer.sanitizeAllowingFormattingAndLinks` allowed no attributes on headings, so `<h2 id="1-gegenstand">` and `<h2 data-anchor-removed="true">` were persisted as bare `<h2>`. Every legal text written through the five legal write paths (department DPP, department imprint, shared ADR-014 legal texts, consent texts, agency admin) lost its chapter anchors on save, and anchors the author explicitly removed with the editor's "x" resurrected after a reload — a second user-visible symptom of the same gap.
- **Prior art:** ORISO-TenantService hit the identical defect and fixed it on 2026-07-04 in `7f37f30` ("fix(sanitizer): keep anchor id and data-anchor-removed on headings"). The rule was never ported here, although this class's doc comment claims to mirror TenantService's sanitizer.
- On the Admin side, `321bdd8` ("Repair legal document read mode", PR #813, merged to `pre-dev` 2026-08-18) already compensates at render time by stamping display-only ids. That repairs the reader's navigation but not the stored HTML — this PR fixes the storage side so anchors survive as authored and removals stay removed.

## What

Port TenantService's rule exactly, including the value restrictions:

- allow `id` on `h1`–`h6` only, value-restricted to the slug charset `[a-zA-Z0-9_-]+` (no colons, quotes, spaces — XSS and DOM-clobbering surface stays at zero)
- allow `data-anchor-removed` on `h1`–`h6` only, with the exact value `true`

`LegalContentSanitizer.sanitizeToJson` is the single sanitisation entry point for all five legal write paths (verified by grep — no other route bypasses it), so this one policy change covers them all.

## What this does NOT do

- **Already-stored texts stay anchorless** until re-saved. This fix stops the loss going forward; it cannot restore ids stripped by previous saves. On Pre-Dev the volume is small (4 `legal_text_version` rows); dev is unquantified. Remedy: re-save the affected texts once, or rely on the Admin reader's render-time stamping (`321bdd8`) for display.
- ORISO-Frontend renders these legal texts flat (no chapter navigation, verified in `LegalContentRenderer`/`DepartmentLegalSection`), so the missing-id exposure outside Admin is limited to in-text `#anchor` cross references, which remain dead in old stored content until re-save.

## Tests (TDD, mutation-proved)

- New `InputSanitizerTest` (mirrors TenantService's): ids survive on headings, removal marker survives, unsafe id values dropped, other marker values dropped, `id` stays disallowed on non-headings, script/event-handler injection still stripped.
- New `LegalContentSanitizerTest` case: anchors survive the canonical `sanitizeToJson` legal write path end to end.
- Red first for the right reason (`<h2 id="intro">` came back as `<h2>`, 4 failures), green after the fix (16/16). Mutation check: production hunk reverted → the same 4 tests fail again; restored → green.
- Full unit suite: 684 tests, 0 failures, 0 skipped.

Verified in a real browser (Playwright against a local Admin Storybook on `origin/pre-dev` + this data shape): chips render and clicking/keyboard-activating them scrolls the document and moves focus to the heading. Evidence index: `~/ORISO/_e2e-artifacts/anchor-chips-20260818/screenshots/INDEX.md` (machine-local evidence contract path) (local run; Pre-Dev untouched — it currently serves demo-branch images).

## Reviewer test plan

- [ ] `./mvnw test` is green (684 tests)
- [ ] Revert the `InputSanitizer` hunk locally → `InputSanitizerTest` and the new `LegalContentSanitizerTest` case fail
- [ ] Save a department DPP with `<h2 id="kapitel-1">` through the API → the stored JSON keeps the id
- [ ] Save a heading with `data-anchor-removed="true"` → the marker is stored; with `"false"` → dropped
- [ ] Save `<h2 id="javascript:alert(1)">` → the id is dropped, the heading text survives
- [ ] Admin reader (desktop 1440 and mobile 390): open a department legal text saved after this fix → chapter chips navigate by mouse click
- [ ] Keyboard: Tab to a chip, press Enter and Space → the document scrolls and focus lands on the heading

🤖 Generated with [Claude Code](https://claude.com/claude-code)
