### PR TITLE
fix: route platform-admin agency detail through the tenant-unaware repository (#265)

### DIFF
--- a/src/main/java/de/caritas/cob/agencyservice/api/admin/service/AgencyAdminService.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/admin/service/AgencyAdminService.java
@@ -129,11 +129,30 @@ public class AgencyAdminService {
   /**
    * Returns the {@link Agency} for the provided agency ID.
    *
+   * <p>Platform-admin contexts (no bound tenant, or the technical tenant sentinel {@code 0L})
+   * bypass the tenant-aware repository so that the detail lookup matches what the admin search
+   * already exposes. Without this the two paths disagree — the search widens for the same
+   * "sees all tenants" signal used here, but the tenant-aware {@code findById} still runs
+   * through the Hibernate {@code tenantFilter}, so a Platform Admin can be shown an agency
+   * they cannot open (#265).
+   *
    * @param agencyId the agency ID
    * @return {@link Agency}
    */
   public Agency findAgencyById(Long agencyId) {
+    if (isCrossTenantAdminContext()) {
+      return agencyTenantUnawareRepository.findById(agencyId)
+          .orElseThrow(NotFoundException::new);
+    }
     return agencyRepository.findById(agencyId).orElseThrow(NotFoundException::new);
+  }
+
+  private boolean isCrossTenantAdminContext() {
+    Long tenantId = authenticatedUser.getTenantId();
+    if (tenantId == null) {
+      tenantId = TenantContext.getCurrentTenant();
+    }
+    return tenantId == null || tenantId.equals(0L);
   }
 
   /**

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/service/AgencyAdminServiceTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/service/AgencyAdminServiceTest.java
@@ -147,6 +147,13 @@ class AgencyAdminServiceTest {
 
   @BeforeEach
   public void setup() {
+    // Mockito's @InjectMocks cannot decide between the two mocks for the
+    // AgencyRepository-typed constructor parameter (AgencyTenantUnawareRepository is a subtype),
+    // so it can silently wire the tenant-unaware mock into the tenant-aware field and the stubs
+    // then no-op. Pin both fields explicitly.
+    ReflectionTestUtils.setField(agencyAdminService, "agencyRepository", agencyRepository);
+    ReflectionTestUtils.setField(
+        agencyAdminService, "agencyTenantUnawareRepository", agencyTenantUnawareRepository);
     ReflectionTestUtils.setField(agencyAdminService, "agencyTopicEnrichmentService", agencyTopicEnrichmentService);
     ReflectionTestUtils.setField(agencyAdminService, "demographicsConverter", demographicsConverter);
 

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/service/AgencyAdminServiceTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/service/AgencyAdminServiceTest.java
@@ -47,6 +47,7 @@ import de.caritas.cob.agencyservice.api.model.UpdateAgencyDTO;
 import de.caritas.cob.agencyservice.api.model.AgencyDTO;
 import de.caritas.cob.agencyservice.api.model.Settings;
 import de.caritas.cob.agencyservice.api.repository.agency.Agency;
+import de.caritas.cob.agencyservice.api.repository.agency.AgencyRepository;
 import de.caritas.cob.agencyservice.api.repository.agency.AgencyTenantUnawareRepository;
 import de.caritas.cob.agencyservice.api.repository.agency.DataProtectionResponsibleEntity;
 import de.caritas.cob.agencyservice.api.repository.agencytopic.AgencyTopic;
@@ -80,7 +81,10 @@ class AgencyAdminServiceTest {
   AgencyAdminService agencyAdminService;
 
   @Mock
-  AgencyTenantUnawareRepository agencyRepository;
+  AgencyRepository agencyRepository;
+
+  @Mock
+  AgencyTenantUnawareRepository agencyTenantUnawareRepository;
 
   @Mock
   UserAdminService userAdminService;
@@ -153,6 +157,11 @@ class AgencyAdminServiceTest {
 
     Mockito.lenient().when(agencySettingsService.toSettings(any())).thenReturn(new Settings());
     Mockito.lenient().when(agencySettingsService.toSettingsJson(any())).thenReturn("{}");
+
+    // Default: a tenant-scoped admin. Tests covering the Platform Admin path
+    // (see findAgencyById_Should_useTenantUnawareRepository_*) override this
+    // to null or 0L explicitly (#265).
+    Mockito.lenient().when(authenticatedUser.getTenantId()).thenReturn(1L);
     Mockito.lenient().when(agencyAdminControlsService.enrichSettingsWithAgencyAdminControls(any()))
         .thenAnswer(invocation -> invocation.getArgument(0) != null
             ? invocation.getArgument(0)
@@ -414,6 +423,62 @@ class AgencyAdminServiceTest {
   @Test
   void findAgencyById_Should_ThrowNotFoundException_WhenAgencyIsNotFound() {
     when(agencyRepository.findById(AGENCY_ID)).thenReturn(Optional.empty());
+
+    assertThrows(NotFoundException.class, () -> agencyAdminService.findAgencyById(AGENCY_ID));
+  }
+
+  @Test
+  void
+      findAgencyById_Should_useTenantUnawareRepository_When_authenticatedUserHasNoBoundTenant() {
+    // A Platform Admin's JWT carries no tenantId claim (#265). The tenant-aware search widens
+    // for exactly this signal, so the detail lookup must match — otherwise the row is visible
+    // in the overview but returns 404 on click.
+    when(authenticatedUser.getTenantId()).thenReturn(null);
+    Agency agency = new Agency();
+    when(agencyTenantUnawareRepository.findById(AGENCY_ID)).thenReturn(Optional.of(agency));
+
+    Agency result = agencyAdminService.findAgencyById(AGENCY_ID);
+
+    assertThat(result, is(agency));
+    verifyNoInteractions(agencyRepository);
+  }
+
+  @Test
+  void
+      findAgencyById_Should_useTenantUnawareRepository_When_technicalTenantSentinelIsBound() {
+    // Technical/super context is represented by tenant 0 in both TenantContext and the
+    // JWT claim path. The tenant-aware repository would apply the Hibernate tenantFilter
+    // even for tenant 0 through the JPQL findById, so route through the unaware repo.
+    when(authenticatedUser.getTenantId()).thenReturn(0L);
+    Agency agency = new Agency();
+    when(agencyTenantUnawareRepository.findById(AGENCY_ID)).thenReturn(Optional.of(agency));
+
+    Agency result = agencyAdminService.findAgencyById(AGENCY_ID);
+
+    assertThat(result, is(agency));
+    verifyNoInteractions(agencyRepository);
+  }
+
+  @Test
+  void
+      findAgencyById_Should_useTenantAwareRepository_When_tenantScopedAdminIsBoundToTenant() {
+    // Tenant-scoped and agency-scoped administrators must remain restricted to their
+    // authorised agencies (#265 acceptance). Only Platform Admin widens.
+    when(authenticatedUser.getTenantId()).thenReturn(42L);
+    Agency agency = new Agency();
+    when(agencyRepository.findById(AGENCY_ID)).thenReturn(Optional.of(agency));
+
+    Agency result = agencyAdminService.findAgencyById(AGENCY_ID);
+
+    assertThat(result, is(agency));
+    verifyNoInteractions(agencyTenantUnawareRepository);
+  }
+
+  @Test
+  void
+      findAgencyById_Should_ThrowNotFoundException_When_platformAdminAndAgencyMissing() {
+    when(authenticatedUser.getTenantId()).thenReturn(null);
+    when(agencyTenantUnawareRepository.findById(AGENCY_ID)).thenReturn(Optional.empty());
 
     assertThrows(NotFoundException.class, () -> agencyAdminService.findAgencyById(AGENCY_ID));
   }


### PR DESCRIPTION
## Summary

Fixes #265 — Platform Admin can see an agency in the overview but the detail endpoint returns 404. Legal and Functionality Access tabs stayed unreachable as a result, blocking Canvas steps 9–13 and 29.

## Root cause

`AgencyAdminSearchService.tenantScopePredicate` widens the search for the same "cross-tenant" signal: `authenticatedUser.getTenantId()` (fallback: `TenantContext`) being null or 0L. So Platform Admin sees all agencies in the overview.

`AgencyAdminService.findAgencyById` called `agencyRepository.findById` unconditionally. `agencyRepository` resolves to the `@Primary AgencyTenantAwareRepository` under `multitenancy.enabled=true`, whose JPQL `findById` runs under the Hibernate `tenantFilter` that `TenantAspect` sets from the JWT `tenantId` claim. Platform Admin's home-tenant filter then hides agencies from other tenants — so the detail 404s even though the overview showed the row.

## Fix

`findAgencyById` now mirrors the search signal and routes through `AgencyTenantUnawareRepository` for the Platform Admin case:

```java
public Agency findAgencyById(Long agencyId) {
  if (isCrossTenantAdminContext()) {
    return agencyTenantUnawareRepository.findById(agencyId)
        .orElseThrow(NotFoundException::new);
  }
  return agencyRepository.findById(agencyId).orElseThrow(NotFoundException::new);
}
```

`isCrossTenantAdminContext()` matches `tenantScopePredicate`: uses `authenticatedUser.getTenantId()` first, falls back to `TenantContext.getCurrentTenant()`, and treats `null` or `0L` as cross-tenant. Tenant-scoped and agency-scoped administrators are unaffected — their path still goes through the tenant-aware repository, so their isolation stays intact.

`AgencyTenantUnawareRepository` is annotated `@TenantUnaware`, and `TenantAspect` skips the filter enable step for that annotation, so no Hibernate filter is applied for the Platform Admin path.

## Tests

Four new unit tests covering the acceptance criteria:

- `findAgencyById_Should_useTenantUnawareRepository_When_authenticatedUserHasNoBoundTenant` — Platform Admin (null tenant) reaches the row.
- `findAgencyById_Should_useTenantUnawareRepository_When_technicalTenantSentinelIsBound` — 0L sentinel takes the same path.
- `findAgencyById_Should_useTenantAwareRepository_When_tenantScopedAdminIsBoundToTenant` — tenant-scoped admin remains on the tenant-aware repository (isolation preserved).
- `findAgencyById_Should_ThrowNotFoundException_When_platformAdminAndAgencyMissing` — not-found still surfaces as `NotFoundException` on the new path.

Existing tests default to a tenant-scoped admin via a lenient `authenticatedUser.getTenantId() -> 1L` stub in `setup()`, so their expectations continue to run against the tenant-aware mock unchanged.

## Not addressed here

- The Admin repo should also stop rendering the edit affordance for a row the backend won't open in the tenant-scoped case — a defence-in-depth item the issue calls out. That is a separate Admin-repo change and outside this PR's blast radius.
- A backend integration test that lists then re-fetches every ID for a Platform Admin context is nice-to-have; happy to add it in a follow-up if reviewers want it before merge, but it needs the multi-tenancy Spring context (`AgencyAdminServiceTenantAwareIT`-style) rather than the mock-based unit path used here.

## Test plan

- [ ] CI green
- [ ] Manual: Platform Admin opens `E2E Beratungsstelle Mainz` from the overview and reaches the General, Legal, and Functionality Access sections.
- [ ] Manual: tenant-scoped admin still cannot open an agency outside their tenant.

Refs #265