### PR TITLE
feat(agency): store and expose agency geocoordinates (#278)

### DIFF
--- a/api/agencyadminservice.yaml
+++ b/api/agencyadminservice.yaml
@@ -1304,6 +1304,18 @@ components:
           type: string
           maxLength: 1000
           example: "Mo-Fr 9-17 Uhr"
+        lat:
+          type: number
+          format: double
+          nullable: true
+          description: WGS84 latitude of the agency, null until geocoded
+          example: 52.520008
+        lng:
+          type: number
+          format: double
+          nullable: true
+          description: WGS84 longitude of the agency, null until geocoded
+          example: 13.404954
         teamAgency:
           type: boolean
           example: false
@@ -1544,6 +1556,22 @@ components:
           type: string
           maxLength: 1000
           example: "Mo-Fr 9-17 Uhr"
+        lat:
+          type: number
+          format: double
+          nullable: true
+          minimum: -90
+          maximum: 90
+          description: WGS84 latitude of the agency
+          example: 52.520008
+        lng:
+          type: number
+          format: double
+          nullable: true
+          minimum: -180
+          maximum: 180
+          description: WGS84 longitude of the agency
+          example: 13.404954
         teamAgency:
           type: boolean
           example: false
@@ -1653,6 +1681,26 @@ components:
             Omit (or send null) to keep the stored opening hours; send an empty
             string to clear them.
           example: "Mo-Fr 9-17 Uhr"
+        lat:
+          type: number
+          format: double
+          nullable: true
+          minimum: -90
+          maximum: 90
+          description: >-
+            WGS84 latitude of the agency. Omit (or send null) to keep the
+            stored value.
+          example: 52.520008
+        lng:
+          type: number
+          format: double
+          nullable: true
+          minimum: -180
+          maximum: 180
+          description: >-
+            WGS84 longitude of the agency. Omit (or send null) to keep the
+            stored value.
+          example: 13.404954
         offline:
           type: boolean
           example: false

--- a/api/agencyservice.yaml
+++ b/api/agencyservice.yaml
@@ -306,6 +306,18 @@ components:
         openingHours:
           type: string
           example: "Mo-Fr 9-17 Uhr"
+        lat:
+          type: number
+          format: double
+          nullable: true
+          description: WGS84 latitude of the agency, null until geocoded
+          example: 52.520008
+        lng:
+          type: number
+          format: double
+          nullable: true
+          description: WGS84 longitude of the agency, null until geocoded
+          example: 13.404954
         departments:
           type: array
           description: The agency's departments (one per assigned topic) with the publication

--- a/src/main/java/de/caritas/cob/agencyservice/api/admin/service/AgencyAdminService.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/admin/service/AgencyAdminService.java
@@ -240,6 +240,8 @@ public class AgencyAdminService {
         .phoneSecondary(agencyDTO.getPhoneSecondary())
         .email(agencyDTO.getEmail())
         .openingHours(agencyDTO.getOpeningHours())
+        .lat(agencyDTO.getLat())
+        .lng(agencyDTO.getLng())
         .offline(true)
         .teamAgency(agencyDTO.getTeamAgency())
         .consultingTypeId(agencyDTO.getConsultingType())
@@ -435,6 +437,19 @@ public class AgencyAdminService {
   }
 
   /**
+   * Null coordinates on update keep the stored values, same as {@code openingHours}: a partial
+   * payload that never mentions {@code lat}/{@code lng} must not silently drop an agency off the
+   * map (#278). There is no "clear" form yet — coordinates are corrected by sending new ones.
+   */
+  private Double resolveLatForUpdate(Agency agency, UpdateAgencyDTO updateAgencyDTO) {
+    return updateAgencyDTO.getLat() != null ? updateAgencyDTO.getLat() : agency.getLat();
+  }
+
+  private Double resolveLngForUpdate(Agency agency, UpdateAgencyDTO updateAgencyDTO) {
+    return updateAgencyDTO.getLng() != null ? updateAgencyDTO.getLng() : agency.getLng();
+  }
+
+  /**
    * Null {@code dataProtection} on update keeps the stored contacts. Calling
    * {@link DataProtectionConverter#convertToEntity} with null would nullify them.
    */
@@ -468,6 +483,8 @@ public class AgencyAdminService {
         .phoneSecondary(updateAgencyDTO.getPhoneSecondary())
         .email(updateAgencyDTO.getEmail())
         .openingHours(resolveOpeningHoursForUpdate(agency, updateAgencyDTO))
+        .lat(resolveLatForUpdate(agency, updateAgencyDTO))
+        .lng(resolveLngForUpdate(agency, updateAgencyDTO))
         .offline(resolveOfflineForUpdate(agency, updateAgencyDTO))
         .teamAgency(agency.isTeamAgency())
         .url(updateAgencyDTO.getUrl())

--- a/src/main/java/de/caritas/cob/agencyservice/api/admin/service/agency/AgencyAdminFullResponseDTOBuilder.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/admin/service/agency/AgencyAdminFullResponseDTOBuilder.java
@@ -64,6 +64,8 @@ public class AgencyAdminFullResponseDTOBuilder {
         .phoneSecondary(this.agency.getPhoneSecondary())
         .email(this.agency.getEmail())
         .openingHours(this.agency.getOpeningHours())
+        .lat(this.agency.getLat())
+        .lng(this.agency.getLng())
         .consultingType(this.agency.getConsultingTypeId())
         .description(this.agency.getDescription())
         .postcode(this.agency.getPostCode())

--- a/src/main/java/de/caritas/cob/agencyservice/api/repository/agency/Agency.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/repository/agency/Agency.java
@@ -111,6 +111,14 @@ public class Agency implements TenantAware {
   @Column(name = "opening_hours")
   private String openingHours;
 
+  /** WGS84 latitude, nullable until an agency is geocoded (#278). */
+  @Column(name = "lat")
+  private Double lat;
+
+  /** WGS84 longitude, nullable until an agency is geocoded (#278). */
+  @Column(name = "lng")
+  private Double lng;
+
   @Column(name = "is_team_agency", nullable = false, columnDefinition = "tinyint")
   @Convert(converter = NumericBooleanConverter.class)
   @JdbcTypeCode(Types.TINYINT)

--- a/src/main/java/de/caritas/cob/agencyservice/api/service/AgencyService.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/service/AgencyService.java
@@ -461,6 +461,8 @@ public class AgencyService {
         .houseNumber(agency.getHouseNumber())
         .phone(agency.getPhone())
         .openingHours(agency.getOpeningHours())
+        .lat(agency.getLat())
+        .lng(agency.getLng())
         .departments(
             agency.getAgencyTopics().stream()
                 .map(topic -> convertToAgencyDepartmentDTO(topic, agency))
@@ -521,7 +523,9 @@ public class AgencyService {
         .street(agency.getStreet())
         .houseNumber(agency.getHouseNumber())
         .phone(agency.getPhone())
-        .openingHours(agency.getOpeningHours());
+        .openingHours(agency.getOpeningHours())
+        .lat(agency.getLat())
+        .lng(agency.getLng());
 
   }
 

--- a/src/main/resources/db/changelog/agencyservice-master.xml
+++ b/src/main/resources/db/changelog/agencyservice-master.xml
@@ -93,6 +93,7 @@
        cookie/authentication notice is deliberately NOT stored: it is a fixed addendum the client
        renders, so no Träger can edit away the platform's mandatory disclosure. -->
   <include file="db/changelog/changeset/0032_legal_consent_text/0032_changeSet.xml"/>
+  <include file="db/changelog/changeset/0033_agency_geocoordinates/0033_changeSet.xml"/>
 
   <!--
     L1 gap detection (2026-07-04): the consolidated changelog was run against a fresh MariaDB

--- a/src/main/resources/db/changelog/changeset/0033_agency_geocoordinates/0033_changeSet.xml
+++ b/src/main/resources/db/changelog/changeset/0033_agency_geocoordinates/0033_changeSet.xml
@@ -1,0 +1,11 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd">
+    <changeSet author="oriso" id="addAgencyGeocoordinates">
+        <sqlFile path="db/changelog/changeset/0033_agency_geocoordinates/addAgencyGeocoordinates.sql" stripComments="true"/>
+        <rollback>
+            <sqlFile path="db/changelog/changeset/0033_agency_geocoordinates/addAgencyGeocoordinates-rollback.sql" stripComments="true"/>
+        </rollback>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changeset/0033_agency_geocoordinates/addAgencyGeocoordinates-rollback.sql
+++ b/src/main/resources/db/changelog/changeset/0033_agency_geocoordinates/addAgencyGeocoordinates-rollback.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `agencyservice`.`agency`
+  DROP COLUMN IF EXISTS `lat`,
+  DROP COLUMN IF EXISTS `lng`;

--- a/src/main/resources/db/changelog/changeset/0033_agency_geocoordinates/addAgencyGeocoordinates.sql
+++ b/src/main/resources/db/changelog/changeset/0033_agency_geocoordinates/addAgencyGeocoordinates.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `agencyservice`.`agency`
+  ADD COLUMN IF NOT EXISTS `lat` DOUBLE NULL,
+  ADD COLUMN IF NOT EXISTS `lng` DOUBLE NULL;

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/service/AgencyAdminServiceTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/service/AgencyAdminServiceTest.java
@@ -329,6 +329,74 @@ class AgencyAdminServiceTest {
   }
 
   @Test
+  void createAgency_Should_StoreCoordinates_WhenProvided() {
+    var agency = this.easyRandom.nextObject(Agency.class);
+    agency.setCounsellingRelations(null);
+    clearDataProtection(agency);
+    var agencyDTO = this.easyRandom.nextObject(AgencyDTO.class);
+    agencyDTO.setCounsellingRelations(null);
+    agencyDTO.setConsultingType(1);
+    agencyDTO.setDataProtection(new DataProtectionDTO());
+    agencyDTO.setLat(52.520008);
+    agencyDTO.setLng(13.404954);
+    when(agencyRepository.save(any())).thenReturn(agency);
+
+    agencyAdminService.createAgency(agencyDTO);
+
+    verify(agencyRepository).save(agencyArgumentCaptor.capture());
+    assertEquals(52.520008, agencyArgumentCaptor.getValue().getLat());
+    assertEquals(13.404954, agencyArgumentCaptor.getValue().getLng());
+  }
+
+  @Test
+  void updateAgency_Should_KeepStoredCoordinates_WhenPayloadOmitsThem() {
+    // Same "absent keeps" contract as openingHours: a partial payload must not
+    // silently drop an agency off the map (#278).
+    var agency = this.easyRandom.nextObject(Agency.class);
+    agency.setCounsellingRelations(null);
+    agency.setLat(52.520008);
+    agency.setLng(13.404954);
+    clearDataProtection(agency);
+    when(agencyRepository.findById(AGENCY_ID)).thenReturn(Optional.of(agency));
+    when(agencyRepository.save(any())).thenReturn(agency);
+
+    var updateAgencyDTO = this.easyRandom.nextObject(UpdateAgencyDTO.class);
+    updateAgencyDTO.setConsultingType(null);
+    updateAgencyDTO.setDataProtection(null);
+    updateAgencyDTO.setLat(null);
+    updateAgencyDTO.setLng(null);
+
+    agencyAdminService.updateAgency(AGENCY_ID, updateAgencyDTO);
+
+    verify(agencyRepository).save(agencyArgumentCaptor.capture());
+    assertEquals(52.520008, agencyArgumentCaptor.getValue().getLat());
+    assertEquals(13.404954, agencyArgumentCaptor.getValue().getLng());
+  }
+
+  @Test
+  void updateAgency_Should_UpdateCoordinates_WhenPayloadSendsThem() {
+    var agency = this.easyRandom.nextObject(Agency.class);
+    agency.setCounsellingRelations(null);
+    agency.setLat(52.520008);
+    agency.setLng(13.404954);
+    clearDataProtection(agency);
+    when(agencyRepository.findById(AGENCY_ID)).thenReturn(Optional.of(agency));
+    when(agencyRepository.save(any())).thenReturn(agency);
+
+    var updateAgencyDTO = this.easyRandom.nextObject(UpdateAgencyDTO.class);
+    updateAgencyDTO.setConsultingType(null);
+    updateAgencyDTO.setDataProtection(null);
+    updateAgencyDTO.setLat(48.135125);
+    updateAgencyDTO.setLng(11.581981);
+
+    agencyAdminService.updateAgency(AGENCY_ID, updateAgencyDTO);
+
+    verify(agencyRepository).save(agencyArgumentCaptor.capture());
+    assertEquals(48.135125, agencyArgumentCaptor.getValue().getLat());
+    assertEquals(11.581981, agencyArgumentCaptor.getValue().getLng());
+  }
+
+  @Test
   void updateAgency_Should_ClearOpeningHours_WhenPayloadSendsEmptyString() {
     // Absent keeps, empty deletes — without this the field could never be cleared.
     var agency = this.easyRandom.nextObject(Agency.class);

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/service/agency/AgencyAdminFullResponseDTOBuilderTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/service/agency/AgencyAdminFullResponseDTOBuilderTest.java
@@ -110,6 +110,8 @@ class AgencyAdminFullResponseDTOBuilderTest {
     assertEquals(agency.getConsultingTypeId(), result.getEmbedded().getConsultingType());
     assertEquals(agency.getAgencyLogo(), result.getEmbedded().getAgencyLogo());
     assertEquals(agency.getOpeningHours(), result.getEmbedded().getOpeningHours());
+    assertEquals(agency.getLat(), result.getEmbedded().getLat());
+    assertEquals(agency.getLng(), result.getEmbedded().getLng());
     assertThat(result.getEmbedded().getCounsellingRelations()).containsOnly(AgencyAdminResponseDTO.CounsellingRelationsEnum.PARENTAL_COUNSELLING, AgencyAdminResponseDTO.CounsellingRelationsEnum.RELATIVE_COUNSELLING);
     assertEquals(String.valueOf(agency.getCreateDate()), result.getEmbedded().getCreateDate());
     assertEquals(String.valueOf(agency.getUpdateDate()), result.getEmbedded().getUpdateDate());

--- a/src/test/java/de/caritas/cob/agencyservice/api/repository/agency/AgencyAddressRepositoryTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/repository/agency/AgencyAddressRepositoryTest.java
@@ -46,6 +46,8 @@ class AgencyAddressRepositoryTest {
             .phoneSecondary("+49301234568")
             .email("kontakt@zentrum.de")
             .openingHours("Mo-Fr 9-17 Uhr\nSa 10-12 Uhr")
+            .lat(52.520008)
+            .lng(13.404954)
             .createDate(now)
             .updateDate(now)
             .build();
@@ -64,5 +66,7 @@ class AgencyAddressRepositoryTest {
     assertThat(reloaded.getPhoneSecondary()).isEqualTo("+49301234568");
     assertThat(reloaded.getEmail()).isEqualTo("kontakt@zentrum.de");
     assertThat(reloaded.getOpeningHours()).isEqualTo("Mo-Fr 9-17 Uhr\nSa 10-12 Uhr");
+    assertThat(reloaded.getLat()).isEqualTo(52.520008);
+    assertThat(reloaded.getLng()).isEqualTo(13.404954);
   }
 }

--- a/src/test/java/de/caritas/cob/agencyservice/api/service/AgencyServiceTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/service/AgencyServiceTest.java
@@ -371,7 +371,8 @@ public class AgencyServiceTest {
     Agency agency = Agency.builder().id(103L).name("Zentrum")
         .consultingTypeId(CONSULTING_TYPE_SUCHT)
         .street("Musterstraße").houseNumber("12a").phone("+49301234567")
-        .openingHours("Mo-Fr 9-17 Uhr").floorBuilding("Haus B").build();
+        .openingHours("Mo-Fr 9-17 Uhr").floorBuilding("Haus B")
+        .lat(52.520008).lng(13.404954).build();
     AgencyTopic overriding = AgencyTopic.builder().agency(agency).topicId(1L)
         .openingHours("Di+Do 14-18 Uhr").phoneExtension("-23").floorLocation("3. OG").build();
     AgencyTopic inheriting = AgencyTopic.builder().agency(agency).topicId(2L).build();
@@ -385,6 +386,8 @@ public class AgencyServiceTest {
     assertEquals("12a", result.getHouseNumber());
     assertEquals("+49301234567", result.getPhone());
     assertEquals("Mo-Fr 9-17 Uhr", result.getOpeningHours());
+    assertEquals(Double.valueOf(52.520008), result.getLat());
+    assertEquals(Double.valueOf(13.404954), result.getLng());
     var byTopicId = result.getDepartments().stream()
         .collect(java.util.stream.Collectors.toMap(d -> d.getTopicId(), d -> d));
     assertEquals("Di+Do 14-18 Uhr", byTopicId.get(1L).getOpeningHours());

--- a/src/test/resources/database/AgencyDatabase.sql
+++ b/src/test/resources/database/AgencyDatabase.sql
@@ -29,6 +29,8 @@ create table AGENCY
     PHONE_SECONDARY varchar(30)   null     default null,
     EMAIL           varchar(255)  null     default null,
     OPENING_HOURS   varchar(1000) null     default null,
+    LAT             double        null     default null,
+    LNG             double        null     default null,
     IS_TEAM_AGENCY  tinyint       not null default 0,
     CONSULTING_TYPE int       null     default 0,
     IS_OFFLINE      tinyint       not null default 0,


### PR DESCRIPTION
Closes #278 (part of epic #277)

## Problem

Nothing in the stack stores agency coordinates, so the registration flow's OpenStreetMap embed has nothing to render.

## What changed

- Liquibase `0033_agency_geocoordinates`: nullable `agency.lat`/`lng` columns (+ rollback), registered after 0032
- `Agency` entity: nullable `Double lat`/`lng`
- Public API: `lat`/`lng` on `AgencyResponseDTO` (`FullAgencyResponseDTO` inherits via `allOf`), mapped in both public builders
- Admin API: `lat`/`lng` on `AgencyDTO` (with −90..90 / −180..180 bounds), `UpdateAgencyDTO`, `AgencyAdminResponseDTO`; create/update/response mapping. Null on update keeps the stored values — the same "absent keeps" contract as `openingHours`
- Tests: create round-trip, update round-trip, update-omits-keeps, admin response builder, public ID-based mapping, H2 repository round-trip

**One deviation from the issue:** columns are `DOUBLE`, not `NUMERIC(9,6)`. `LiquibaseChangelogDriftIT` (ddl-auto=validate on real MariaDB) rejects a DECIMAL column behind a `Double` entity field — it caught exactly this on the first attempt. The DTOs are JSON doubles either way, so `DOUBLE` keeps changelog, entity and API on one type.

## Verification (local, Java 21)

- `./mvnw -B test` → 696/696, BUILD SUCCESS
- `scripts/ci/run-required-integration-tests.sh` → 20/20, incl. `LiquibaseChangelogDriftIT` building the schema from the master changelog on a fresh MariaDB 10.11 container and Hibernate-validating it

## Reviewer test plan (from the issue)

- [ ] Create an agency via the admin API with `lat`/`lng` set → `GET` the public endpoint → values come back unchanged
- [ ] Create/update an agency without `lat`/`lng` → no error, fields come back `null`
- [ ] Existing agencies are unaffected — public/admin responses otherwise unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)