### PR TITLE
fix(deps): pin Tomcat 11.0.25 for three fixable CRITICALs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,11 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <java.version>21</java.version>
+    <!-- CVE-2026-65182 / CVE-2026-65905 / CVE-2026-68525: three CRITICAL auth-bypass
+         issues in the Tomcat 11.0.22 that spring-boot 4.0.7 manages; the Trivy publish
+         gate rejects them as fixable. Boot 4.0.8 still only manages 11.0.24, so pin the
+         fixed patch here and drop this once the parent manages >= 11.0.25. -->
+    <tomcat.version>11.0.25</tomcat.version>
     <openapi.generator.maven.version>7.17.0</openapi.generator.maven.version>
     <jackson-databind-nullable.version>0.2.3</jackson-databind-nullable.version>
     <jakarta.ws.rs-api.version>3.1.0</jakarta.ws.rs-api.version>


### PR DESCRIPTION
## Problem

`dev` publishes no images: [run 33850849531](https://github.com/OpenResilienceInitiative/ORISO-AgencyService/actions/runs/33850849531) fails the Trivy publish gate (tests all pass — the failing step is the image scan):

```
tomcat-embed-core (app.jar)  11.0.22 → fixed in 11.0.25
CVE-2026-65182  CRITICAL  security constraint bypass
CVE-2026-65905  CRITICAL  DIGEST authenticator replay bypass
CVE-2026-68525  CRITICAL  FORM authentication bypass
```

Unrelated to #281's content (no dependency changes) — the merge commit was simply the first push that hit the gate after the CVEs got fix versions.

## What changed

One property: `<tomcat.version>11.0.25</tomcat.version>`. **A Spring Boot parent bump does not solve this** — checked `spring-boot-dependencies` directly: 4.0.7 manages 11.0.22, and even 4.0.8 only manages 11.0.24. The pin carries a comment to drop it once the parent manages ≥ 11.0.25.

## Verification (local)

- `dependency:list` → `tomcat-embed-core:11.0.25:compile`
- `./mvnw -B test` → **696/696**, BUILD SUCCESS (no Tomcat 11.0.22→25 compatibility fallout)
- Packaged `AgencyService.jar` (what the Dockerfile COPYs) contains only `tomcat-embed-{core,el,websocket}-11.0.25.jar`; no other Tomcat copy anywhere in the image — this is exactly the artifact+version fingerprint the gate scans

## Note

`pre-dev` has the same Boot 4.0.7 parent and no override, so its next image publish will hit the same wall — this pin should ride the next `dev → pre-dev` sync, or be cherry-picked if a pre-dev publish is needed sooner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)