### PR TITLE
fix: close trailing-slash auth bypass + redact README secrets (Java-21 follow-up to PR #67)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,13 @@ chmod +x mvnw
 ## Configuration
 
 ### Database Connection
-**MariaDB ClusterIP:** `10.43.123.72:3306`
+Point the service at the cluster's MariaDB service; the address is environment-specific and lives in the environment's secret store, not here.
 
 ```properties
-# application-local.properties
-spring.datasource.url=jdbc:mariadb://10.43.123.72:3306/agencyservice
-spring.datasource.username=agencyservice
-spring.datasource.password=agencyservice
+# application-local.properties — supply real values from the environment
+spring.datasource.url=jdbc:mariadb://<mariadb-host>:3306/agencyservice
+spring.datasource.username=${DB_USERNAME}
+spring.datasource.password=${DB_PASSWORD}
 ```
 
 ### Liquibase
@@ -53,14 +53,12 @@ keycloak.resource=agency-service
 - **Port:** `8084`
 - **Profile:** `local`
 - **Liquibase:** DISABLED - schemas managed in ORISO-Database
-- **Database:** Uses MariaDB ClusterIP (NOT localhost)
+- **Database:** Uses the cluster's MariaDB service (NOT localhost)
 - **Host Network:** Enabled in Kubernetes for direct localhost access
 - **Caching:** Ehcache enabled for agency data
 
 ## Kubernetes Deployment Path
-```
-/home/caritas/Desktop/online-beratung/caritas-workspace/ORISO-AgencyService
-```
+The deploy host keeps the working copy under the operator's home directory; the exact path is environment-specific and documented in the deployment runbook.
 
 ## Health Check
 ```bash
@@ -68,8 +66,8 @@ curl http://localhost:8084/actuator/health
 ```
 
 ## Dependencies
-- Java 17
-- Spring Boot 2.7.14
+- Java 21
+- Spring Boot 4.0.1
 - MariaDB
 - Keycloak
 - Ehcache

--- a/src/main/java/de/caritas/cob/agencyservice/config/SecurityConfig.java
+++ b/src/main/java/de/caritas/cob/agencyservice/config/SecurityConfig.java
@@ -87,11 +87,14 @@ public class SecurityConfig {
             .requestMatchers(HttpMethod.OPTIONS, "/topic/public", "/topic/public/**").permitAll()
             .requestMatchers(HttpMethod.GET, "/topic/public", "/topic/public/**").permitAll()
             .requestMatchers("/agencies").permitAll()
-            .requestMatchers(HttpMethod.GET, "/agencyadmin/agencies")
+            .requestMatchers(HttpMethod.GET, "/agencyadmin/agencies", "/agencyadmin/agencies/")
             .hasAuthority(AuthorityValue.SEARCH_AGENCIES)
-            .requestMatchers("/agencies/by-tenant")
+            // Both variants are required: Spring Boot 4 defaults setUseTrailingSlashMatch(false),
+            // and the later "/agencies/**" permitAll would otherwise let "/agencies/by-tenant/"
+            // through anonymously — bypassing SEARCH_AGENCIES_WITHIN_TENANT.
+            .requestMatchers("/agencies/by-tenant", "/agencies/by-tenant/")
             .hasAuthority(AuthorityValue.SEARCH_AGENCIES_WITHIN_TENANT)
-            .requestMatchers("/agencyadmin/agencies/tenant/*")
+            .requestMatchers("/agencyadmin/agencies/tenant/*", "/agencyadmin/agencies/tenant/*/")
             .access(new WebExpressionAuthorizationManager("hasAuthority('"
                 + AuthorityValue.AGENCY_ADMIN + "') and hasAuthority('"
                 + AuthorityValue.TENANT_ADMIN + "')"))


### PR DESCRIPTION
Follow-up to the Java 21 + Spring Boot 4 upgrade merged as [#67](https://github.com/OpenResilienceInitiative/ORISO-AgencyService/pull/67). Addresses the two still-valid **security findings** from the review threads that were not closed by later PRs on `pre-dev`.

## Sentry HIGH — trailing-slash auth bypass on `/agencies/by-tenant`

Spring Boot 4 changed the default of `spring.mvc.pathmatch.use-trailing-slash-match` to `false`. That means exact matchers like `.requestMatchers("/agencies/by-tenant")` no longer match `/agencies/by-tenant/`.

The rest of `SecurityConfig` still contains:

```java
.requestMatchers("/agencies/**").permitAll()
```

late in the chain. So `/agencies/by-tenant/` was falling through the tenant-authority requirement (\`SEARCH_AGENCIES_WITHIN_TENANT\`) into `permitAll()` — anonymous access to a tenant-scoped endpoint. That is the pattern the Sentry HIGH alert flagged.

**Fix**: add trailing-slash variants for the three endpoints that used exact matchers in an authority-critical chain:

| Matcher | Authority | Trailing-slash variant added |
|---|---|---|
| `GET /agencyadmin/agencies` | SEARCH_AGENCIES | ✅ |
| `/agencies/by-tenant` | SEARCH_AGENCIES_WITHIN_TENANT | ✅ *(the reported bypass)* |
| `/agencyadmin/agencies/tenant/*` | AGENCY_ADMIN + TENANT_ADMIN | ✅ |

The pattern already used further down (`/agencyadmin/controls`, `/agencyadmin`, `/agencies/topics`) is now consistent: **whenever the matcher stands in front of a broader wildcard, list both variants explicitly.**

Deliberately not touching `/internal/agencies/**` — the trailing wildcard already handles both `.../foo` and `.../foo/`.

## README — hard-coded infrastructure secrets

The README was flagged twice (severity HIGH by both Sentry and Copilot) for shipping:

- A concrete MariaDB ClusterIP (`10.43.123.72:3306`) — internal-network detail
- Plaintext DB credentials (`username=agencyservice`, `password=agencyservice`)
- An operator-specific absolute path (`/home/caritas/Desktop/…`) as the deployment-path example
- Declared toolchain of Java 17 / Spring Boot 2.7.14 — contradicted the `pom.xml` after #67 landed (now Java 21 / Spring Boot 4.0.1)

Replaced with env-driven placeholders (`<mariadb-host>`, `${DB_USERNAME}`, `${DB_PASSWORD}`) and a pointer to the deployment runbook for the operator path. Version list corrected.

## Scope

Deliberately minimal — only the still-valid findings from #67's review threads. Explicitly **not** included:

- **`AgencyAdminController` `@Valid` re-adds** — need to verify against the generated OpenAPI interface first (it may already declare them, making the re-add redundant). Deferred to its own review pass.
- **`Agency.java` `columnDefinition = \"longtext\"`** — test-side H2 concern, works fine in production against MariaDB. Deferred with the H2 test-datasource discussion.
- **Duplicate `RegistrationDTO` import in test** — Java compiler tolerates it; cosmetic.
- **`RestTemplateConfig` `RestTemplateBuilder` restore** — behavioural change worth its own review.

## Verification

- [ ] Anonymous `GET /agencies/by-tenant/` returns 401/403 (previously 200 via the permitAll fall-through).
- [ ] Anonymous `GET /agencies/by-tenant` (no trailing slash) still returns 401/403.
- [ ] Authenticated request with `SEARCH_AGENCIES_WITHIN_TENANT` still succeeds on both variants.
- [ ] `./mvnw -B verify` green under Java 21.
- [ ] README no longer contains ClusterIP, credentials, or operator path.

Refs [#67](https://github.com/OpenResilienceInitiative/ORISO-AgencyService/pull/67)
Refs OpenResilienceInitiative/ORISO-Frontend#1047 (Java-21 evidence follow-up)